### PR TITLE
docs: persist operator upgrade notes from #625

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -39,6 +39,11 @@ process-local pool; no new environment variable or setting is required.
 Review Admin Center > Settings > Exports and Reports. The common CSV limits
 apply to Requirements Library, procurement, and full specification CSV.
 
+<!-- operator-upgrade:source pr-625 start -->
+### RFI question suggestions require consistent lifecycle history
+Before upgrade, verify that existing RFI question suggestions have consistent lifecycle history. In particular, handled or dismissed suggestions must have a recorded review request, motivation, and chronologically valid lifecycle timestamps. The database migration stops and identifies affected records rather than altering historical evidence; correct them before retrying.
+Update integrations and support runbooks to follow the forward-only lifecycle: draft → review requested → handled or dismissed.
+<!-- operator-upgrade:source pr-625 end -->
 ## v0.3.0 - 2026-07-09
 
 ### Requirements specifications need lifecycle status before upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #625
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/29772844868

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/626)
<!-- Reviewable:end -->
