### PR TITLE
docs: persist operator upgrade notes

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -27,6 +27,7 @@
     "!playwright-report/**",
     "!playwright-report-dev/**",
     "!playwright-report-preview/**",
-    "!tests/quality/spec_audits/**"
+    "!tests/quality/spec_audits/**",
+    "!docs/operations/operator-upgrade-notes.md"
   ]
 }

--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -182,9 +182,6 @@ requirement-package co-authors and local responsibility-person rows, while
 assignment-level AI flags no longer appear. Review local evidence templates or
 operator runbooks that expect those older fields.
 
-<!-- operator-upgrade:source pr-393 start -->
-Test upgrade note.
-<!-- operator-upgrade:source pr-393 end -->
 
 <!-- operator-upgrade:source pr-394 start -->
 Update automated requirement-import producers and API/MCP integrations before rollout to use the version 2 requirement import schema and the renamed verifiability attribute. Payloads built for the previous import schema, including the old testing-required flag, will not be accepted by this release.

--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -181,3 +181,7 @@ Access-review, privacy export and retention outputs now include
 requirement-package co-authors and local responsibility-person rows, while
 assignment-level AI flags no longer appear. Review local evidence templates or
 operator runbooks that expect those older fields.
+
+<!-- operator-upgrade:source pr-393 start -->
+Test upgrade note.
+<!-- operator-upgrade:source pr-393 end -->

--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -182,7 +182,6 @@ requirement-package co-authors and local responsibility-person rows, while
 assignment-level AI flags no longer appear. Review local evidence templates or
 operator runbooks that expect those older fields.
 
-
 <!-- operator-upgrade:source pr-394 start -->
 Update automated requirement-import producers and API/MCP integrations before rollout to use the version 2 requirement import schema and the renamed verifiability attribute. Payloads built for the previous import schema, including the old testing-required flag, will not be accepted by this release.
 <!-- operator-upgrade:source pr-394 end -->

--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -185,3 +185,7 @@ operator runbooks that expect those older fields.
 <!-- operator-upgrade:source pr-393 start -->
 Test upgrade note.
 <!-- operator-upgrade:source pr-393 end -->
+
+<!-- operator-upgrade:source pr-394 start -->
+Update automated requirement-import producers and API/MCP integrations before rollout to use the version 2 requirement import schema and the renamed verifiability attribute. Payloads built for the previous import schema, including the old testing-required flag, will not be accepted by this release.
+<!-- operator-upgrade:source pr-394 end -->


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #394
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/28679806989

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/397)
<!-- Reviewable:end -->
