### PR TITLE
Enhance role-based access control and permissions documentation

### DIFF
--- a/app/[locale]/admin/admin-client.tsx
+++ b/app/[locale]/admin/admin-client.tsx
@@ -197,6 +197,7 @@ type AccessReviewSavingAction = 'cancel' | 'complete' | 'create' | 'decision'
 
 const ADMIN_ROLE = 'Admin'
 const PRIVACY_OFFICER_ROLE = 'PrivacyOfficer'
+const EMPTY_USER_ROLES: string[] = []
 
 const adminTabs: { icon: LucideIcon; id: AdminTab }[] = [
   { icon: LayoutPanelTop, id: 'columns' },
@@ -221,9 +222,35 @@ const ADMIN_TAB_DEVELOPER_MODE_VALUES: Record<AdminTab, string> = {
 const ADMIN_TAB_QUERY_KEY = 'tab'
 const DEFAULT_ADMIN_TAB: AdminTab = 'columns'
 
+const ADMIN_TAB_DISABLED_TOOLTIP_KEYS: Partial<Record<AdminTab, string>> = {
+  accessReview: 'accessReview.disabledTooltip',
+  actionAuditLog: 'auditLog.disabledTooltip',
+  archiving: 'archiving.disabledTooltip',
+  privacy: 'privacy.disabledTooltip',
+}
+
+function canAccessAdminTab(tab: AdminTab, roles: string[]): boolean {
+  const isAdmin = roles.includes(ADMIN_ROLE)
+  const isPrivacyOfficer = roles.includes(PRIVACY_OFFICER_ROLE)
+
+  if (tab === 'accessReview') {
+    return isAdmin || isPrivacyOfficer
+  }
+
+  if (tab === 'actionAuditLog') {
+    return isAdmin
+  }
+
+  if (tab === 'archiving' || tab === 'privacy') {
+    return isPrivacyOfficer
+  }
+
+  return true
+}
+
 function getAdminTabFromSearchParams(
   searchParams: URLSearchParams,
-  options: { canManageAccessReviews: boolean; canUsePrivacy: boolean },
+  roles: string[],
 ): AdminTab {
   const requestedTab = searchParams.get(ADMIN_TAB_QUERY_KEY)
   const tab =
@@ -236,11 +263,7 @@ function getAdminTabFromSearchParams(
     return DEFAULT_ADMIN_TAB
   }
 
-  if (tab === 'actionAuditLog' && !options.canManageAccessReviews) {
-    return DEFAULT_ADMIN_TAB
-  }
-
-  if ((tab === 'privacy' || tab === 'archiving') && !options.canUsePrivacy) {
+  if (!canAccessAdminTab(tab as AdminTab, roles)) {
     return DEFAULT_ADMIN_TAB
   }
 
@@ -2684,7 +2707,7 @@ function AccessReviewPanel({ canManage }: { canManage: boolean }) {
 }
 export default function AdminClient({
   actionAuditLog,
-  currentUserRoles = [],
+  currentUserRoles = EMPTY_USER_ROLES,
   initialColumnDefaults,
 }: {
   actionAuditLog?: ActionAuditLogInitialState
@@ -2699,13 +2722,18 @@ export default function AdminClient({
   const locale = useLocale()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const canUsePrivacy = currentUserRoles.includes(PRIVACY_OFFICER_ROLE)
-  const canManageAccessReviews = currentUserRoles.includes(ADMIN_ROLE)
+  const canUseAccessReview = canAccessAdminTab('accessReview', currentUserRoles)
+  const canUseArchiving = canAccessAdminTab('archiving', currentUserRoles)
+  const canUsePrivacy = canAccessAdminTab('privacy', currentUserRoles)
+  const canViewActionAuditLog = canAccessAdminTab(
+    'actionAuditLog',
+    currentUserRoles,
+  )
   const [activeTab, setActiveTab] = useState<AdminTab>(() =>
-    getAdminTabFromSearchParams(new URLSearchParams(searchParams), {
-      canManageAccessReviews,
-      canUsePrivacy,
-    }),
+    getAdminTabFromSearchParams(
+      new URLSearchParams(searchParams),
+      currentUserRoles,
+    ),
   )
   const [columnDefaults, setColumnDefaults] = useState<
     RequirementListColumnDefault[]
@@ -2731,19 +2759,15 @@ export default function AdminClient({
 
   useEffect(() => {
     setActiveTab(
-      getAdminTabFromSearchParams(new URLSearchParams(searchParams), {
-        canManageAccessReviews,
-        canUsePrivacy,
-      }),
+      getAdminTabFromSearchParams(
+        new URLSearchParams(searchParams),
+        currentUserRoles,
+      ),
     )
-  }, [canManageAccessReviews, canUsePrivacy, searchParams])
+  }, [currentUserRoles, searchParams])
 
   const selectTab = (tab: AdminTab) => {
-    if (tab === 'actionAuditLog' && !canManageAccessReviews) {
-      return
-    }
-
-    if ((tab === 'privacy' || tab === 'archiving') && !canUsePrivacy) {
+    if (!canAccessAdminTab(tab, currentUserRoles)) {
       return
     }
 
@@ -3006,57 +3030,55 @@ export default function AdminClient({
               })}
               role="tablist"
             >
-              {adminTabs
-                .filter(
-                  tab => tab.id !== 'actionAuditLog' || canManageAccessReviews,
-                )
-                .map(tab => {
-                  const isDisabled =
-                    (tab.id === 'privacy' || tab.id === 'archiving') &&
-                    !canUsePrivacy
-                  const label =
-                    tab.id === 'privacy'
-                      ? ta('privacy.title')
-                      : tab.id === 'accessReview'
-                        ? ta('accessReview.title')
-                        : tab.id === 'archiving'
-                          ? ta('archiving.title')
-                          : tab.id === 'actionAuditLog'
-                            ? ta('auditLog.title')
-                            : ta(tab.id)
+              {adminTabs.map(tab => {
+                const isDisabled = !canAccessAdminTab(tab.id, currentUserRoles)
+                const disabledTooltipKey =
+                  ADMIN_TAB_DISABLED_TOOLTIP_KEYS[tab.id]
+                const label =
+                  tab.id === 'privacy'
+                    ? ta('privacy.title')
+                    : tab.id === 'accessReview'
+                      ? ta('accessReview.title')
+                      : tab.id === 'archiving'
+                        ? ta('archiving.title')
+                        : tab.id === 'actionAuditLog'
+                          ? ta('auditLog.title')
+                          : ta(tab.id)
 
-                  return (
-                    <button
-                      aria-controls={`${tab.id}-panel`}
-                      aria-disabled={isDisabled ? 'true' : undefined}
-                      aria-selected={activeTab === tab.id}
-                      className={`inline-flex min-h-11 min-w-11 shrink-0 items-center gap-2 whitespace-nowrap rounded-full px-4 py-2.5 text-sm font-medium transition-colors ${
-                        isDisabled
-                          ? 'cursor-not-allowed text-secondary-400 opacity-50 hover:bg-transparent dark:text-secondary-500'
-                          : activeTab === tab.id
-                            ? 'bg-primary-700 text-white'
-                            : 'text-secondary-700 hover:bg-secondary-100 dark:text-secondary-200 dark:hover:bg-secondary-800'
-                      }`}
-                      key={`admin-tab-${tab.id}`}
-                      {...devMarker({
-                        context: 'admin center',
-                        name: 'edge tab',
-                        priority: 360,
-                        value: ADMIN_TAB_DEVELOPER_MODE_VALUES[tab.id],
-                      })}
-                      id={`${tab.id}-tab`}
-                      onClick={() => selectTab(tab.id)}
-                      role="tab"
-                      title={
-                        isDisabled ? ta('privacy.disabledTooltip') : undefined
-                      }
-                      type="button"
-                    >
-                      <tab.icon aria-hidden="true" className="h-4 w-4" />
-                      {label}
-                    </button>
-                  )
-                })}
+                return (
+                  <button
+                    aria-controls={`${tab.id}-panel`}
+                    aria-disabled={isDisabled ? 'true' : undefined}
+                    aria-selected={activeTab === tab.id}
+                    className={`inline-flex min-h-11 min-w-11 shrink-0 items-center gap-2 whitespace-nowrap rounded-full px-4 py-2.5 text-sm font-medium transition-colors ${
+                      isDisabled
+                        ? 'cursor-not-allowed text-secondary-400 opacity-50 hover:bg-transparent dark:text-secondary-500'
+                        : activeTab === tab.id
+                          ? 'bg-primary-700 text-white'
+                          : 'text-secondary-700 hover:bg-secondary-100 dark:text-secondary-200 dark:hover:bg-secondary-800'
+                    }`}
+                    key={`admin-tab-${tab.id}`}
+                    {...devMarker({
+                      context: 'admin center',
+                      name: 'edge tab',
+                      priority: 360,
+                      value: ADMIN_TAB_DEVELOPER_MODE_VALUES[tab.id],
+                    })}
+                    id={`${tab.id}-tab`}
+                    onClick={() => selectTab(tab.id)}
+                    role="tab"
+                    title={
+                      isDisabled && disabledTooltipKey
+                        ? ta(disabledTooltipKey as Parameters<typeof ta>[0])
+                        : undefined
+                    }
+                    type="button"
+                  >
+                    <tab.icon aria-hidden="true" className="h-4 w-4" />
+                    {label}
+                  </button>
+                )
+              })}
             </div>
           </div>
         </section>
@@ -3282,17 +3304,19 @@ export default function AdminClient({
           </section>
         ) : null}
 
-        {activeTab === 'accessReview' ? (
-          <AccessReviewPanel canManage={canManageAccessReviews} />
+        {activeTab === 'accessReview' && canUseAccessReview ? (
+          <AccessReviewPanel canManage={canUseAccessReview} />
         ) : null}
 
-        {activeTab === 'archiving' && canUsePrivacy ? <ArchivingPanel /> : null}
+        {activeTab === 'archiving' && canUseArchiving ? (
+          <ArchivingPanel />
+        ) : null}
 
         {activeTab === 'privacy' && canUsePrivacy ? (
           <PrivacyErasurePanel />
         ) : null}
 
-        {activeTab === 'actionAuditLog' && canManageAccessReviews ? (
+        {activeTab === 'actionAuditLog' && canViewActionAuditLog ? (
           <section
             aria-labelledby="actionAuditLog-tab"
             className="space-y-6"

--- a/docs/admin-center.md
+++ b/docs/admin-center.md
@@ -8,6 +8,8 @@ for database-backed mutation and authorization-denial review.
 
 For requirement-list interaction details such as resizing, sorting, and
 filtering, see [requirements-ui-behaviour.md](./requirements-ui-behaviour.md).
+For the cross-application role matrix, see
+[permissions.md](./permissions.md).
 
 ## Purpose
 
@@ -33,8 +35,10 @@ The admin center currently has six tabs for core administration:
 - `Archiving`
 - `Privacy`
 
-Admins also see an `Action log` tab. The tab renders the action-log
-filters, table, pagination, and CSV export directly in the Admin Center.
+The `Action log` tab renders the action-log filters, table, pagination, and
+CSV export directly in the Admin Center for users with `Admin`.
+Users without the required role still see privileged tabs, but disabled tabs
+are dimmed, cannot be selected, and explain the missing role in a tooltip.
 
 ## Action Log
 
@@ -112,8 +116,9 @@ Requirements list reset:
 
 ## Privacy
 
-The `Privacy` tab is available at `/{locale}/admin?tab=privacy`. It supports
-GDPR Article 17 erasure handling for actor identities and live assignments.
+The `Privacy` tab is available at `/{locale}/admin?tab=privacy` for users with
+`PrivacyOfficer`. It supports GDPR Article 17 erasure handling for actor
+identities and live assignments.
 After a successful preview it also supports data subject access export for the
 previewed HSA-ID. JSON is the machine-readable authoritative payload, and PDF
 is a readable report of the same scope.
@@ -242,10 +247,10 @@ presentation as the Admin Center export.
 
 ## Archiving
 
-The `Archiving` tab is available at `/{locale}/admin?tab=archiving`. Archive
-and retention work is separated from personal data erasure and data subject
-access export flows. Retention is also separate from the requirement
-lifecycle's functional `Archived` state.
+The `Archiving` tab is available at `/{locale}/admin?tab=archiving` for users
+with `PrivacyOfficer`. Archive and retention work is separated from personal
+data erasure and data subject access export flows. Retention is also separate
+from the requirement lifecycle's functional `Archived` state.
 
 A `PrivacyOfficer` can load documented retention policies, preview rows whose
 policy age and status criteria have passed, create row-level exceptions for
@@ -293,12 +298,13 @@ free-text payloads. Export responses and mutation responses use
 
 ## Access Review
 
-The `Access review` tab is available at `/{locale}/admin?tab=accessReview`.
-It supports the recurring authorization review required by the information
-security action plan. The feature inventories app-managed assignments, stores a
-point-in-time review run, assigns newly created runs to the signed-in actor from
-the verified IdP session, lets the assigned reviewer decide each item, lets
-Admin cancel mistaken pending runs without deleting evidence, and lets Admin
+The `Access review` tab is available at
+`/{locale}/admin?tab=accessReview` for users with `Admin` or
+`PrivacyOfficer`. It supports the recurring authorization review required by
+the information security action plan. The feature inventories app-managed
+assignments, stores a point-in-time review run, assigns newly created runs to
+the signed-in actor from the verified IdP session, lets authorized handlers
+decide each item, cancel mistaken pending runs without deleting evidence, and
 export the review evidence as structured JSON or a PDF rendering of the same
 payload.
 
@@ -318,18 +324,19 @@ point to that external record.
 
 Access is role-aware:
 
-- `Admin` can create, list, cancel, complete, and export access review runs.
-- The assigned reviewer can open their assigned run and decide items by
-  matching the verified session HSA-ID to the run reviewer HSA-ID.
+- `Admin` and `PrivacyOfficer` can create, list, decide, cancel, complete, and
+  export access review runs.
+- `Reviewer` alone does not grant access-review management, even when the
+  user's HSA-ID appears as the stored reviewer snapshot on a run.
 - Other users receive a server-side authorization error even if they manipulate
   the client.
 
 New runs default to an annual period and a due date 30 days after creation. Only
-one `draft` or `in_review` access review may exist at a time; the Admin UI
-disables creation while a run is open, and the create route enforces the same
-rule server-side. The create route does not accept a manual reviewer payload;
-the reviewer snapshot is derived from the same verified actor ticket that
-created the request. Each item starts as `pending` and must be changed to
+one `draft` or `in_review` access review may exist at a time; the Admin Center
+UI disables creation while a run is open, and the create route enforces the
+same rule server-side. The create route does not accept a manual reviewer
+payload; the reviewer snapshot is derived from the same verified actor ticket
+that created the request. Each item starts as `pending` and must be changed to
 `approved`,
 `revoke_required`, `changed`, or `not_applicable` before the run can be
 completed. Decision updates record the deciding actor, timestamp, and optional

--- a/docs/arkitekturbeskrivning-kravhantering.md
+++ b/docs/arkitekturbeskrivning-kravhantering.md
@@ -558,9 +558,11 @@ förvaltningsflikar och en administratörsflik för
    kravversionsstatusar, kravunderlagets livscykelstatusar och
    användningsstatusar.
 4. **Behörighetsöversyn** — Återkommande kontroll av
-   applikationsstyrda uppdrag och AI-behörigheter.
+   applikationsstyrda uppdrag och AI-behörigheter. Fliken kräver
+   `Admin` eller `PrivacyOfficer`.
 5. **Arkivering** — Policybaserad gallring med förhandsgranskning,
-   exportbekräftelse och undantag.
+   exportbekräftelse och undantag. Fliken kräver
+   `PrivacyOfficer`.
 6. **Dataskydd** — Förhandsgranskning och körning av
    HSA-ID-baserad radering av personuppgifter. Fliken kräver rollen
    `PrivacyOfficer` (`Dataskyddshandläggare`) och ger inte

--- a/docs/auth-developer-workflow.md
+++ b/docs/auth-developer-workflow.md
@@ -312,8 +312,8 @@ The realm emits a `roles` claim as a JSON array of strings on both ID and
 access tokens. Values are exactly `Reviewer`, `Admin`, and
 `PrivacyOfficer` (the canonical names used throughout the app). Authoring
 rights are not carried by the roles claim — they are assignment-driven via
-`employeeHsaId`. `PrivacyOfficer` is limited to personal data erasure preview
-and execution in the Admin Center privacy tab; it does not imply `Admin`.
+`employeeHsaId`. `PrivacyOfficer` grants the narrow Admin Center privacy,
+archiving retention, and access-review surfaces; it does not imply `Admin`.
 
 ### `employeeHsaId` claim
 

--- a/docs/auth-how-it-works.md
+++ b/docs/auth-how-it-works.md
@@ -11,6 +11,8 @@ It is intentionally not a replacement for the more detailed workflow docs:
 - For local Keycloak, integration-test CI dependency, test setup, and
   env-var reference, see
   [auth-developer-workflow.md](./auth-developer-workflow.md).
+- For application role and permission decisions, see
+  [permissions.md](./permissions.md).
 
 ## Reading guide
 
@@ -413,8 +415,9 @@ flowchart LR
   expose that field through the realm user-profile configuration.
 - Emit global role information in a way that resolves to the canonical app
   roles `Reviewer`, `Admin`, and `PrivacyOfficer`. For the least friction,
-  emit those exact values on a `roles` claim. `PrivacyOfficer` is only for
-  personal data erasure work and does not imply `Admin`.
+  emit those exact values on a `roles` claim. `PrivacyOfficer` is a narrow
+  role for privacy, archiving retention, and access-review handling; it does
+  not imply `Admin`.
 - Do not model authoring rights as IdP roles. The application derives
   authoring rights from area and specification assignments matched on
   `employeeHsaId`.

--- a/docs/developer-mode-overlay.md
+++ b/docs/developer-mode-overlay.md
@@ -333,8 +333,8 @@ should be updated alongside the relevant `devMarker(...)` call sites.
 The current canonical labels include:
 
 - `edge tab`
-  - Admin Center uses this marker for all top tabs, including access review
-    and the disabled privacy tab shown to users without `PrivacyOfficer`.
+  - Admin Center uses this marker for all top tabs, including privileged tabs
+    that render disabled when the current user lacks the required role.
 - `floating action rail`
 - `floating pill`
 - `floating pill menu`

--- a/docs/manual-test-cases.md
+++ b/docs/manual-test-cases.md
@@ -14,8 +14,8 @@ the exact Swedish UI labels used by the seeded Playwright flows.
   - [AUTH-03: signed-out API request returns JSON 401](#auth-03-signed-out-api-request-returns-json-401)
   - [AUTH-04: session projection hides raw tokens](#auth-04-session-projection-hides-raw-tokens)
   - [AUTH-05: Admin-only page accepts Admin user](#auth-05-admin-only-page-accepts-admin-user)
-  - [AUTH-06: privacy tab is disabled for Admin without PrivacyOfficer](#auth-06-privacy-tab-is-disabled-for-admin-without-privacyofficer)
-  - [AUTH-07: PrivacyOfficer can use privacy without Admin powers](#auth-07-privacyofficer-can-use-privacy-without-admin-powers)
+  - [AUTH-06: Admin-only user cannot use PrivacyOfficer tabs](#auth-06-admin-only-user-cannot-use-privacyofficer-tabs)
+  - [AUTH-07: PrivacyOfficer without Admin powers](#auth-07-privacyofficer-without-admin-powers)
   - [AUTH-08: no-role user is denied privileged work](#auth-08-no-role-user-is-denied-privileged-work)
   - [AUTH-09: auth callback failure shows a browser error page](#auth-09-auth-callback-failure-shows-a-browser-error-page)
 - [Requirements library](#requirements-library)
@@ -117,7 +117,7 @@ and must not be reused outside local testing.
 | `linnea.areaowner` | `devpass` | Linnéa AreaOwner | None | `SE5560000001-linneab` | Broad privacy preview fixture and requirement area ownership checks. |
 | `petra.specresp` | `devpass` | Petra SpecificationResp | None | `SE5560000001-specresp1` | Specification lead checks. |
 | `paul.pkgcoauthor` | `devpass` | Paul PkgCoAuthor | None | `SE5560000001-pkgco1` | Requirement-package co-author checks. |
-| `rita.reviewer` | `devpass` | Rita Reviewer | `Reviewer` | `SE5560000001-reviewer1` | Review and decision workflow checks. |
+| `rita.reviewer` | `devpass` | Rita Reviewer | `Reviewer` | `SE5560000001-reviewer1` | Review-workflow checks outside privileged Admin Center tabs. |
 | `ada.admin` | `devpass` | Ada Admin | `Admin`, `PrivacyOfficer` | `SE5560000001-admin1` | Broad Admin and PrivacyOfficer happy path. |
 | `only.admin` | `devpass` | Only Admin | `Admin` | `SE5560000001-admin2` | Admin-only checks where privacy must be disabled. |
 | `disa.privacy` | `devpass` | Disa PrivacyOfficer | `PrivacyOfficer` | `SE5560000001-privacy1` | Privacy without Admin powers. |
@@ -155,6 +155,8 @@ Useful seeded routes and identifiers:
 - Common library fixture: `INT0001`.
 - Deviation fixtures: `PWT0001`, `PWT0002`, `PWT0003`, `PWT0004`.
 - Archive fixtures: `PWT0005` through `PWT0010`.
+
+The maintained role matrix lives in [permissions.md](./permissions.md).
 
 ## Authentication and authorization
 
@@ -245,9 +247,10 @@ and `hsaId`, but does not include raw tokens, authorization codes, `state`,
 **Expected result:** The Admin Center loads, `Taxonomi` is usable, and the
 taxonomy page opens. Normreferenser are not listed under `Taxonomi`.
 
-### AUTH-06: privacy tab is disabled for Admin without PrivacyOfficer
+### AUTH-06: Admin-only user cannot use PrivacyOfficer tabs
 
-**Purpose:** Confirm the narrow privacy role is required.
+**Purpose:** Confirm the narrow PrivacyOfficer role is required for privacy
+and retention work while Admin-only surfaces remain available.
 
 **Users:** `only.admin`.
 
@@ -256,15 +259,18 @@ taxonomy page opens. Normreferenser are not listed under `Taxonomi`.
 **Steps:**
 
 1. Open `/sv/admin`.
-1. Locate the `Dataskydd` and `Arkivering` tabs.
+1. Locate `Behörighetsöversyn`, `Arkivering`, `Dataskydd`, and
+   `Åtgärdslogg`.
+1. Verify `Behörighetsöversyn` and `Åtgärdslogg` are selectable.
 1. Try to select `Dataskydd`.
 
 **Expected result:** The privacy and archiving tabs are disabled with a tooltip
 that mentions `Dataskyddshandläggare`, and the active tab does not change.
 
-### AUTH-07: PrivacyOfficer can use privacy without Admin powers
+### AUTH-07: PrivacyOfficer without Admin powers
 
-**Purpose:** Confirm privacy duties do not imply Admin-only permissions.
+**Purpose:** Confirm PrivacyOfficer duties do not imply Admin-only
+permissions, while still allowing privacy, archiving, and access-review work.
 
 **Users:** `disa.privacy`.
 
@@ -274,10 +280,14 @@ that mentions `Dataskyddshandläggare`, and the active tab does not change.
 
 1. Open `/sv/admin?tab=privacy`.
 1. Verify the `Dataskydd` panel is visible.
+1. Open `/sv/admin?tab=archiving`.
+1. Verify the `Arkivering` panel is visible.
+1. Open `/sv/admin?tab=accessReview`.
+1. Verify the `Behörighetsöversyn` panel is visible.
 1. Open `/sv/admin/audit-log`.
 
-**Expected result:** The privacy panel is usable, while the action log does not
-load as an Admin page for this user.
+**Expected result:** The PrivacyOfficer panels are usable, while the action log
+does not load as an Admin page for this user.
 
 ### AUTH-08: no-role user is denied privileged work
 
@@ -1512,9 +1522,9 @@ correctly.
 
 ### ADMIN-07: access-review decision and export
 
-**Purpose:** Confirm Admin users can decide and export access reviews.
+**Purpose:** Confirm authorized users can decide and export access reviews.
 
-**Users:** `ada.admin`.
+**Users:** `ada.admin` or `disa.privacy`.
 
 **Prerequisites:** Open `/sv/admin?tab=accessReview`.
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,61 @@
+# Permissions
+
+This page explains which roles let you use sensitive parts of Kravhantering.
+It is written for people who use or support the service.
+
+## Roles
+
+Your organization gives roles to your user account. A role decides what kind
+of work you can do in Kravhantering. If you need a role that you do not have,
+contact your local administrator or identity support contact.
+
+Being listed as an owner, author, reviewer, or contact person inside
+Kravhantering is not the same as having one of these account roles.
+
+| Role | What it lets you do |
+| --- | --- |
+| `Admin` | Manage shared administration and review the action log. |
+| `PrivacyOfficer` | Work with privacy, archiving, and access reviews. |
+| `Reviewer` | Take part in review work; no privileged Admin Center tabs. |
+
+## Admin Center
+
+The Admin Center shows privileged tabs even when you cannot use them. Tabs
+that you cannot use are dimmed and cannot be selected. This makes it clear
+that the function exists and which role is needed.
+
+| Tab | Who can use it |
+| --- | --- |
+| Kolumner | Users who can open the Admin Center. |
+| Taxonomi | Users who can open the Admin Center. |
+| Statusar och arbetsflöden | Users who can open the Admin Center. |
+| Behörighetsöversyn | Users with `Admin` or `PrivacyOfficer`. |
+| Arkivering | Users with `PrivacyOfficer`. |
+| Dataskydd | Users with `PrivacyOfficer`. |
+| Åtgärdslogg | Users with `Admin`. |
+
+## Dimmed Tabs
+
+When a tab is dimmed, your account does not currently have the role needed for
+that work. A short message explains which role is required. Selecting the tab
+does not change the page.
+
+If someone sends you a direct link to a tab that you cannot use, Kravhantering
+opens the Admin Center on a tab you are allowed to see instead.
+
+## Access Review
+
+`Behörighetsöversyn` is available only to users with `Admin` or
+`PrivacyOfficer`. Being assigned as a reviewer is not enough on its own.
+
+This means a user who only has `Reviewer` can still take part in ordinary
+review work, but cannot open or decide access reviews in the Admin Center.
+
+## Privacy Work
+
+`Dataskydd` and `Arkivering` are available to users with `PrivacyOfficer`.
+These areas can include sensitive personal data work, so Kravhantering checks
+the role again when the user previews, exports, saves, or performs an action.
+
+The dimmed tab is therefore only a helpful signpost. The service still stops
+the action if the required role is missing.

--- a/lib/access-review/service.ts
+++ b/lib/access-review/service.ts
@@ -564,6 +564,8 @@ export async function getAccessReviewRun(
   id: number,
   actor: AccessReviewAuthContext,
 ): Promise<AccessReviewRunDetail> {
+  assertCanViewRun(actor)
+
   const runRows = (await db.query(`${runSelectSql('WHERE run.id = @0')}`, [
     id,
   ])) as Row[]
@@ -575,7 +577,6 @@ export async function getAccessReviewRun(
   }
 
   const run = mapRun(runRows[0])
-  assertCanViewRun(actor)
 
   const itemRows = (await db.query(
     `SELECT

--- a/lib/access-review/service.ts
+++ b/lib/access-review/service.ts
@@ -69,6 +69,7 @@ export interface DecideAccessReviewItemInput {
 }
 
 const ADMIN_ROLE = 'Admin'
+const PRIVACY_OFFICER_ROLE = 'PrivacyOfficer'
 const ACCESS_REVIEW_ITEM_INSERT_BATCH_SIZE = 150
 const ACCESS_REVIEW_ITEM_INSERT_PARAMETER_COUNT = 11
 const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000
@@ -78,12 +79,18 @@ function isAdmin(actor: AccessReviewAuthContext): boolean {
   return actor.roles.includes(ADMIN_ROLE)
 }
 
-function requireAdmin(actor: AccessReviewAuthContext): AccessReviewActor {
-  if (!isAdmin(actor)) {
+function canUseAccessReview(actor: AccessReviewAuthContext): boolean {
+  return isAdmin(actor) || actor.roles.includes(PRIVACY_OFFICER_ROLE)
+}
+
+function requireAccessReviewRole(
+  actor: AccessReviewAuthContext,
+): AccessReviewActor {
+  if (!canUseAccessReview(actor)) {
     throw forbiddenError(
-      'Admin role is required for access review management',
+      'Admin or PrivacyOfficer role is required for access review management',
       {
-        reason: 'admin_required',
+        reason: 'access_review_role_required',
       },
     )
   }
@@ -102,29 +109,12 @@ function requireActor(actor: AccessReviewAuthContext): AccessReviewActor {
   }
 }
 
-function assertCanViewRun(
-  actor: AccessReviewAuthContext,
-  run: Pick<AccessReviewRun, 'reviewer'>,
-): void {
-  if (isAdmin(actor)) return
-  const actorSnapshot = requireActor(actor)
-  if (actorSnapshot.hsaId === run.reviewer.hsaId) return
-  throw forbiddenError('Access review is assigned to another reviewer', {
-    reason: 'assigned_reviewer_required',
-  })
+function assertCanViewRun(actor: AccessReviewAuthContext): void {
+  requireAccessReviewRole(actor)
 }
 
-function assertCanDecideRun(
-  actor: AccessReviewAuthContext,
-  run: Pick<AccessReviewRun, 'reviewer'>,
-): AccessReviewActor {
-  const actorSnapshot = requireActor(actor)
-  if (isAdmin(actor) || actorSnapshot.hsaId === run.reviewer.hsaId) {
-    return actorSnapshot
-  }
-  throw forbiddenError('Access review is assigned to another reviewer', {
-    reason: 'assigned_reviewer_required',
-  })
+function assertCanDecideRun(actor: AccessReviewAuthContext): AccessReviewActor {
+  return requireAccessReviewRole(actor)
 }
 
 function isoTimestamp(value: unknown): string {
@@ -483,7 +473,7 @@ export async function createAccessReviewRun(
   actor: AccessReviewAuthContext,
   options: CreateAccessReviewRunOptions = {},
 ): Promise<AccessReviewRunDetail> {
-  const createdBy = requireAdmin(actor)
+  const createdBy = requireAccessReviewRole(actor)
   const generatedAt = input.generatedAt ?? new Date()
   let runId = 0
 
@@ -560,12 +550,11 @@ export async function listAccessReviewRuns(
   db: QueryExecutor,
   actor: AccessReviewAuthContext,
 ): Promise<AccessReviewRun[]> {
-  const actorSnapshot = requireActor(actor)
-  const admin = isAdmin(actor)
+  requireAccessReviewRole(actor)
   const rows = (await db.query(
-    `${runSelectSql(admin ? '' : 'WHERE run.reviewer_hsa_id = @0')}
+    `${runSelectSql('')}
       ORDER BY run.created_at DESC, run.id DESC`,
-    admin ? [] : [actorSnapshot.hsaId],
+    [],
   )) as Row[]
   return rows.map(mapRun)
 }
@@ -586,7 +575,7 @@ export async function getAccessReviewRun(
   }
 
   const run = mapRun(runRows[0])
-  assertCanViewRun(actor, run)
+  assertCanViewRun(actor)
 
   const itemRows = (await db.query(
     `SELECT
@@ -626,7 +615,7 @@ export async function decideAccessReviewItem(
   actor: AccessReviewAuthContext,
 ): Promise<AccessReviewRunDetail> {
   const detail = await getAccessReviewRun(db, runId, actor)
-  const decidedBy = assertCanDecideRun(actor, detail.run)
+  const decidedBy = assertCanDecideRun(actor)
   if (detail.run.status === 'completed' || detail.run.status === 'cancelled') {
     throw conflictError('Access review run is no longer editable', {
       reason: 'access_review_closed',
@@ -677,7 +666,7 @@ export async function completeAccessReviewRun(
   runId: number,
   actor: AccessReviewAuthContext,
 ): Promise<AccessReviewRunDetail> {
-  const completedBy = requireAdmin(actor)
+  const completedBy = requireAccessReviewRole(actor)
   const detail = await getAccessReviewRun(db, runId, actor)
   if (detail.run.status === 'completed') return detail
   if (detail.run.status === 'cancelled') {
@@ -711,7 +700,7 @@ export async function cancelAccessReviewRun(
   runId: number,
   actor: AccessReviewAuthContext,
 ): Promise<AccessReviewRunDetail> {
-  requireAdmin(actor)
+  requireAccessReviewRole(actor)
   const detail = await getAccessReviewRun(db, runId, actor)
   if (detail.run.status === 'cancelled') return detail
   if (detail.run.status === 'completed') {
@@ -737,7 +726,7 @@ export async function buildAccessReviewExport(
   actor: AccessReviewAuthContext,
   generatedAt = new Date(),
 ): Promise<AccessReviewExportV1> {
-  const generatedBy = requireAdmin(actor)
+  const generatedBy = requireAccessReviewRole(actor)
   const detail = await getAccessReviewRun(db, runId, actor)
 
   return {

--- a/messages/en.json
+++ b/messages/en.json
@@ -935,7 +935,8 @@
       "empty": "No action log events match the filters.",
       "pagination": "Page {page} of {totalPages}, {total} event(s)",
       "previous": "Previous",
-      "next": "Next"
+      "next": "Next",
+      "disabledTooltip": "You need the Administrator role."
     },
     "privacy": {
       "title": "Privacy",
@@ -1061,6 +1062,7 @@
     "archiving": {
       "body": "Use archiving to preview and execute approved retention policies and export archive evidence before deletion. The data protection flow remains separate for data-subject cases.",
       "description": "Preview retention candidates, manage exceptions, and export archive material before data is removed from the application.",
+      "disabledTooltip": "You need the Privacy officer role.",
       "heading": "Archiving and retention",
       "retention": {
         "action": "Retention action",
@@ -1102,6 +1104,7 @@
     },
     "accessReview": {
       "title": "Access review",
+      "disabledTooltip": "You need the Administrator or Privacy officer role.",
       "action": "Action",
       "aiDisabled": "AI disabled",
       "aiEnabled": "AI enabled",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -935,7 +935,8 @@
       "empty": "Inga åtgärdsloggsposter matchar filtren.",
       "pagination": "Sida {page} av {totalPages}, {total} händelse(r)",
       "previous": "Föregående",
-      "next": "Nästa"
+      "next": "Nästa",
+      "disabledTooltip": "Du behöver rollen Administratör."
     },
     "privacy": {
       "title": "Dataskydd",
@@ -1061,6 +1062,7 @@
     "archiving": {
       "body": "Använd arkivering för att förhandsgranska och köra beslutade gallringspolicyer samt exportera arkivunderlag innan radering. Dataskyddsflödet ligger kvar separat för individärenden.",
       "description": "Förhandsgranska gallringskandidater, hantera undantag och exportera arkivmaterial innan data tas bort ur applikationen.",
+      "disabledTooltip": "Du behöver rollen Dataskyddshandläggare.",
       "heading": "Arkivering och gallring",
       "retention": {
         "action": "Gallringsåtgärd",
@@ -1102,6 +1104,7 @@
     },
     "accessReview": {
       "title": "Behörighetsöversyn",
+      "disabledTooltip": "Du behöver rollen Administratör eller Dataskyddshandläggare.",
       "action": "Åtgärd",
       "aiDisabled": "AI av",
       "aiEnabled": "AI på",

--- a/tests/integration/admin-entrypoint.spec.ts
+++ b/tests/integration/admin-entrypoint.spec.ts
@@ -216,7 +216,27 @@ for (const { name, viewport } of viewportVariants) {
           const tablist = page.getByRole('tablist', {
             name: 'Administrationscenter',
           })
+          const accessReviewTab = page.getByRole('tab', {
+            name: 'Behörighetsöversyn',
+          })
+          const archivingTab = page.getByRole('tab', { name: 'Arkivering' })
           const privacyTab = page.getByRole('tab', { name: 'Dataskydd' })
+          const actionAuditLogTab = page.getByRole('tab', {
+            name: 'Åtgärdslogg',
+          })
+          await expect(accessReviewTab).not.toHaveAttribute(
+            'aria-disabled',
+            'true',
+          )
+          await expect(actionAuditLogTab).not.toHaveAttribute(
+            'aria-disabled',
+            'true',
+          )
+          await expect(archivingTab).toHaveAttribute('aria-disabled', 'true')
+          await expect(archivingTab).toHaveAttribute(
+            'title',
+            /Dataskyddshandläggare/,
+          )
           await expect(privacyTab).toHaveAttribute('aria-disabled', 'true')
           await expect(privacyTab).toHaveAttribute(
             'title',

--- a/tests/integration/admin-permissions.spec.ts
+++ b/tests/integration/admin-permissions.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('admin center permissions', () => {
+  test.use({ storageState: 'test-results/auth/reviewer.json' })
+
+  test('reviewer-only users see privileged admin tabs disabled', async ({
+    page,
+  }) => {
+    await page.goto('/sv/admin?tab=accessReview')
+
+    const columnsTab = page.getByRole('tab', { name: 'Kolumner' })
+    const disabledTabs = [
+      {
+        name: 'Behörighetsöversyn',
+        title: /Administratör eller Dataskyddshandläggare/,
+      },
+      { name: 'Arkivering', title: /Dataskyddshandläggare/ },
+      { name: 'Dataskydd', title: /Dataskyddshandläggare/ },
+      { name: 'Åtgärdslogg', title: /Administratör/ },
+    ]
+
+    await expect(columnsTab).toHaveAttribute('aria-selected', 'true')
+    await expect(page.getByRole('heading', { name: 'Kolumner' })).toBeVisible()
+
+    for (const { name, title } of disabledTabs) {
+      const tab = page.getByRole('tab', { name })
+
+      await expect(tab).toHaveAttribute('aria-disabled', 'true')
+      await expect(tab).toHaveAttribute('title', title)
+
+      await tab.click({ force: true })
+
+      await expect(tab).toHaveAttribute('aria-selected', 'false')
+      await expect(columnsTab).toHaveAttribute('aria-selected', 'true')
+    }
+  })
+})

--- a/tests/unit/access-review-route.test.ts
+++ b/tests/unit/access-review-route.test.ts
@@ -272,7 +272,9 @@ describe('access review routes', () => {
 
   it('returns service authorization failures for forbidden create', async () => {
     routeState.createAccessReviewRun.mockRejectedValueOnce(
-      forbiddenError('Admin role is required', { reason: 'admin_required' }),
+      forbiddenError('Admin or PrivacyOfficer role is required', {
+        reason: 'access_review_role_required',
+      }),
     )
     const { POST } = await import('@/app/api/admin/access-reviews/route')
     const response = await POST(
@@ -285,7 +287,7 @@ describe('access review routes', () => {
         detail: {
           actionKind: 'access_review.create',
           errorCode: 'forbidden',
-          reason: 'admin_required',
+          reason: 'access_review_role_required',
           requestSource: 'rest',
         },
         event: 'auth.authorization.denied',

--- a/tests/unit/access-review.test.ts
+++ b/tests/unit/access-review.test.ts
@@ -4,6 +4,9 @@ import {
   cancelAccessReviewRun,
   collectAccessReviewAssignments,
   createAccessReviewRun,
+  decideAccessReviewItem,
+  getAccessReviewRun,
+  listAccessReviewRuns,
 } from '@/lib/access-review/service'
 
 function accessReviewSnapshot(index: number): AccessReviewPrincipalSnapshot {
@@ -178,7 +181,7 @@ describe('access review service', () => {
     ).toBe('SE5560000001-admin1')
   })
 
-  it('requires Admin to create a review run', async () => {
+  it('requires Admin or PrivacyOfficer to create a review run', async () => {
     const db = {
       transaction: vi.fn(),
     }
@@ -200,9 +203,79 @@ describe('access review service', () => {
       ),
     ).rejects.toMatchObject({
       code: 'forbidden',
-      details: { reason: 'admin_required' },
+      details: { reason: 'access_review_role_required' },
     })
     expect(db.transaction).not.toHaveBeenCalled()
+  })
+
+  it('lets PrivacyOfficer list access review runs without reviewer filtering', async () => {
+    const db = {
+      query: vi.fn(async () => [
+        {
+          ...accessReviewRunRow(1),
+          reviewerHsaId: 'SE5560000001-admin1',
+        },
+      ]),
+    }
+
+    const runs = await listAccessReviewRuns(db as never, {
+      displayName: 'Disa PrivacyOfficer',
+      hsaId: 'SE5560000001-privacy1',
+      roles: ['PrivacyOfficer'],
+    })
+
+    expect(runs).toHaveLength(1)
+    expect(db.query).toHaveBeenCalledWith(
+      expect.not.stringContaining('WHERE run.reviewer_hsa_id'),
+      [],
+    )
+  })
+
+  it('rejects reviewer-only users even when they are assigned reviewer', async () => {
+    const db = {
+      query: vi.fn(async (sql: string) => {
+        if (sql.includes('FROM access_review_runs')) {
+          return [
+            {
+              ...accessReviewRunRow(1),
+              reviewerDisplayName: 'Rita Reviewer',
+              reviewerHsaId: 'SE5560000001-reviewer1',
+            },
+          ]
+        }
+        return accessReviewItemRows([accessReviewSnapshot(1)])
+      }),
+    }
+    const reviewerOnlyActor = {
+      displayName: 'Rita Reviewer',
+      hsaId: 'SE5560000001-reviewer1',
+      roles: ['Reviewer'],
+    }
+
+    await expect(
+      listAccessReviewRuns(db as never, reviewerOnlyActor),
+    ).rejects.toMatchObject({
+      code: 'forbidden',
+      details: { reason: 'access_review_role_required' },
+    })
+    await expect(
+      getAccessReviewRun(db as never, 42, reviewerOnlyActor),
+    ).rejects.toMatchObject({
+      code: 'forbidden',
+      details: { reason: 'access_review_role_required' },
+    })
+    await expect(
+      decideAccessReviewItem(
+        db as never,
+        42,
+        1,
+        { decision: 'approved' },
+        reviewerOnlyActor,
+      ),
+    ).rejects.toMatchObject({
+      code: 'forbidden',
+      details: { reason: 'access_review_role_required' },
+    })
   })
 
   it('blocks creating a second review while one is still open', async () => {

--- a/tests/unit/access-review.test.ts
+++ b/tests/unit/access-review.test.ts
@@ -233,8 +233,9 @@ describe('access review service', () => {
 
   it('rejects reviewer-only users even when they are assigned reviewer', async () => {
     const db = {
-      query: vi.fn(async (sql: string) => {
+      query: vi.fn(async (sql: string, parameters?: unknown[]) => {
         if (sql.includes('FROM access_review_runs')) {
+          if (parameters?.[0] === 999) return []
           return [
             {
               ...accessReviewRunRow(1),
@@ -260,6 +261,12 @@ describe('access review service', () => {
     })
     await expect(
       getAccessReviewRun(db as never, 42, reviewerOnlyActor),
+    ).rejects.toMatchObject({
+      code: 'forbidden',
+      details: { reason: 'access_review_role_required' },
+    })
+    await expect(
+      getAccessReviewRun(db as never, 999, reviewerOnlyActor),
     ).rejects.toMatchObject({
       code: 'forbidden',
       details: { reason: 'access_review_role_required' },

--- a/tests/unit/admin-client.test.tsx
+++ b/tests/unit/admin-client.test.tsx
@@ -631,6 +631,26 @@ describe('AdminClient', () => {
     )
   })
 
+  it.each([
+    ['tab=accessReview', 'admin.accessReview.title'],
+    ['tab=actionAuditLog', 'admin.auditLog.title'],
+  ])('falls back from unauthorized admin tab URL %s', (query, tabName) => {
+    searchParamsMock.current = new URLSearchParams(query)
+
+    render(
+      <AdminClient
+        initialColumnDefaults={DEFAULT_REQUIREMENT_LIST_COLUMN_DEFAULTS}
+      />,
+    )
+
+    expect(screen.getByRole('tab', { name: tabName })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    )
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('id', 'columns-panel')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('removes the admin tab query when returning to the default tab', () => {
     searchParamsMock.current = new URLSearchParams('tab=taxonomy')
 
@@ -1031,9 +1051,8 @@ describe('AdminClient', () => {
     ).toBeTruthy()
   })
 
-  it('hides access review decision controls without Admin permission', async () => {
+  it('blocks the access review tab without Admin or PrivacyOfficer permission', () => {
     searchParamsMock.current = new URLSearchParams('tab=accessReview')
-    mockAccessReviewApi()
 
     renderWithConfirmModal(
       <AdminClient
@@ -1042,28 +1061,23 @@ describe('AdminClient', () => {
       />,
     )
 
-    const principalCell = await screen.findByText('Kalle Svensson')
-    const row = principalCell.closest('tr')
-    expect(row).not.toBeNull()
-    expect(screen.queryByText('admin.accessReview.lockState')).toBeNull()
-    expect(
-      within(row as HTMLTableRowElement).queryByRole('button', {
-        name: 'admin.accessReview.rowNeedsReview',
-      }),
-    ).toBeNull()
-    expect(
-      within(row as HTMLTableRowElement).queryByRole('button', {
-        name: 'admin.accessReview.rowApproved',
-      }),
-    ).toBeNull()
-    expect(
-      within(row as HTMLTableRowElement).queryByRole('combobox'),
-    ).toBeNull()
-    expect(within(row as HTMLTableRowElement).queryByRole('textbox')).toBeNull()
-    expect(fetchMock).not.toHaveBeenCalledWith(
-      `/api/admin/access-reviews/${TEST_ACCESS_REVIEW_RUN_ID}/items/${TEST_ACCESS_REVIEW_ITEM_ID}`,
-      expect.objectContaining({ method: 'PATCH' }),
+    const accessReviewTab = screen.getByRole('tab', {
+      name: 'admin.accessReview.title',
+    })
+
+    expect(accessReviewTab).toHaveAttribute('aria-disabled', 'true')
+    expect(accessReviewTab).toHaveAttribute(
+      'title',
+      'admin.accessReview.disabledTooltip',
     )
+    expect(accessReviewTab).toHaveAttribute('aria-selected', 'false')
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('id', 'columns-panel')
+    expect(screen.queryByText('Kalle Svensson')).toBeNull()
+
+    fireEvent.click(accessReviewTab)
+
+    expect(routerReplace).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('keeps a row in place when locking a saved access review decision', async () => {
@@ -1602,7 +1616,7 @@ describe('AdminClient', () => {
     expect(within(alert).getByText('Unauthorized')).toBeTruthy()
   })
 
-  it('dims and disables the privacy tab without the PrivacyOfficer role', () => {
+  it('dims and disables privileged tabs without Admin or PrivacyOfficer roles', () => {
     searchParamsMock.current = new URLSearchParams('tab=privacy')
 
     render(
@@ -1611,20 +1625,80 @@ describe('AdminClient', () => {
       />,
     )
 
-    const privacyTab = screen.getByRole('tab', {
-      name: 'admin.privacy.title',
-    })
+    const disabledTabs = [
+      ['admin.accessReview.title', 'admin.accessReview.disabledTooltip'],
+      ['admin.archiving.title', 'admin.archiving.disabledTooltip'],
+      ['admin.privacy.title', 'admin.privacy.disabledTooltip'],
+      ['admin.auditLog.title', 'admin.auditLog.disabledTooltip'],
+    ] as const
 
-    expect(privacyTab).toHaveAttribute('aria-disabled', 'true')
-    expect(privacyTab).toHaveAttribute('title', 'admin.privacy.disabledTooltip')
-    expect(privacyTab).toHaveAttribute('aria-selected', 'false')
+    for (const [name, tooltip] of disabledTabs) {
+      const tab = screen.getByRole('tab', { name })
+
+      expect(tab).toHaveAttribute('aria-disabled', 'true')
+      expect(tab).toHaveAttribute('title', tooltip)
+      expect(tab).toHaveAttribute('aria-selected', 'false')
+
+      fireEvent.click(tab)
+    }
+
     expect(screen.getByRole('tabpanel')).toHaveAttribute('id', 'columns-panel')
     expect(screen.queryByLabelText('admin.privacy.targetHsaId')).toBeNull()
 
-    fireEvent.click(privacyTab)
-
     expect(routerReplace).not.toHaveBeenCalled()
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('allows PrivacyOfficer to use access review, archiving, and privacy tabs', async () => {
+    mockAccessReviewApi()
+
+    render(
+      <ConfirmModalProvider>
+        <AdminClient
+          currentUserRoles={['PrivacyOfficer']}
+          initialColumnDefaults={DEFAULT_REQUIREMENT_LIST_COLUMN_DEFAULTS}
+        />
+      </ConfirmModalProvider>,
+    )
+
+    const accessReviewTab = screen.getByRole('tab', {
+      name: 'admin.accessReview.title',
+    })
+    const archivingTab = screen.getByRole('tab', {
+      name: 'admin.archiving.title',
+    })
+    const privacyTab = screen.getByRole('tab', {
+      name: 'admin.privacy.title',
+    })
+    const actionAuditLogTab = screen.getByRole('tab', {
+      name: 'admin.auditLog.title',
+    })
+
+    expect(actionAuditLogTab).toHaveAttribute('aria-disabled', 'true')
+    expect(actionAuditLogTab).toHaveAttribute(
+      'title',
+      'admin.auditLog.disabledTooltip',
+    )
+
+    fireEvent.click(accessReviewTab)
+    expect(await screen.findByText('Kalle Svensson')).toBeVisible()
+    expect(accessReviewTab).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.click(privacyTab)
+    expect(screen.getByLabelText('admin.privacy.targetHsaId')).toBeTruthy()
+    expect(privacyTab).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.click(archivingTab)
+    expect(
+      await screen.findByText('admin.archiving.retention.title'),
+    ).toBeTruthy()
+    expect(archivingTab).toHaveAttribute('aria-selected', 'true')
+
+    routerReplace.mockClear()
+    fireEvent.click(actionAuditLogTab)
+
+    expect(routerReplace).not.toHaveBeenCalled()
+    expect(actionAuditLogTab).toHaveAttribute('aria-selected', 'false')
   })
 
   it('shows inline help for each privacy form field', () => {


### PR DESCRIPTION
## Description

- Updated admin center documentation to clarify role requirements for accessing various tabs, including Action Log, Privacy, and Archiving.
- Introduced a new permissions.md file detailing roles and their associated capabilities within the application.
- Modified access review service to allow both Admin and PrivacyOfficer roles to manage access reviews.
- Adjusted UI tests to verify that tabs are correctly disabled for users without the necessary roles.
- Improved error messages to specify required roles for access review actions.
- Enhanced integration tests to ensure that reviewer-only users see privileged admin tabs as disabled.

## Related Issues

<!-- Fixes #123, Closes #123, or Relates to #123 -->

## Reviewer Notes

<!-- Optional: screenshots, test notes, rollout notes, or review context. -->

## Operator Upgrade Impact

Complete this section when the PR changes migrations or required seed data.

- [ ] <!-- operator-upgrade:reviewed --> Operator upgrade impact is reviewed,
  or explicitly not relevant.
- [ ] <!-- operator-upgrade:no-notes --> No operator upgrade notes are needed.

<!-- operator-upgrade:notes start -->
Write operator upgrade notes here...
<!-- operator-upgrade:notes end -->

## SSDLC Gate

Complete this section when the PR changes app code, API, database migrations,
AI/MCP, authentication, authorization, logging, dependencies, workflows, or
personal data. The CI gate enforces these checkboxes for security-sensitive
paths.

- [x] <!-- ssdlc:requirements --> Security requirements are identified below,
  or explicitly not relevant.
- [x] <!-- ssdlc:tests --> Security tests are added/run, or explicitly not
  required.
- [x] <!-- ssdlc:privacy --> Data protection impact is assessed, or explicitly
  not relevant.
- [x] <!-- ssdlc:threat-model --> Threat model impact is assessed, or
  explicitly not required.
- [x] <!-- ssdlc:approval --> Security reviewer approval is complete,
  requested, or covered by CODEOWNERS.

<!-- ssdlc:notes -->
<!-- List requirement IDs such as 8.25/8.26, test evidence, privacy impact,
threat-model decision, and approval context. Use "Not relevant: ..." with a
reason when a point does not apply. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/310)
<!-- Reviewable:end -->
