### PR TITLE
docs: persist operator upgrade notes from #572

### DIFF
--- a/app/[locale]/requirements/stewardship/requirement-selection-questions-client.tsx
+++ b/app/[locale]/requirements/stewardship/requirement-selection-questions-client.tsx
@@ -1699,6 +1699,7 @@ export default function RequirementSelectionQuestionsClient() {
       const nextQuestionIds = new Set(
         nextQuestions.map(question => question.id),
       )
+      questionsRef.current = nextQuestions
       setQuestions(nextQuestions)
       setExpandedQuestionIds(current => {
         if (current.size === 0) return current

--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -20,6 +20,9 @@ FROM access_review_runs
 WHERE period_start > period_end;
 ```
 
+<!-- operator-upgrade:source pr-572 start -->
+Before rollout, review identity-provider role assignments for Admin Center users. Access is now limited to users with the Admin or PrivacyOfficer role, and users who need both general administration and privacy or archiving work must have both roles. Users without either role will no longer see the Admin Center entry point, and direct links will show an access-denied page.
+<!-- operator-upgrade:source pr-572 end -->
 ## v0.3.0 - 2026-07-09
 
 ### Requirements specifications need lifecycle status before upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #572
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/29337317607

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/573)
<!-- Reviewable:end -->
