### PR TITLE
docs: persist operator upgrade notes

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -181,3 +181,7 @@ Access-review, privacy export and retention outputs now include
 requirement-package co-authors and local responsibility-person rows, while
 assignment-level AI flags no longer appear. Review local evidence templates or
 operator runbooks that expect those older fields.
+
+<!-- operator-upgrade:source pr-393 start -->
+Test upgrade note.
+<!-- operator-upgrade:source pr-393 end -->


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #393
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/28676434264

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/396)
<!-- Reviewable:end -->
