### PR TITLE
fix: run HSA certificate generator without npm

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -163,7 +163,7 @@ services:
     build:
       context: ${WORKSPACE_BUILD_ROOT:-..}/containers/hsa-person-lookup-adapter
       dockerfile: Dockerfile
-    command: npm run generate-certs
+    command: ["node", "src/generate-certs.mjs"]
     user: "0:0"
     volumes:
       - hsa-mtls-certs:/run/hsa-mtls

--- a/.devcontainer/elevated/docker-compose.yml
+++ b/.devcontainer/elevated/docker-compose.yml
@@ -181,7 +181,7 @@ services:
     build:
       context: ${WORKSPACE_BUILD_ROOT:-../..}/containers/hsa-person-lookup-adapter
       dockerfile: Dockerfile
-    command: npm run generate-certs
+    command: ["node", "src/generate-certs.mjs"]
     user: "0:0"
     volumes:
       - hsa-mtls-certs:/run/hsa-mtls

--- a/containers/production/compose/single-node-demo.compose.yml
+++ b/containers/production/compose/single-node-demo.compose.yml
@@ -4,7 +4,7 @@
 services:
   hsa-mtls-cert-generator:
     image: ${HSA_PERSON_LOOKUP_ADAPTER_IMAGE_REF:?set HSA_PERSON_LOOKUP_ADAPTER_IMAGE_REF}
-    command: npm run generate-certs
+    command: ["node", "src/generate-certs.mjs"]
     user: "0:0"
     volumes:
       - hsa-mtls-certs:/run/hsa-mtls

--- a/scripts/azure-dev/templates/quadlet/krav-hsa-mtls-cert-generator.container
+++ b/scripts/azure-dev/templates/quadlet/krav-hsa-mtls-cert-generator.container
@@ -8,7 +8,7 @@ ContainerName=hsa-mtls-cert-generator
 Image=localhost/kravhantering/hsa-person-lookup-adapter:local
 User=0:0
 Volume=krav-hsa-mtls-certs.volume:/run/hsa-mtls:Z
-Exec=npm run generate-certs
+Exec=node src/generate-certs.mjs
 
 [Service]
 Environment=HOME=%h

--- a/tests/unit/container-image-contract.test.ts
+++ b/tests/unit/container-image-contract.test.ts
@@ -129,6 +129,29 @@ describe('container image contract', () => {
     }
   })
 
+  it('runs the HSA certificate generator without runtime npm', () => {
+    for (const relativePath of [
+      '.devcontainer/docker-compose.yml',
+      '.devcontainer/elevated/docker-compose.yml',
+      'containers/production/compose/single-node-demo.compose.yml',
+    ]) {
+      const compose = parseYaml(readWorkspaceFile(relativePath)) as {
+        services?: Record<string, { command?: string[] }>
+      }
+
+      expect(compose.services?.['hsa-mtls-cert-generator']?.command).toEqual([
+        'node',
+        'src/generate-certs.mjs',
+      ])
+    }
+
+    const azureQuadlet = readWorkspaceFile(
+      'scripts/azure-dev/templates/quadlet/krav-hsa-mtls-cert-generator.container',
+    )
+    expect(azureQuadlet).toContain('Exec=node src/generate-certs.mjs')
+    expect(azureQuadlet).not.toContain('Exec=npm')
+  })
+
   it('keeps app-runtime to standalone output and public assets', () => {
     const target = dockerfileTarget('app-runtime')
 


### PR DESCRIPTION
## Description

- Invoke the HSA mTLS certificate generator with Node directly because npm is intentionally removed from final runtime images.
- Apply the corrected command to the Azure Quadlet, both devcontainer profiles, and the single-node demo overlay.
- Add a container contract test that prevents runtime launchers from depending on npm.

## Related Issues

None.

## Reviewer Notes

Validation:

- npm run check
- Focused container-image and development-environment contract tests
- Certificate generation executed successfully in the npm-less runtime image

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
No operator upgrade notes.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/722)
<!-- Reviewable:end -->
