### PR TITLE
feat: add container vulnerability exception skill

### DIFF
--- a/.github/skills/manage-container-vulnerability-exceptions/SKILL.md
+++ b/.github/skills/manage-container-vulnerability-exceptions/SKILL.md
@@ -35,7 +35,8 @@ not an approval or a way around the container release gate.
      `if: always()`.
    - For an already published release, download that release's complete Grype
      reports, policy decision, SBOMs, and database status. Bind the evidence to
-     the requested release digest.
+     the requested release digest. Keep the downloaded files in the canonical
+     `metadata`, `reports`, and `sbom` directory layout.
    - Reject evidence from a different commit, release, image digest, or stale
      scan when exact evidence can be generated.
 
@@ -85,17 +86,10 @@ gh run download <run-id> \
 
 For an accepted exception, edit only
 `.github/container-vulnerability-exceptions.json` and supporting decision
-documentation that is necessary for review. Preserve the schema implemented by
-the canonical evaluator and add one exact record containing:
-
-- a unique `id`;
-- exact `vulnerabilityId` and release `image`;
-- exact `package.name` and `package.installedVersion` from the report;
-- an accountable `owner` and evidence-based `rationale`;
-- ISO `created`, `reviewBy`, and hard `expires` dates;
-- authoritative HTTPS `references`; and
-- `expectedFix.status`, concrete `details`, and `reference` when a fix or
-  tracking item is known.
+documentation that is necessary for review. Construct the record from the
+current exception document and `validateExceptionDocument`; do not maintain a
+second schema in this skill. Require the evaluator's exact scope, ownership,
+rationale, lifecycle dates, references, and expected-fix evidence.
 
 Use the shortest justified review interval and expiry. Keep `reviewBy` on or
 before `expires`. For an unknown upstream timeline, explain which authoritative
@@ -104,8 +98,9 @@ date.
 
 For existing exceptions:
 
-- Remove an expired exception and remediate its finding; expiration never
-  justifies extending the record without a fresh decision.
+- Remove an expired exception and recommend remediation. Perform remediation
+  only when the task separately includes it; expiration never justifies
+  extending the record without a fresh decision.
 - Remove an exception after a clean canonical scan shows that the exact finding
   is gone or an upstream fix has been applied.
 - When the installed version changes but remains affected, let the old exact
@@ -121,9 +116,12 @@ the full Grype report.
 ## Validate
 
 Run the evaluator against the downloaded evidence after every proposed edit.
-Derive the image list from the evaluator instead of maintaining another copy:
+Use digest-bound release metadata for published releases. For pull-request
+evidence, derive the image list from the evaluator instead of maintaining
+another copy:
 
 ```bash
+EVIDENCE_DIR="<temporary-evidence-directory>"
 RELEASE_IMAGES="$(
   node --input-type=module <<'NODE'
 import {
@@ -132,12 +130,18 @@ import {
 process.stdout.write(RELEASE_IMAGE_NAMES.join(','))
 NODE
 )"
+POLICY_SCOPE=(--images "${RELEASE_IMAGES}")
+if [[ -f "${EVIDENCE_DIR}/metadata/release-metadata.json" ]]; then
+  POLICY_SCOPE=(
+    --metadata "${EVIDENCE_DIR}/metadata/release-metadata.json"
+  )
+fi
 node scripts/release/container-vulnerability-policy.mjs evaluate \
-  --images "${RELEASE_IMAGES}" \
+  "${POLICY_SCOPE[@]}" \
   --exceptions .github/container-vulnerability-exceptions.json \
-  --reports-dir "<temporary-evidence-directory>/reports" \
-  --sbom-dir "<temporary-evidence-directory>/sbom" \
-  --output "<temporary-evidence-directory>/metadata/recheck-decision.json" \
+  --reports-dir "${EVIDENCE_DIR}/reports" \
+  --sbom-dir "${EVIDENCE_DIR}/sbom" \
+  --output "${EVIDENCE_DIR}/metadata/recheck-decision.json" \
   --as-of "$(date -u +%F)"
 ```
 
@@ -145,9 +149,11 @@ Require `passed: true`, zero exception errors, and the intended finding under
 `excepted`. For removal after remediation, require that the finding appears in
 neither `blocking` nor `excepted`.
 
-Run the focused policy and workflow tests, then the repository check. Push the
-commit to the non-protected branch and require a fresh `Container PR Smoke` run
-for that exact commit before declaring validation complete.
+Run the focused policy and workflow tests, then the repository check. When the
+task authorizes repository mutations, push the commit to the non-protected
+branch and require a fresh `Container PR Smoke` run for that exact commit. When
+it does not, stop after local validation and report the fresh PR gate as an
+outstanding completion condition.
 
 ```bash
 npm run test -- scripts/__tests__/container-vulnerability-policy.test.mjs \

--- a/.github/skills/manage-container-vulnerability-exceptions/SKILL.md
+++ b/.github/skills/manage-container-vulnerability-exceptions/SKILL.md
@@ -34,9 +34,10 @@ not an approval or a way around the container release gate.
      `container-pr-vulnerability-<run-id>`; the workflow uploads it with
      `if: always()`.
    - For an already published release, download that release's complete Grype
-     reports, policy decision, SBOMs, and database status. Bind the evidence to
-     the requested release digest. Keep the downloaded files in the canonical
-     `metadata`, `reports`, and `sbom` directory layout.
+     reports, policy decision, SBOMs, database status, and
+     `release-metadata.json`. Bind the evidence to the requested release digest.
+     Keep the downloaded files in the canonical `metadata`, `reports`, and
+     `sbom` directory layout.
    - Reject evidence from a different commit, release, image digest, or stale
      scan when exact evidence can be generated.
 
@@ -122,6 +123,7 @@ another copy:
 
 ```bash
 EVIDENCE_DIR="<temporary-evidence-directory>"
+EVIDENCE_KIND="<pr-or-release>"
 RELEASE_IMAGES="$(
   node --input-type=module <<'NODE'
 import {
@@ -130,12 +132,15 @@ import {
 process.stdout.write(RELEASE_IMAGE_NAMES.join(','))
 NODE
 )"
-POLICY_SCOPE=(--images "${RELEASE_IMAGES}")
-if [[ -f "${EVIDENCE_DIR}/metadata/release-metadata.json" ]]; then
-  POLICY_SCOPE=(
-    --metadata "${EVIDENCE_DIR}/metadata/release-metadata.json"
-  )
-fi
+case "${EVIDENCE_KIND}" in
+  pr) POLICY_SCOPE=(--images "${RELEASE_IMAGES}") ;;
+  release)
+    RELEASE_METADATA="${EVIDENCE_DIR}/metadata/release-metadata.json"
+    [[ -f "${RELEASE_METADATA}" ]] || exit 1
+    POLICY_SCOPE=(--metadata "${RELEASE_METADATA}")
+    ;;
+  *) exit 1 ;;
+esac
 node scripts/release/container-vulnerability-policy.mjs evaluate \
   "${POLICY_SCOPE[@]}" \
   --exceptions .github/container-vulnerability-exceptions.json \

--- a/.github/skills/manage-container-vulnerability-exceptions/SKILL.md
+++ b/.github/skills/manage-container-vulnerability-exceptions/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: manage-container-vulnerability-exceptions
+description: >-
+  Investigate, add, review, update, or remove committed container vulnerability
+  exceptions. Use when a Grype container finding needs evidence and a risk
+  decision, when `.github/container-vulnerability-exceptions.json` needs
+  maintenance, or when an exception may be stale, expired, or superseded by an
+  upstream fix.
+---
+
+# Manage Container Vulnerability Exceptions
+
+Prefer remediation. Treat an exception as a temporary, reviewable risk proposal,
+not an approval or a way around the container release gate.
+
+## Workflow
+
+1. Read the canonical sources before acting:
+   - `.github/actions/container-vulnerability-gate/action.yml`
+   - `.github/container-vulnerability-exceptions.json`
+   - `scripts/release/container-vulnerability-policy.mjs`
+   - `docs/development/trusted-container-publishing.md`, section
+     `Vulnerability Promotion Policy`
+2. Record the target branch, commit SHA, image, and vulnerability ID. Keep
+   investigation artifacts under a directory created with `mktemp -d`; do not
+   commit scan output.
+3. Obtain fresh evidence from the canonical gate.
+   - For a pull-request commit, use its `Container PR Smoke` run. Confirm the
+     run's `headSha` equals the pushed commit before using it.
+   - If no run exists for the exact commit, push a non-protected branch and
+     open or update a draft pull request only when the task authorizes those
+     repository mutations. Otherwise request that authority.
+   - Watch the run even when a vulnerability is expected to fail it. Download
+     `container-pr-vulnerability-<run-id>`; the workflow uploads it with
+     `if: always()`.
+   - For an already published release, download that release's complete Grype
+     reports, policy decision, SBOMs, and database status. Bind the evidence to
+     the requested release digest.
+   - Reject evidence from a different commit, release, image digest, or stale
+     scan when exact evidence can be generated.
+
+```bash
+gh pr view --json number,headRefOid,url
+gh run list --workflow "Container PR Smoke" \
+  --branch "$(git branch --show-current)" --event pull_request \
+  --json databaseId,headSha,status,conclusion,url
+gh run watch <run-id> --exit-status
+gh run download <run-id> \
+  --name "container-pr-vulnerability-<run-id>" \
+  --dir "<temporary-evidence-directory>"
+```
+
+4. Read `metadata/vulnerability-policy-decision.json` and the complete matching
+   `reports/<image>.json`. Record all of these exact facts:
+   - vulnerability ID;
+   - image;
+   - package name and installed version;
+   - Grype severity;
+   - fix state and every known fixed version;
+   - candidate digest or pull-request commit that binds the evidence; and
+   - Grype database status or scan time.
+5. Research current authoritative evidence. Prefer the affected vendor's
+   security advisory and package tracker, then the ecosystem advisory, CVE
+   record, or GitHub Security Advisory. Record direct HTTPS links. Distinguish
+   published facts from inference and note conflicting severity or fix data.
+6. Assess the finding:
+   - Explain the vulnerable behavior and exploit prerequisites.
+   - Locate the package in the image and determine whether the application or
+     runtime reaches the affected feature. Treat missing reachability evidence
+     as uncertainty, not proof of safety.
+   - Identify remediation in this order: update the package or base image,
+     remove the package or feature, reduce exposure, then use a temporary
+     exception.
+   - State the residual impact and likelihood if remediation is deferred.
+7. Recommend `accept` or `reject`; do not silently accept risk.
+   - Reject broad, wildcard, multi-finding, ownerless, unexplained, or
+     non-expiring proposals.
+   - Reject an exception when a practical supported remediation is available.
+   - Require an accountable owner and reviewer-visible rationale before
+     proposing acceptance. A pull request proposes the risk decision; an
+     accountable reviewer approves it.
+8. Apply only the requested maintenance after the evidence supports it.
+
+## Exception Changes
+
+For an accepted exception, edit only
+`.github/container-vulnerability-exceptions.json` and supporting decision
+documentation that is necessary for review. Preserve the schema implemented by
+the canonical evaluator and add one exact record containing:
+
+- a unique `id`;
+- exact `vulnerabilityId` and release `image`;
+- exact `package.name` and `package.installedVersion` from the report;
+- an accountable `owner` and evidence-based `rationale`;
+- ISO `created`, `reviewBy`, and hard `expires` dates;
+- authoritative HTTPS `references`; and
+- `expectedFix.status`, concrete `details`, and `reference` when a fix or
+  tracking item is known.
+
+Use the shortest justified review interval and expiry. Keep `reviewBy` on or
+before `expires`. For an unknown upstream timeline, explain which authoritative
+sources lack a timeline and set the next review date. Never invent a version or
+date.
+
+For existing exceptions:
+
+- Remove an expired exception and remediate its finding; expiration never
+  justifies extending the record without a fresh decision.
+- Remove an exception after a clean canonical scan shows that the exact finding
+  is gone or an upstream fix has been applied.
+- When the installed version changes but remains affected, let the old exact
+  record become stale and assess a new exact record from fresh evidence. Do not
+  widen or silently retarget the old scope.
+- Update owner, rationale, review, expiry, references, or expected-fix data only
+  from current evidence and with reviewer-visible justification.
+
+Keep the release action, policy evaluator, blocking severities, evidence
+retention, and promotion gate unchanged. Do not add scanner ignores or filter
+the full Grype report.
+
+## Validate
+
+Run the evaluator against the downloaded evidence after every proposed edit.
+Derive the image list from the evaluator instead of maintaining another copy:
+
+```bash
+RELEASE_IMAGES="$(
+  node --input-type=module <<'NODE'
+import {
+  RELEASE_IMAGE_NAMES,
+} from './scripts/release/container-vulnerability-policy.mjs'
+process.stdout.write(RELEASE_IMAGE_NAMES.join(','))
+NODE
+)"
+node scripts/release/container-vulnerability-policy.mjs evaluate \
+  --images "${RELEASE_IMAGES}" \
+  --exceptions .github/container-vulnerability-exceptions.json \
+  --reports-dir "<temporary-evidence-directory>/reports" \
+  --sbom-dir "<temporary-evidence-directory>/sbom" \
+  --output "<temporary-evidence-directory>/metadata/recheck-decision.json" \
+  --as-of "$(date -u +%F)"
+```
+
+Require `passed: true`, zero exception errors, and the intended finding under
+`excepted`. For removal after remediation, require that the finding appears in
+neither `blocking` nor `excepted`.
+
+Run the focused policy and workflow tests, then the repository check. Push the
+commit to the non-protected branch and require a fresh `Container PR Smoke` run
+for that exact commit before declaring validation complete.
+
+```bash
+npm run test -- scripts/__tests__/container-vulnerability-policy.test.mjs \
+  tests/unit/github-actions-workflow-security.test.ts
+npm run check
+```
+
+## Pull Request Rationale
+
+Prepare a concise pull-request summary with:
+
+- the exact finding and evidence-bound image or commit;
+- authoritative links and the exposure or reachability assessment;
+- remediation attempted or the concrete reason it is temporarily blocked;
+- the accept or reject recommendation and residual risk;
+- owner, creation, review, and hard-expiry dates;
+- expected fix version, date, or tracking link, or why it is unknown; and
+- local evaluator, focused test, repository check, and fresh PR gate results.
+
+Use a normal pull request for every committed exception change. Keep protected
+branches and release gates unchanged.

--- a/.github/skills/manage-container-vulnerability-exceptions/SKILL.md
+++ b/.github/skills/manage-container-vulnerability-exceptions/SKILL.md
@@ -42,14 +42,23 @@ not an approval or a way around the container release gate.
      scan when exact evidence can be generated.
 
 ```bash
-gh pr view --json number,headRefOid,url
-gh run list --workflow "Container PR Smoke" \
-  --branch "$(git branch --show-current)" --event pull_request \
-  --json databaseId,headSha,status,conclusion,url
-gh run watch <run-id> --exit-status
-gh run download <run-id> \
-  --name "container-pr-vulnerability-<run-id>" \
+PR="<pr-number-or-url>"
+PR_JSON="$(gh pr view "${PR}" --json number,headRefName,headRefOid,url)"
+PR_HEAD_REF="$(jq -er '.headRefName' <<<"${PR_JSON}")"
+PR_HEAD_SHA="$(jq -er '.headRefOid' <<<"${PR_JSON}")"
+RUN_ID="$(
+  gh run list --workflow "Container PR Smoke" \
+    --branch "${PR_HEAD_REF}" --event pull_request \
+    --json databaseId,headSha,status,conclusion,url |
+    jq -er --arg sha "${PR_HEAD_SHA}" \
+      '[.[] | select(.headSha == $sha)] | first | .databaseId'
+)"
+RUN_WATCH_STATUS=0
+gh run watch "${RUN_ID}" --exit-status || RUN_WATCH_STATUS=$?
+gh run download "${RUN_ID}" \
+  --name "container-pr-vulnerability-${RUN_ID}" \
   --dir "<temporary-evidence-directory>"
+printf 'Container PR Smoke watch exit status: %s\n' "${RUN_WATCH_STATUS}"
 ```
 
 4. Read `metadata/vulnerability-policy-decision.json` and the complete matching
@@ -104,9 +113,9 @@ For existing exceptions:
   extending the record without a fresh decision.
 - Remove an exception after a clean canonical scan shows that the exact finding
   is gone or an upstream fix has been applied.
-- When the installed version changes but remains affected, let the old exact
-  record become stale and assess a new exact record from fresh evidence. Do not
-  widen or silently retarget the old scope.
+- When the installed version changes but remains affected, remove the old exact
+  record before adding a replacement exact record assessed from fresh evidence.
+  Do not widen or silently change the old scope.
 - Update owner, rationale, review, expiry, references, or expected-fix data only
   from current evidence and with reviewer-visible justification.
 
@@ -119,11 +128,17 @@ the full Grype report.
 Run the evaluator against the downloaded evidence after every proposed edit.
 Use digest-bound release metadata for published releases. For pull-request
 evidence, derive the image list from the evaluator instead of maintaining
-another copy:
+another copy. For release evidence, set `RELEASE_IMAGE` to the requested
+evaluator image name and `EXPECTED_RELEASE_DIGEST` to the requested published
+image's independently verified manifest digest. Do not derive the expected
+digest from `release-metadata.json`.
 
 ```bash
 EVIDENCE_DIR="<temporary-evidence-directory>"
 EVIDENCE_KIND="<pr-or-release>"
+RELEASE_IMAGE="${RELEASE_IMAGE:-}"
+EXPECTED_RELEASE_DIGEST="${EXPECTED_RELEASE_DIGEST:-}"
+RECHECK_DECISION="${EVIDENCE_DIR}/metadata/recheck-decision.json"
 RELEASE_IMAGES="$(
   node --input-type=module <<'NODE'
 import {
@@ -137,6 +152,9 @@ case "${EVIDENCE_KIND}" in
   release)
     RELEASE_METADATA="${EVIDENCE_DIR}/metadata/release-metadata.json"
     [[ -f "${RELEASE_METADATA}" ]] || exit 1
+    : "${RELEASE_IMAGE:?Set the requested release image name}"
+    : "${EXPECTED_RELEASE_DIGEST:?Set the requested release manifest digest}"
+    [[ "${EXPECTED_RELEASE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]] || exit 1
     POLICY_SCOPE=(--metadata "${RELEASE_METADATA}")
     ;;
   *) exit 1 ;;
@@ -146,13 +164,23 @@ node scripts/release/container-vulnerability-policy.mjs evaluate \
   --exceptions .github/container-vulnerability-exceptions.json \
   --reports-dir "${EVIDENCE_DIR}/reports" \
   --sbom-dir "${EVIDENCE_DIR}/sbom" \
-  --output "${EVIDENCE_DIR}/metadata/recheck-decision.json" \
+  --output "${RECHECK_DECISION}" \
   --as-of "$(date -u +%F)"
+if [[ "${EVIDENCE_KIND}" == release ]]; then
+  jq -e --arg image "${RELEASE_IMAGE}" \
+    --arg digest "${EXPECTED_RELEASE_DIGEST}" '
+      [.evidence[]? | select(.image == $image)] as $entries
+      | ($entries | length > 0)
+        and all($entries[]; .candidateManifestDigest == $digest)
+    ' "${RECHECK_DECISION}" >/dev/null || exit 1
+fi
 ```
 
 Require `passed: true`, zero exception errors, and the intended finding under
-`excepted`. For removal after remediation, require that the finding appears in
-neither `blocking` nor `excepted`.
+`excepted`. For release evidence, reject a missing or mismatched requested
+image-to-digest entry even when the evaluator otherwise passes. For removal
+after remediation, require that the finding appears in neither `blocking` nor
+`excepted`.
 
 Run the focused policy and workflow tests, then the repository check. When the
 task authorizes repository mutations, push the commit to the non-protected

--- a/.github/skills/manage-container-vulnerability-exceptions/agents/openai.yaml
+++ b/.github/skills/manage-container-vulnerability-exceptions/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Manage Container Vulnerability Exceptions"
+  short_description: "Investigate and maintain container exceptions"
+  default_prompt: "Use $manage-container-vulnerability-exceptions to investigate and manage a narrowly scoped container vulnerability exception."
+policy:
+  allow_implicit_invocation: false

--- a/.github/skills/manage-container-vulnerability-exceptions/agents/openai.yaml
+++ b/.github/skills/manage-container-vulnerability-exceptions/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Investigate and maintain container exceptions"
   default_prompt: "Use $manage-container-vulnerability-exceptions to investigate and manage a narrowly scoped container vulnerability exception."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true


### PR DESCRIPTION
## Description

- Add an implicitly triggered repository skill for investigating, adding, reviewing, updating, and removing container vulnerability exceptions.
- Reuse exact-commit Container PR Smoke artifacts and the canonical vulnerability policy evaluator instead of duplicating scan or policy logic.
- Require authoritative evidence, remediation-first decisions, exact exception scope, accountable review, hard expiry, and digest-bound release validation.
- Keep exception changes on normal pull-request branches without weakening the release gate or filtering full Grype reports.

## Related Issues

Closes #708

## Reviewer Notes

- `npm run check` passed: 4,811 tests passed, 75 skipped; both HSA support suites passed.
- Focused container policy and GitHub Actions workflow tests passed: 28 tests.
- Skill structure validation and embedded shell syntax validation passed.
- Forward-tested both add-exception and stale/expired cleanup requests.
- Final two-axis code review: 0 Standards findings and 0 Spec findings.
- Internal agent-workflow change; no manual UI test cases are required.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
None.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/720)
<!-- Reviewable:end -->
