### PR TITLE
chore: update nginx container to 1.31.3-alpine

### DIFF
--- a/containers/nginx/image.lock.json
+++ b/containers/nginx/image.lock.json
@@ -2,8 +2,8 @@
   "name": "nginx",
   "role": "tls-proxy",
   "image": "docker.io/library/nginx",
-  "tag": "1.31.2-alpine",
-  "manifestDigest": "sha256:35cd77497979abe70dc8d26f5ae60811eea233a2eb5dc03c2ee30972caeb303e",
-  "imageId": "sha256:ea51152ef8c480b999cee0271a288c698704b18483276119b1253e576ef3232f",
+  "tag": "1.31.3-alpine",
+  "manifestDigest": "sha256:1d40e3eb3bf4f138de1d67193f2aa5309fcaf343eb5ffadbf5e9439de1eb1ebb",
+  "imageId": "sha256:f0ba77f796e57c6fa89ae7f4fdad1665d6fcbd8e3f211535120542b337f9959e",
   "source": "https://hub.docker.com/_/nginx"
 }

--- a/containers/production/env/release.env.template
+++ b/containers/production/env/release.env.template
@@ -20,7 +20,7 @@ KEYCLOAK_IMAGE_REF=registry.example.internal/keycloak/keycloak:replace-with-rele
 # pull-time digest pinning.
 # APP_RUNTIME_IMAGE_REF=ghcr.io/viscalyx/kravhantering-app-runtime:replace-with-release-tag
 # DB_JOB_IMAGE_REF=ghcr.io/viscalyx/kravhantering-db-job:replace-with-release-tag
-# NGINX_IMAGE_REF=docker.io/library/nginx:1.31.2-alpine
+# NGINX_IMAGE_REF=docker.io/library/nginx:1.31.3-alpine
 # SQLSERVER_IMAGE_REF=mcr.microsoft.com/mssql/server:2025-CU6-ubuntu-24.04
 # KEYCLOAK_IMAGE_REF=quay.io/keycloak/keycloak:26.7.0-0
 


### PR DESCRIPTION
## Description

### nginx 1.31.3-alpine

Updates the nginx vendor image lock from main to 1.31.3-alpine.

Lane: `nginx 1.x`

| Field | Previous | Proposed |
| --- | --- | --- |
| Tag | `1.31.2-alpine` | `1.31.3-alpine` |
| Manifest digest | `sha256:35cd77497979abe70dc8d26f5ae60811eea233a2eb5dc03c2ee30972caeb303e` | `sha256:1d40e3eb3bf4f138de1d67193f2aa5309fcaf343eb5ffadbf5e9439de1eb1ebb` |
| Image ID | `sha256:ea51152ef8c480b999cee0271a288c698704b18483276119b1253e576ef3232f` | `sha256:f0ba77f796e57c6fa89ae7f4fdad1665d6fcbd8e3f211535120542b337f9959e` |

Branch: `automation/vendor-image/nginx-1.31.3-alpine`
Platform: `linux/amd64`

## Related Issues

Relates to automated vendor image maintenance.

## Reviewer Notes

Files changed by policy:

- `containers/nginx/image.lock.json`
- `containers/production/env/release.env.template`

Normal pull request CI performs validation for this update.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
No operator notes needed for this vendor image lock update.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

Automated vendor image maintenance was reviewed for security, data protection, threat-model, and security-testing impacts.
Normal pull request CI validates the generated lock and companion-file changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/618)
<!-- Reviewable:end -->
