### PR TITLE
chore: add implementation workflow skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,8 +38,8 @@
   If the change is internal-only and no manual case update is needed, state that
   in the final response.
 - Follow `docs/development/sql-server-developer-workflow.md` for database setup, migrations, seeding, and developer browse workflow expectations.
-- For visible UI element, label, role, or layout surface changes, see `.github/instructions/developer-mode.instructions.md`.
 - Developer Mode is a desktop-only developer tool. Its overlay, chips, badge, and toast do **not** need to follow WCAG touch-target sizes, mobile responsiveness, or accessibility guidelines. Keep chips compact so they don't obscure the underlying UI.
+
 ## Database Schema Changes
 
 - See `.github/instructions/database-schema.instructions.md` for all schema, migration, seed, naming, versioning, and lifecycle rules.
@@ -56,14 +56,3 @@
 - `ConfirmModalProvider` is already mounted in `app/[locale]/layout.tsx`.
 
 <!-- markdownlint-enable MD013 -->
-
-## Spelling
-
-- If cSpell reports a misspelling in a Markdown file, add the word to the
-  project dictionary if
-  - the word is a correctly spelled technical term
-  - the word or term is linguistically correct for the language the text is written in
-  - the word is a proper noun (e.g. product name, company name, person's name)
-  - the word is a common abbreviation or acronym that is widely recognized in the
-    context of the project
-- If the word is a misspelling, correct the spelling in the text.

--- a/.github/skills/implement/SKILL.md
+++ b/.github/skills/implement/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: implement
+description: "Implement a piece of work based on a spec or set of tickets."
+disable-model-invocation: true
+---
+
+Implement the work described by the user in the spec or tickets.
+
+Use /tdd where possible, at pre-agreed seams.
+
+Run typechecking regularly, single test files regularly, and the full test suite once at the end.
+
+Once done, use /code-review to review the work.
+
+Commit your work to the current branch.

--- a/.github/skills/implement/agents/openai.yaml
+++ b/.github/skills/implement/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Implement"
+  short_description: "Build work from a spec or tickets"
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## Description

- Add a user-invoked `implement` skill for implementing ticketed work with TDD, regular type checking, a final full suite, code review, and a branch commit.
- Add matching skill-list metadata with implicit invocation disabled.
- Trim duplicated global Copilot guidance that is supplied by the repository's higher-level agent instructions.

## Related Issues

None.

## Reviewer Notes

- `npm run check` passed: 4,811 tests passed, 75 skipped; both HSA support suites passed.
- `git diff --check` passed.
- The general `quick_validate.py` utility rejects `disable-model-invocation`, while the repository's `writing-for-agents` contract requires that field for user-invoked skills. The repository check remains green and the invocation metadata is internally consistent.
- Internal agent-workflow change; no manual UI test cases are required.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
None.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/721)
<!-- Reviewable:end -->
