### PR TITLE
fix: correct double escaping of HTML entities in decodeHtmlEntities

### DIFF
--- a/scripts/security/__tests__/get-session-cookie.test.mjs
+++ b/scripts/security/__tests__/get-session-cookie.test.mjs
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { decodeHtmlEntities } from '../get-session-cookie.mjs'
+
+describe('decodeHtmlEntities', () => {
+  it('decodes each supported entity', () => {
+    expect(decodeHtmlEntities('&quot;')).toBe('"')
+    expect(decodeHtmlEntities('&#x2F;')).toBe('/')
+    expect(decodeHtmlEntities('&#39;')).toBe("'")
+    expect(decodeHtmlEntities('&lt;')).toBe('<')
+    expect(decodeHtmlEntities('&gt;')).toBe('>')
+    expect(decodeHtmlEntities('&amp;')).toBe('&')
+  })
+
+  it('decodes a typical Keycloak form action with multiple entities', () => {
+    const input =
+      'https://kc.example/realms/r/login-actions/authenticate?session_code=abc&amp;execution=def&amp;client_id=app&amp;tab_id=xyz'
+    expect(decodeHtmlEntities(input)).toBe(
+      'https://kc.example/realms/r/login-actions/authenticate?session_code=abc&execution=def&client_id=app&tab_id=xyz',
+    )
+  })
+
+  it('does not double-unescape: &amp;quot; becomes &quot;, not "', () => {
+    expect(decodeHtmlEntities('&amp;quot;')).toBe('&quot;')
+  })
+
+  it('does not double-unescape combined entities: &amp;lt;div&amp;gt; becomes &lt;div&gt;', () => {
+    expect(decodeHtmlEntities('&amp;lt;div&amp;gt;')).toBe('&lt;div&gt;')
+  })
+
+  it('handles a mix of all entities in one string', () => {
+    expect(
+      decodeHtmlEntities(
+        'a&amp;b &quot;c&quot; &lt;d&gt; &#39;e&#39; path&#x2F;f',
+      ),
+    ).toBe('a&b "c" <d> \'e\' path/f')
+  })
+
+  it('returns an empty string unchanged', () => {
+    expect(decodeHtmlEntities('')).toBe('')
+  })
+
+  it('leaves an already-decoded string unchanged', () => {
+    expect(decodeHtmlEntities('plain text with no entities')).toBe(
+      'plain text with no entities',
+    )
+  })
+
+  it('leaves unknown entities intact', () => {
+    expect(decodeHtmlEntities('&unknown; &nbsp; &copy;')).toBe(
+      '&unknown; &nbsp; &copy;',
+    )
+  })
+
+  it('leaves a bare ampersand without a known entity unchanged', () => {
+    expect(decodeHtmlEntities('a & b')).toBe('a & b')
+  })
+
+  it('handles repeated occurrences of the same entity', () => {
+    expect(decodeHtmlEntities('&amp;&amp;&amp;')).toBe('&&&')
+    expect(decodeHtmlEntities('&lt;&lt;&gt;&gt;')).toBe('<<>>')
+  })
+})

--- a/scripts/security/get-session-cookie.mjs
+++ b/scripts/security/get-session-cookie.mjs
@@ -137,12 +137,12 @@ async function followingRedirects(
 
 function decodeHtmlEntities(value) {
   return value
-    .replace(/&amp;/g, '&')
     .replace(/&quot;/g, '"')
     .replace(/&#x2F;/g, '/')
     .replace(/&#39;/g, "'")
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
 }
 
 async function main() {

--- a/scripts/security/get-session-cookie.mjs
+++ b/scripts/security/get-session-cookie.mjs
@@ -19,7 +19,9 @@
  * new npm dependency.
  */
 
+import { resolve } from 'node:path'
 import { argv, env, exit, stderr, stdout } from 'node:process'
+import { fileURLToPath } from 'node:url'
 
 const APP_BASE_URL = (env.APP_BASE_URL ?? 'http://localhost:3001').replace(
   /\/$/,
@@ -33,11 +35,6 @@ const MAX_REDIRECTS = 10
 function fail(message) {
   stderr.write(`[get-session-cookie] ${message}\n`)
   exit(1)
-}
-
-const username = argv[2]
-if (!username) {
-  fail('Missing required argument: <username>')
 }
 
 /**
@@ -135,7 +132,7 @@ async function followingRedirects(
   )
 }
 
-function decodeHtmlEntities(value) {
+export function decodeHtmlEntities(value) {
   return value
     .replace(/&quot;/g, '"')
     .replace(/&#x2F;/g, '/')
@@ -146,6 +143,10 @@ function decodeHtmlEntities(value) {
 }
 
 async function main() {
+  const username = argv[2]
+  if (!username) {
+    fail('Missing required argument: <username>')
+  }
   // 1. Trigger the OIDC login. /api/auth/login 302s to Keycloak /authorize,
   //    which renders the username/password form.
   const { response: loginPage, finalUrl: loginPageUrl } =
@@ -208,6 +209,11 @@ async function main() {
   stdout.write(`${SESSION_COOKIE_NAME}=${sessionValue}\n`)
 }
 
-main().catch(err => {
-  fail(err instanceof Error ? (err.stack ?? err.message) : String(err))
-})
+const isMainEntry =
+  argv[1] != null && resolve(argv[1]) === fileURLToPath(import.meta.url)
+
+if (isMainEntry) {
+  main().catch(err => {
+    fail(err instanceof Error ? (err.stack ?? err.message) : String(err))
+  })
+}

--- a/tests/integration/global-setup.ts
+++ b/tests/integration/global-setup.ts
@@ -129,12 +129,12 @@ async function loginAndSaveStorageState(
 
 function decodeHtmlEntities(value: string): string {
   return value
-    .replace(/&amp;/g, '&')
     .replace(/&quot;/g, '"')
     .replace(/&#x2F;/g, '/')
     .replace(/&#39;/g, "'")
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
 }
 
 export default async function globalSetup(config: FullConfig): Promise<void> {


### PR DESCRIPTION

## Description

<!-- Brief description of the changes -->

## Screenshots (if applicable)

<!-- Include screenshots if the changes affect the UI -->

### Related Issues

<!--
- Fixes #123
- Closes #123
- Relates to #123
-->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement (improves performance without changing functionality)
- [ ] Dependency update (updating libraries or tools)

## Testing

- [ ] `npm run check` passes locally
- [ ] All existing tests still pass
- [ ] Manual testing completed
- [ ] UI tested on desktop and mobile (if applicable)

## Checklist


- [ ] Documentation updated as needed

## Checklist

- [ ] Code follows the project style guidelines (Biome)
- [ ] Tests added/updated as needed
- [ ] Self-review of code completed
- [ ] Comments added for complex logic
- [ ] No hardcoded strings (use translations if i18n is added)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/126)
<!-- Reviewable:end -->
