### PR TITLE
feat: add import schema and instruction MCP tools

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -437,6 +437,16 @@ var kraven ska sparas; destinationen väljs i importflödet.
 _Avoid_: Kravbiblioteksimport när filformatet avses, kravunderlagsimport när
 filformatet avses, datamigrering.
 
+**Importinstruktion**:
+Vägledning för att ta fram en kravimportfil. Importinstruktionen beskriver
+regler, fältval och stödjande sammanhang för import-JSON, men JSON Schema är
+det styrande filformatskontraktet.
+
+- `en`: Import instruction
+
+_Avoid_: AI-prompt när importvägledningen avses, schema när strikt JSON Schema
+avses.
+
 **Terminologi**:
 De verksamhetsbegrepp och användargränssnittstermer som används för att
 beskriva kravhanteringen. Terminologi förvaltas genom detta sammanhang,

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -32,6 +32,7 @@
     "Embedder",
     "erikl",
     "focusable",
+    "filformatskontraktet",
     "formatdelen",
     "healthcheck",
     "historikmarkörer",

--- a/docs/integrations/mcp-server-contributor-guide.md
+++ b/docs/integrations/mcp-server-contributor-guide.md
@@ -120,7 +120,7 @@ schema is the mandatory contract for generated import JSON.
 
 Returns the canonical `Importinstruktion` Markdown for producing a
 `Kravimportfil`. The instruction is Kravhantering guidance and does not override
-the JSON Schema.
+or replace the JSON Schema.
 
 - **Inputs:** `locale` (`en` | `sv`, default `en`)
 - **Output:** Markdown in `structuredContent.importInstruction`

--- a/docs/integrations/mcp-server-contributor-guide.md
+++ b/docs/integrations/mcp-server-contributor-guide.md
@@ -21,7 +21,7 @@ For admin-managed default column settings, see
 - Primary public identifier: `uniqueId`
 - Read response formats: `markdown`, `json`
 - Supported locales: `en`, `sv`
-- Exposed MCP tools: 12
+- Exposed MCP tools: 14
 - Exposed MCP resources:
   - `requirements://requirement/{uniqueId}`
   - `ui://requirements/requirement-detail/{uniqueId}`
@@ -36,7 +36,7 @@ For admin-managed default column settings, see
   Creates a fresh `WebStandardStreamableHTTPServerTransport` for each request
   and connects the server instance.
 - `lib/mcp/server.ts`
-  Registers the twelve tools, the JSON resource, and the HTML UI resource.
+  Registers the fourteen tools, the JSON resource, and the HTML UI resource.
 - `lib/dal/ui-settings.ts`
   Loads default column settings.
 - `messages/en.json` and `messages/sv.json`
@@ -81,9 +81,9 @@ keeps lifecycle behavior aligned between REST and MCP.
 
 ## Tool Design
 
-The MCP surface is split into three areas: individual requirements (four
-tools), requirements specifications (six tools), and improvement suggestions
-(two tools).
+The MCP surface is split into four areas: import contracts (two tools),
+individual requirements (four tools), requirements specifications (six tools),
+and improvement suggestions (two tools).
 
 ### `requirements_query_catalog`
 
@@ -105,6 +105,28 @@ status icon data and priority-level icon data as additive fields so older
 clients can keep using the existing status and priority-level names.
 
 This avoids a larger set of narrowly scoped read tools.
+
+### `requirements_get_import_schema`
+
+Returns the canonical JSON Schema for producing a `Kravimportfil`. The returned
+schema is the mandatory contract for generated import JSON.
+
+- **Inputs:** `locale` (`en` | `sv`, default `en`)
+- **Output:** the JSON Schema object directly in `structuredContent`
+- **Text content:** short status text that points to `structuredContent`
+- **Grouping:** import contracts
+
+### `requirements_get_import_instruction`
+
+Returns the canonical `Importinstruktion` Markdown for producing a
+`Kravimportfil`. The instruction is Kravhantering guidance and does not override
+the JSON Schema.
+
+- **Inputs:** `locale` (`en` | `sv`, default `en`)
+- **Output:** Markdown in `structuredContent.importInstruction`
+- **Text content:** short status text that points to
+  `structuredContent.importInstruction`
+- **Grouping:** import contracts
 
 ### `requirements_get_requirement`
 
@@ -467,7 +489,7 @@ Useful commands:
 Manual verification should still include:
 
 - connecting an MCP client to `/api/mcp` with a non-production Bearer token
-- checking that all twelve tools appear
+- checking that all fourteen tools appear
 - checking that the JSON resource resolves
 - checking that the requirement view app renders in a client with MCP Apps
   support

--- a/docs/integrations/mcp-server-user-guide.md
+++ b/docs/integrations/mcp-server-user-guide.md
@@ -26,6 +26,12 @@ agents can use it reliably.
   List or search requirements and fetch lookup catalogs such as areas,
   categories, types, quality characteristics, priority levels, statuses,
   usage statuses, requirement packages, and transitions.
+- `requirements_get_import_schema`
+  Retrieve the canonical JSON Schema for a `Kravimportfil`. Use this as the
+  mandatory file-format contract for generated import JSON.
+- `requirements_get_import_instruction`
+  Retrieve the canonical `Importinstruktion` Markdown for a `Kravimportfil`.
+  This is Kravhantering guidance and does not override or replace the JSON Schema.
 - `requirements_get_requirement`
   Fetch the current requirement detail, a specific version, or full version
   history.

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -62,6 +62,26 @@ const ResponseLocaleSchema = z
   .default('en')
   .describe('Response language for names and messages.')
 
+const ImportArtifactLocaleSchema = z
+  .enum(['en', 'sv'])
+  .default('en')
+  .describe(
+    'Artifact language. Supported values: "en" and "sv". Defaults to "en".',
+  )
+
+const ImportInstructionOutputSchema = z
+  .object({
+    importInstruction: z
+      .string()
+      .describe('Canonical import instruction Markdown.'),
+  })
+  .strict()
+
+const ImportSchemaOutputSchema = z
+  .object({})
+  .catchall(z.unknown())
+  .describe('Canonical requirement import JSON Schema object.')
+
 const QueryCatalogOutputSchema = z
   .object({
     catalog: z
@@ -1246,6 +1266,90 @@ export function createKravhanteringMcpServer(
           content: [
             {
               text: payload.message,
+              type: 'text',
+            },
+          ],
+          structuredContent: payload,
+        }
+      } catch (error) {
+        return formatError(error)
+      }
+    },
+  )
+
+  server.registerTool(
+    'requirements_get_import_schema',
+    {
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+        readOnlyHint: true,
+      },
+      description:
+        'Return the canonical JSON Schema for producing a Kravimportfil (requirement import file). Use this schema as the mandatory contract for generated import JSON. The only input is locale, with supported values "en" and "sv".',
+      inputSchema: z
+        .object({
+          locale: ImportArtifactLocaleSchema,
+        })
+        .strict(),
+      outputSchema: ImportSchemaOutputSchema,
+      title: 'Get Requirement Import Schema',
+    },
+    async input => {
+      try {
+        const payload = await service.getImportSchema(
+          await getBaseContext(request, 'requirements_get_import_schema'),
+          {
+            locale: toResponseLocale(input.locale),
+          },
+        )
+        return {
+          content: [
+            {
+              text: 'Requirement import JSON Schema returned in structuredContent.',
+              type: 'text',
+            },
+          ],
+          structuredContent: payload,
+        }
+      } catch (error) {
+        return formatError(error)
+      }
+    },
+  )
+
+  server.registerTool(
+    'requirements_get_import_instruction',
+    {
+      annotations: {
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+        readOnlyHint: true,
+      },
+      description:
+        'Return the canonical Importinstruktion (import instruction) Markdown for producing a Kravimportfil. Use requirements_get_import_schema as the mandatory JSON contract; this instruction is Kravhantering guidance and does not override or replace the schema. The only input is locale, with supported values "en" (for English) and "sv" (for Swedish).',
+      inputSchema: z
+        .object({
+          locale: ImportArtifactLocaleSchema,
+        })
+        .strict(),
+      outputSchema: ImportInstructionOutputSchema,
+      title: 'Get Requirement Import Instruction',
+    },
+    async input => {
+      try {
+        const payload = await service.getImportInstruction(
+          await getBaseContext(request, 'requirements_get_import_instruction'),
+          {
+            locale: toResponseLocale(input.locale),
+          },
+        )
+        return {
+          content: [
+            {
+              text: 'Requirement import instruction returned in structuredContent.importInstruction.',
               type: 'text',
             },
           ],

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -60,13 +60,8 @@ const ResponseFormatSchema = z
 const ResponseLocaleSchema = z
   .enum(['en', 'sv'])
   .default('en')
-  .describe('Response language for names and messages.')
-
-const ImportArtifactLocaleSchema = z
-  .enum(['en', 'sv'])
-  .default('en')
   .describe(
-    'Artifact language. Supported values: "en" and "sv". Defaults to "en".',
+    'Response language for names, messages, and generated artifacts. Supported values: "en" and "sv". Defaults to "en".',
   )
 
 const ImportInstructionOutputSchema = z
@@ -1290,7 +1285,7 @@ export function createKravhanteringMcpServer(
         'Return the canonical JSON Schema for producing a Kravimportfil (requirement import file). Use this schema as the mandatory contract for generated import JSON. The only input is locale, with supported values "en" and "sv".',
       inputSchema: z
         .object({
-          locale: ImportArtifactLocaleSchema,
+          locale: ResponseLocaleSchema,
         })
         .strict(),
       outputSchema: ImportSchemaOutputSchema,
@@ -1332,7 +1327,7 @@ export function createKravhanteringMcpServer(
         'Return the canonical Importinstruktion (import instruction) Markdown for producing a Kravimportfil. Use requirements_get_import_schema as the mandatory JSON contract; this instruction is Kravhantering guidance and does not override or replace the schema. The only input is locale, with supported values "en" (for English) and "sv" (for Swedish).',
       inputSchema: z
         .object({
-          locale: ImportArtifactLocaleSchema,
+          locale: ResponseLocaleSchema,
         })
         .strict(),
       outputSchema: ImportInstructionOutputSchema,
@@ -1541,7 +1536,7 @@ export function createKravhanteringMcpServer(
       description: `List all requirements specifications, optionally filtered by name. Returns id, uniqueId (slug), names, item count, governance object type, and implementation type for each specification. ${specificationIdentifierCopyPaths}`,
       inputSchema: z
         .object({
-          locale: z.enum(['en', 'sv']).default('en'),
+          locale: ResponseLocaleSchema,
           nameSearch: z
             .string()
             .optional()
@@ -1613,7 +1608,7 @@ export function createKravhanteringMcpServer(
             .describe(
               'Case-insensitive substring filter on the requirement description.',
             ),
-          locale: z.enum(['en', 'sv']).default('en'),
+          locale: ResponseLocaleSchema,
           specificationId: z
             .number()
             .int()
@@ -1779,7 +1774,7 @@ export function createKravhanteringMcpServer(
       description: `Link one or more requirements to a requirements specification. Requirements must have a published version; those without are skipped and returned in skippedIds. Optionally attach an existing needsReferenceId or create a new needsReferenceText plus needsReferenceDescription for all added items. Identify the specification with specificationId (numeric) or specificationSlug (e.g. "SAKLYFT-INFOR-Q2"). ${specificationIdentifierCopyPaths} ${addRequirementIdsCopyPath}`,
       inputSchema: z
         .object({
-          locale: z.enum(['en', 'sv']).default('en'),
+          locale: ResponseLocaleSchema,
           needsReferenceDescription: z
             .string()
             .optional()
@@ -1900,7 +1895,7 @@ export function createKravhanteringMcpServer(
       description: `Unlink one or more requirements from a requirements specification. The requirements themselves are not deleted. Identify the specification with specificationId (numeric) or specificationSlug (e.g. "SAKLYFT-INFOR-Q2"). ${specificationIdentifierCopyPaths} ${removeRequirementIdsCopyPath}`,
       inputSchema: z
         .object({
-          locale: z.enum(['en', 'sv']).default('en'),
+          locale: ResponseLocaleSchema,
           specificationId: z
             .number()
             .int()

--- a/lib/requirements/assignment-authorization.ts
+++ b/lib/requirements/assignment-authorization.ts
@@ -464,6 +464,8 @@ export class AssignmentBasedAuthorizationService
 
     switch (action.kind) {
       case 'query_catalog':
+      case 'get_import_schema':
+      case 'get_import_instruction':
         return
       case 'list_specifications':
         return this.assertCanListSpecifications(context)

--- a/lib/requirements/auth.ts
+++ b/lib/requirements/auth.ts
@@ -90,6 +90,12 @@ export type RequirementsAction =
       catalog: string
     }
   | {
+      kind: 'get_import_schema'
+    }
+  | {
+      kind: 'get_import_instruction'
+    }
+  | {
       kind: 'list_specifications'
       nameSearch?: string
     }

--- a/lib/requirements/import-schema.ts
+++ b/lib/requirements/import-schema.ts
@@ -127,7 +127,7 @@ export type ImportPreviewBody = z.infer<typeof importPreviewBodySchema>
 export type ImportReviewRowInput = z.infer<typeof importReviewRowSchema>
 export type ImportExecuteBody = z.infer<typeof importExecuteBodySchema>
 
-type JsonSchema = Record<string, unknown>
+export type JsonSchema = Record<string, unknown>
 
 const optionalStringSchema = (maxLength = BUSINESS_TEXT_MAX_LENGTH) => ({
   maxLength,

--- a/lib/requirements/import-service.ts
+++ b/lib/requirements/import-service.ts
@@ -25,13 +25,20 @@ import {
 } from '@/lib/requirements/auth'
 import { conflictError, validationError } from '@/lib/requirements/errors'
 import {
+  buildRequirementsImportJsonSchema,
   type ImportExecuteBody,
   type ImportRequirement,
   type ImportRequirementsPayload,
   type ImportReviewRowInput,
+  type JsonSchema,
   REQUIREMENTS_IMPORT_SCHEMA_VERSION,
 } from '@/lib/requirements/import-schema'
+import {
+  createRequirementsLogger,
+  type RequirementsLogger,
+} from '@/lib/requirements/logging'
 import { recordSensitiveMutationSucceededWithExecutor } from '@/lib/requirements/security-audit'
+import { authorize, withLogging } from '@/lib/requirements/service-shared'
 
 export type RequirementsImportMode = 'library' | 'specification-local'
 
@@ -143,6 +150,7 @@ export interface RequirementsImportExecuteResult {
 export interface ImportWorkflowOptions {
   authorization: AuthorizationService
   db: SqlServerDatabase
+  logger?: RequirementsLogger
 }
 
 function compactText(value: string | null | undefined): string | null {
@@ -1071,8 +1079,45 @@ function toLocalRequirementMutationInput(
 export function createRequirementsImportWorkflow({
   authorization,
   db,
+  logger = createRequirementsLogger(),
 }: ImportWorkflowOptions) {
-  return {
+  const workflow = {
+    async getImportSchema(
+      context: RequestContext,
+      input: { locale: 'en' | 'sv' },
+    ): Promise<JsonSchema> {
+      await authorize(authorization, { kind: 'get_import_schema' }, context)
+
+      return withLogging(
+        logger,
+        context,
+        'requirements.get_import_schema',
+        { locale: input.locale },
+        async () => buildRequirementsImportJsonSchema(input.locale),
+      )
+    },
+
+    async getImportInstruction(
+      context: RequestContext,
+      input: { locale: 'en' | 'sv' },
+    ): Promise<{ importInstruction: string }> {
+      await authorize(
+        authorization,
+        { kind: 'get_import_instruction' },
+        context,
+      )
+
+      return withLogging(
+        logger,
+        context,
+        'requirements.get_import_instruction',
+        { locale: input.locale },
+        async () => ({
+          importInstruction: await workflow.buildImportAiPrompt(input.locale),
+        }),
+      )
+    },
+
     async buildImportAiPrompt(locale: 'en' | 'sv') {
       const referenceData = await loadImportReferenceData(db)
       const isSv = locale === 'sv'
@@ -1405,4 +1450,6 @@ export function createRequirementsImportWorkflow({
       })
     },
   }
+
+  return workflow
 }

--- a/lib/requirements/security-audit.ts
+++ b/lib/requirements/security-audit.ts
@@ -89,6 +89,9 @@ function actionAuditDetail(
   switch (action.kind) {
     case 'query_catalog':
       return { actionKind: action.kind, catalog: action.catalog }
+    case 'get_import_schema':
+    case 'get_import_instruction':
+      return { actionKind: action.kind }
     case 'list_specifications':
       return { actionKind: action.kind }
     case 'get_specification_items':

--- a/lib/requirements/service.ts
+++ b/lib/requirements/service.ts
@@ -24,6 +24,7 @@ import { notFoundError, validationError } from '@/lib/requirements/errors'
 import type {
   ImportExecuteBody,
   ImportRequirementsPayload,
+  JsonSchema,
 } from '@/lib/requirements/import-schema'
 import {
   createRequirementsImportWorkflow,
@@ -348,6 +349,16 @@ export interface RequirementsService {
     },
   ): Promise<RequirementsImportExecuteResult>
 
+  getImportInstruction(
+    context: RequestContext,
+    input: { locale: ResponseLocale },
+  ): Promise<{ importInstruction: string }>
+
+  getImportSchema(
+    context: RequestContext,
+    input: { locale: ResponseLocale },
+  ): Promise<JsonSchema>
+
   getRequirement(
     context: RequestContext,
     input: GetRequirementInput,
@@ -523,7 +534,7 @@ export function createRequirementsService(
   } = {},
 ): RequirementsService {
   return {
-    ...createRequirementsImportWorkflow({ authorization, db }),
+    ...createRequirementsImportWorkflow({ authorization, db, logger }),
     ...createRequirementWorkflow({ authorization, db, logger }),
 
     ...createSpecificationWorkflow({ authorization, db, logger }),

--- a/tests/fixtures/mcp-requests/expected-tools.json
+++ b/tests/fixtures/mcp-requests/expected-tools.json
@@ -1,6 +1,8 @@
 {
   "tools": [
     "requirements_add_to_specification",
+    "requirements_get_import_instruction",
+    "requirements_get_import_schema",
     "requirements_get_requirement",
     "requirements_get_specification_items",
     "requirements_graduate_local_requirement",

--- a/tests/fixtures/mcp-requests/seeded-cases.json
+++ b/tests/fixtures/mcp-requests/seeded-cases.json
@@ -12,6 +12,22 @@
       }
     },
     {
+      "name": "read requirement import JSON Schema",
+      "tool": "requirements_get_import_schema",
+      "kind": "read",
+      "arguments": {
+        "locale": "sv"
+      }
+    },
+    {
+      "name": "read requirement import instruction",
+      "tool": "requirements_get_import_instruction",
+      "kind": "read",
+      "arguments": {
+        "locale": "en"
+      }
+    },
+    {
       "name": "read requirement detail",
       "tool": "requirements_get_requirement",
       "kind": "read",

--- a/tests/integration/mcp/seeded-scan.spec.ts
+++ b/tests/integration/mcp/seeded-scan.spec.ts
@@ -366,6 +366,45 @@ test.describe('MCP seeded HTTP security gate', () => {
         status: 'ok',
       })
 
+      const importSchema = await callToolOk(
+        client,
+        'requirements_get_import_schema',
+        {
+          locale: 'sv',
+        },
+      )
+      expect(importSchema.$schema).toBe(
+        'https://json-schema.org/draft/2020-12/schema',
+      )
+      expect(arrayField(importSchema, 'required', 'import schema')).toEqual(
+        expect.arrayContaining(['schemaVersion', 'requirements']),
+      )
+      const importSchemaProperties = recordField(
+        importSchema,
+        'properties',
+        'import schema',
+      )
+      expect(importSchemaProperties).not.toHaveProperty('areaId')
+      expect(importSchemaProperties).not.toHaveProperty('specificationId')
+      expect(importSchema).not.toHaveProperty('jsonSchema')
+
+      const importInstruction = await callToolOk(
+        client,
+        'requirements_get_import_instruction',
+        {
+          locale: 'en',
+        },
+      )
+      expect(
+        stringField(
+          importInstruction,
+          'importInstruction',
+          'import instruction',
+        ),
+      ).toContain('# Create JSON for requirements import')
+      expect(importInstruction).not.toHaveProperty('schemaVersion')
+      events.push('import-contracts:ok')
+
       let unknownTool: ToolCallResult | undefined
       let unknownToolError: unknown
       try {

--- a/tests/unit/mcp-authz.test.ts
+++ b/tests/unit/mcp-authz.test.ts
@@ -67,6 +67,16 @@ function createService() {
       total: 0,
     },
   }))
+  const getImportSchema = vi.fn(
+    async (_context: RequestContext, _input: { locale: 'en' | 'sv' }) => ({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+    }),
+  )
+  const getImportInstruction = vi.fn(
+    async (_context: RequestContext, _input: { locale: 'en' | 'sv' }) => ({
+      importInstruction: '# Create JSON for requirements import',
+    }),
+  )
   const getRequirement = vi.fn(async (_context: RequestContext) => ({
     message: 'Requirement detail',
     requirement: createDetail(),
@@ -164,6 +174,8 @@ function createService() {
       mode: 'specification-local' as const,
       summary: { createdCount: 0 },
     })),
+    getImportInstruction,
+    getImportSchema,
     getRequirement,
     getSpecificationItems,
     graduateSpecificationLocalRequirement,
@@ -195,6 +207,8 @@ function createService() {
 
   return {
     addToSpecification,
+    getImportInstruction,
+    getImportSchema,
     getRequirement,
     graduateSpecificationLocalRequirement,
     listGraduationTargetAreas,
@@ -267,6 +281,14 @@ describe('MCP authorization seams', () => {
       name: 'requirements_query_catalog',
     })
     await client.callTool({
+      arguments: {},
+      name: 'requirements_get_import_schema',
+    })
+    await client.callTool({
+      arguments: {},
+      name: 'requirements_get_import_instruction',
+    })
+    await client.callTool({
       arguments: {
         operation: 'edit',
         requirement: {
@@ -310,6 +332,11 @@ describe('MCP authorization seams', () => {
       name: 'requirements_manage_improvement_suggestion',
     })
     expectContext(service.queryCatalog, 'requirements_query_catalog')
+    expectContext(service.getImportSchema, 'requirements_get_import_schema')
+    expectContext(
+      service.getImportInstruction,
+      'requirements_get_import_instruction',
+    )
     expectContext(service.manageRequirement, 'requirements_manage_requirement')
     expectContext(
       service.transitionRequirement,

--- a/tests/unit/mcp-http.test.ts
+++ b/tests/unit/mcp-http.test.ts
@@ -406,7 +406,7 @@ describe('handleRequirementsMcpRequest', () => {
       expect(instructionTool).toBeDefined()
       expect(instructionTool?.description).toContain('Importinstruktion')
       expect(instructionTool?.description).toContain(
-        'does not override the schema',
+        'does not override or replace the schema',
       )
       expect(JSON.stringify(instructionTool?.inputSchema)).toContain(
         'Supported values',

--- a/tests/unit/mcp-http.test.ts
+++ b/tests/unit/mcp-http.test.ts
@@ -65,6 +65,10 @@ import {
 } from '@/lib/mcp/http'
 import { createKravhanteringMcpServer } from '@/lib/mcp/server'
 import { RequirementsServiceError } from '@/lib/requirements/errors'
+import {
+  buildRequirementsImportJsonSchema,
+  REQUIREMENTS_IMPORT_SCHEMA_VERSION,
+} from '@/lib/requirements/import-schema'
 
 function createFakeService(
   normReferences: Array<{
@@ -79,6 +83,18 @@ function createFakeService(
       skippedCount: 0,
       skippedIds: [],
     }),
+    getImportInstruction: vi.fn(
+      async (_context: unknown, input: { locale: 'en' | 'sv' }) => ({
+        importInstruction:
+          input.locale === 'sv'
+            ? '# Skapa JSON för kravimport'
+            : '# Create JSON for requirements import',
+      }),
+    ),
+    getImportSchema: vi.fn(
+      async (_context: unknown, input: { locale: 'en' | 'sv' }) =>
+        buildRequirementsImportJsonSchema(input.locale),
+    ),
     getRequirement: vi.fn().mockResolvedValue({
       message: 'Requirement detail',
       requirement: {
@@ -341,6 +357,8 @@ describe('handleRequirementsMcpRequest', () => {
       expect(tools.map(tool => tool.name).sort()).toEqual(
         [
           'requirements_add_to_specification',
+          'requirements_get_import_instruction',
+          'requirements_get_import_schema',
           'requirements_get_requirement',
           'requirements_get_specification_items',
           'requirements_graduate_local_requirement',
@@ -367,6 +385,35 @@ describe('handleRequirementsMcpRequest', () => {
       expect(queryInputSchemaText).toContain('requirementPackageIds')
       expect(queryInputSchemaText).toContain('sortBy')
       expect(JSON.stringify(queryTool?.outputSchema)).toContain('pagination')
+    })
+
+    it('describes import schema and instruction artifacts', async () => {
+      const schemaTool = getTool('requirements_get_import_schema')
+      const instructionTool = getTool('requirements_get_import_instruction')
+
+      expect(schemaTool).toBeDefined()
+      expect(schemaTool?.description).toContain('mandatory contract')
+      expect(schemaTool?.description).toContain('Kravimportfil')
+      expect(JSON.stringify(schemaTool?.inputSchema)).toContain(
+        'Supported values',
+      )
+      expect(JSON.stringify(schemaTool?.inputSchema)).toContain('"en"')
+      expect(JSON.stringify(schemaTool?.inputSchema)).toContain('"sv"')
+      expect(JSON.stringify(schemaTool?.outputSchema)).toContain(
+        'Canonical requirement import JSON Schema object',
+      )
+
+      expect(instructionTool).toBeDefined()
+      expect(instructionTool?.description).toContain('Importinstruktion')
+      expect(instructionTool?.description).toContain(
+        'does not override the schema',
+      )
+      expect(JSON.stringify(instructionTool?.inputSchema)).toContain(
+        'Supported values',
+      )
+      expect(JSON.stringify(instructionTool?.outputSchema)).toContain(
+        'importInstruction',
+      )
     })
 
     it('describes specification copy paths for MCP clients', async () => {
@@ -688,6 +735,74 @@ describe('handleRequirementsMcpRequest', () => {
         sortDirection: 'desc',
         requirementPackageIds: [3],
       }),
+    )
+
+    await client.close()
+    await transport.close()
+  })
+
+  it('returns the canonical import schema as structured content', async () => {
+    const { client, transport } = await createClient()
+    const fakeService = serviceState.getService.mock.results[0]?.value
+
+    const result = await client.callTool({
+      arguments: { locale: 'sv' },
+      name: 'requirements_get_import_schema',
+    })
+
+    expect(result.isError).not.toBe(true)
+    expect(result.content).toEqual([
+      expect.objectContaining({
+        text: 'Requirement import JSON Schema returned in structuredContent.',
+        type: 'text',
+      }),
+    ])
+    expect(result.structuredContent).toMatchObject({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      properties: {
+        schemaVersion: {
+          const: REQUIREMENTS_IMPORT_SCHEMA_VERSION,
+        },
+      },
+      required: ['schemaVersion', 'requirements'],
+      title: 'Kravimport',
+    })
+    const schemaProperties = (
+      result.structuredContent as { properties?: Record<string, unknown> }
+    ).properties
+    expect(schemaProperties).not.toHaveProperty('areaId')
+    expect(schemaProperties).not.toHaveProperty('specificationId')
+    expect(fakeService.getImportSchema).toHaveBeenCalledWith(
+      expect.anything(),
+      { locale: 'sv' },
+    )
+
+    await client.close()
+    await transport.close()
+  })
+
+  it('returns the canonical import instruction as structured content', async () => {
+    const { client, transport } = await createClient()
+    const fakeService = serviceState.getService.mock.results[0]?.value
+
+    const result = await client.callTool({
+      arguments: {},
+      name: 'requirements_get_import_instruction',
+    })
+
+    expect(result.isError).not.toBe(true)
+    expect(result.content).toEqual([
+      expect.objectContaining({
+        text: 'Requirement import instruction returned in structuredContent.importInstruction.',
+        type: 'text',
+      }),
+    ])
+    expect(result.structuredContent).toEqual({
+      importInstruction: '# Create JSON for requirements import',
+    })
+    expect(fakeService.getImportInstruction).toHaveBeenCalledWith(
+      expect.anything(),
+      { locale: 'en' },
     )
 
     await client.close()

--- a/tests/unit/mcp-property.test.ts
+++ b/tests/unit/mcp-property.test.ts
@@ -23,6 +23,16 @@ const TOOL_CASES: ToolCase[] = [
     valid: { catalog: 'requirements' },
   },
   {
+    acceptsResponseFormat: false,
+    name: 'requirements_get_import_schema',
+    valid: {},
+  },
+  {
+    acceptsResponseFormat: false,
+    name: 'requirements_get_import_instruction',
+    valid: {},
+  },
+  {
     acceptsResponseFormat: true,
     name: 'requirements_get_requirement',
     valid: { uniqueId: 'INT0001' },
@@ -150,6 +160,12 @@ function createService() {
       createdRows: [],
       mode: 'specification-local' as const,
       summary: { createdCount: 0 },
+    })),
+    getImportInstruction: vi.fn(async () => ({
+      importInstruction: '# Create JSON for requirements import',
+    })),
+    getImportSchema: vi.fn(async () => ({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
     })),
     getRequirement: vi.fn(async () => ({
       message: 'Requirement detail',

--- a/tests/unit/mcp-security.test.ts
+++ b/tests/unit/mcp-security.test.ts
@@ -12,6 +12,8 @@ import type {
 
 const EXPECTED_TOOLS = [
   'requirements_add_to_specification',
+  'requirements_get_import_instruction',
+  'requirements_get_import_schema',
   'requirements_get_requirement',
   'requirements_get_specification_items',
   'requirements_graduate_local_requirement',
@@ -84,6 +86,12 @@ function createService() {
       createdRows: [],
       mode: 'specification-local' as const,
       summary: { createdCount: 0 },
+    })),
+    getImportInstruction: vi.fn(async () => ({
+      importInstruction: '# Create JSON for requirements import',
+    })),
+    getImportSchema: vi.fn(async () => ({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
     })),
     getRequirement: vi.fn(async () => ({
       message: 'Requirement detail',

--- a/tests/unit/requirements-assignment-authorization.test.ts
+++ b/tests/unit/requirements-assignment-authorization.test.ts
@@ -138,14 +138,15 @@ describe('AssignmentBasedAuthorizationService', () => {
     expect(lookup.isRequirementAreaAuthor).not.toHaveBeenCalled()
   })
 
-  it('allows catalog queries for any authenticated actor', async () => {
+  it.each<RequirementsAction>([
+    { catalog: 'requirements', kind: 'query_catalog' },
+    { kind: 'get_import_schema' },
+    { kind: 'get_import_instruction' },
+  ])('allows %s for any authenticated actor', async action => {
     const { lookup, service } = makeService()
 
     await expect(
-      service.assertAuthorized(
-        { catalog: 'requirements', kind: 'query_catalog' },
-        makeContext([]),
-      ),
+      service.assertAuthorized(action, makeContext([], '')),
     ).resolves.toBeUndefined()
     expect(lookup.resolveRequirementTarget).not.toHaveBeenCalled()
   })

--- a/tests/unit/requirements-import-service.test.ts
+++ b/tests/unit/requirements-import-service.test.ts
@@ -12,7 +12,9 @@ import {
   createSpecificationLocalRequirementsBatch,
   getSpecificationBySlug,
 } from '@/lib/dal/requirements-specifications'
+import type { RequestContext } from '@/lib/requirements/auth'
 import {
+  buildRequirementsImportJsonSchema,
   REQUIREMENTS_IMPORT_SCHEMA_VERSION,
   requirementsImportPayloadSchema,
 } from '@/lib/requirements/import-schema'
@@ -78,6 +80,23 @@ function extractReferenceData(prompt: string) {
       name: string
       purposeAndScope: string | null
     }>
+  }
+}
+
+function makeContext(toolName: string): RequestContext {
+  return {
+    actor: {
+      displayName: 'Import Service Actor',
+      hsaId: 'SE5560000001-import1',
+      id: 'actor-import',
+      isAuthenticated: true,
+      roles: ['Reviewer'],
+      source: 'mcp',
+    },
+    correlationId: 'corr-import-service',
+    requestId: 'req-import-service',
+    source: 'mcp',
+    toolName,
   }
 }
 
@@ -150,6 +169,70 @@ describe('requirements import service', () => {
         }),
       ],
     })
+  })
+
+  it('returns the import JSON Schema through the authorized service method', async () => {
+    const authorization = { assertAuthorized: vi.fn() }
+    const logger = { error: vi.fn(), info: vi.fn() }
+    const workflow = createRequirementsImportWorkflow({
+      authorization,
+      db: {} as never,
+      logger,
+    })
+    const context = makeContext('requirements_get_import_schema')
+
+    const schema = await workflow.getImportSchema(context, { locale: 'sv' })
+
+    expect(schema).toEqual(buildRequirementsImportJsonSchema('sv'))
+    expect(authorization.assertAuthorized).toHaveBeenCalledWith(
+      { kind: 'get_import_schema' },
+      context,
+    )
+    expect(logger.info).toHaveBeenCalledWith(
+      'requirements.get_import_schema',
+      expect.objectContaining({
+        actor_id: 'actor-import',
+        correlation_id: 'corr-import-service',
+        locale: 'sv',
+        request_id: 'req-import-service',
+        source: 'mcp',
+        tool_name: 'requirements_get_import_schema',
+      }),
+    )
+  })
+
+  it('returns the import instruction through the authorized service method', async () => {
+    const authorization = { assertAuthorized: vi.fn() }
+    const logger = { error: vi.fn(), info: vi.fn() }
+    const workflow = createRequirementsImportWorkflow({
+      authorization,
+      db: {} as never,
+      logger,
+    })
+    const context = makeContext('requirements_get_import_instruction')
+
+    const result = await workflow.getImportInstruction(context, {
+      locale: 'en',
+    })
+
+    expect(result.importInstruction).toContain(
+      '# Create JSON for requirements import',
+    )
+    expect(authorization.assertAuthorized).toHaveBeenCalledWith(
+      { kind: 'get_import_instruction' },
+      context,
+    )
+    expect(logger.info).toHaveBeenCalledWith(
+      'requirements.get_import_instruction',
+      expect.objectContaining({
+        actor_id: 'actor-import',
+        correlation_id: 'corr-import-service',
+        locale: 'en',
+        request_id: 'req-import-service',
+        source: 'mcp',
+        tool_name: 'requirements_get_import_instruction',
+      }),
+    )
   })
 
   it('resolves proposed norm references by key when norm reference id is omitted', async () => {


### PR DESCRIPTION
## Description

<!-- Optional: what changed and why? -->

## Related Issues

<!-- Fixes #123, Closes #123, or Relates to #123 -->

## Reviewer Notes

<!-- Optional: screenshots, test notes, rollout notes, or review context. -->

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
After rollout, MCP clients can discover two additional requirements-import tools for retrieving the canonical import schema and import instruction. Existing MCP clients should continue to work, but operators or support staff should notify teams that maintain strict MCP tool inventories, allowlists, or client-side assertions so they can refresh their expected tool count after upgrade.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/399)
<!-- Reviewable:end -->
