### PR TITLE
chore: explain Grype scan lifecycle warnings

### DIFF
--- a/.github/workflows/container-vulnerability-monitor.yml
+++ b/.github/workflows/container-vulnerability-monitor.yml
@@ -123,6 +123,11 @@ jobs:
             "${GRYPE_CMD}" "sbom:${sbom_path}" -o json > "${report_path}"
           done < <(jq -c '.entries[]' "${EVIDENCE_ROOT}/scan-plan.json")
 
+          node scripts/release/container-vulnerability-monitor.mjs summarize \
+            --plan "${EVIDENCE_ROOT}/scan-plan.json" \
+            --db-status "${EVIDENCE_ROOT}/grype-db-status.json" \
+            --summary "${GITHUB_STEP_SUMMARY}"
+
       - name: Evaluate shared vulnerability policy
         id: evaluate
         continue-on-error: true

--- a/scripts/__tests__/container-vulnerability-monitor.test.mjs
+++ b/scripts/__tests__/container-vulnerability-monitor.test.mjs
@@ -9,6 +9,7 @@ import {
   planPublicIssueActions,
   renderPrivateAdvisory,
   renderPublicIssue,
+  renderScanContextSummary,
   main as runMonitor,
   selectSupportedReleases,
   synchronizeTracking,
@@ -277,6 +278,45 @@ describe('container vulnerability release monitor', () => {
     expect(() => buildScanPlan({ releases: [release] }, root)).toThrow(
       'project-owned image',
     )
+  })
+
+  it('explains current database and Debian LTS context after scans', () => {
+    const root = temporaryDirectory()
+    const plan = {
+      entries: [
+        {
+          imageName: 'app-runtime',
+          releaseTag: 'v0.3.0',
+          reportPath: path.join(root, 'bookworm.json'),
+        },
+        {
+          imageName: 'app-runtime',
+          releaseTag: 'v0.4.0-preview.87',
+          reportPath: path.join(root, 'trixie.json'),
+        },
+      ],
+    }
+    writeJson(plan.entries[0].reportPath, {
+      distro: { name: 'debian', version: '12' },
+    })
+    writeJson(plan.entries[1].reportPath, {
+      distro: { name: 'debian', version: '13' },
+    })
+
+    const summary = renderScanContextSummary({
+      databaseStatus: {
+        built: '2026-08-02T07:02:31Z',
+        schemaVersion: 'v6.1.9',
+        valid: true,
+      },
+      plan,
+    })
+
+    expect(summary).toContain('No vulnerability database update available')
+    expect(summary).toContain('`v0.3.0` | `debian 12`')
+    expect(summary).toContain('`v0.4.0-preview.87` | `debian 13`')
+    expect(summary).toContain('reduced-scope LTS security maintenance')
+    expect(summary).toContain('2028-06-30')
   })
 
   it('rejects altered assets and attestations whose predicates differ', () => {
@@ -923,6 +963,8 @@ describe('container vulnerability release monitor', () => {
     const selectionPath = path.join(root, 'selection.json')
     const planPath = path.join(root, 'plan.json')
     const verificationPath = path.join(root, 'verification.json')
+    const databaseStatusPath = path.join(root, 'grype-db-status.json')
+    const summaryPath = path.join(root, 'summary.md')
     const exceptionsPath = path.join(root, 'exceptions.json')
     const resultPath = path.join(root, 'result.json')
     writeJson(selectionPath, { releases: [release] })
@@ -952,8 +994,24 @@ describe('container vulnerability release monitor', () => {
       ])
       writeJson(entry.reportPath, { matches: [] })
     }
+    writeJson(databaseStatusPath, {
+      built: '2026-08-02T07:02:31Z',
+      schemaVersion: 'v6.1.9',
+      valid: true,
+    })
     writeJson(exceptionsPath, { exceptions: [], schemaVersion: 1 })
 
+    await expect(
+      runMonitor([
+        'summarize',
+        '--plan',
+        planPath,
+        '--db-status',
+        databaseStatusPath,
+        '--summary',
+        summaryPath,
+      ]),
+    ).resolves.toBe(0)
     await expect(
       runMonitor([
         'verify-attestations',
@@ -992,5 +1050,8 @@ describe('container vulnerability release monitor', () => {
     ).resolves.toBe(0)
     expect(readJson(verificationPath).verified).toBe(5)
     expect(readJson(resultPath).findings).toEqual([])
+    expect(fs.readFileSync(summaryPath, 'utf8')).toContain(
+      'Container vulnerability scan context',
+    )
   })
 })

--- a/scripts/release/container-vulnerability-monitor.mjs
+++ b/scripts/release/container-vulnerability-monitor.mjs
@@ -24,6 +24,10 @@ const DIGEST_PATTERN = /^sha256:[a-f\d]{64}$/u
 const TAG_PATTERN = /^v[0-9A-Za-z][0-9A-Za-z.-]*$/u
 const FINGERPRINT_PATTERN = /^[a-f\d]{64}$/u
 const GITHUB_REPOSITORY_PATTERN = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/u
+const DEBIAN_BOOKWORM_LTS_END = '2028-06-30'
+const DEBIAN_BOOKWORM_LIFECYCLE_URL =
+  'https://www.debian.org/News/2026/20260712'
+const DEBIAN_BOOKWORM_LTS_URL = 'https://wiki.debian.org/LTS/Bookworm'
 const PUBLIC_ISSUE_MARKER =
   /<!-- container-vulnerability:(?<fingerprint>[a-f\d]{64}) -->/u
 const IMAGE_PACKAGES = new Map([
@@ -66,6 +70,7 @@ const USAGE = `Usage:
   node scripts/release/container-vulnerability-monitor.mjs select --releases <path> --support <path> --output <path>
   node scripts/release/container-vulnerability-monitor.mjs plan --selection <path> --releases-dir <path> --output <path>
   node scripts/release/container-vulnerability-monitor.mjs verify-attestations --plan <path> --output <path>
+  node scripts/release/container-vulnerability-monitor.mjs summarize --plan <path> --db-status <path> --summary <path>
   node scripts/release/container-vulnerability-monitor.mjs evaluate --plan <path> --exceptions <path> --output <path> [--scanned-at <ISO timestamp>]
   node scripts/release/container-vulnerability-monitor.mjs sync --result <path> --repository <owner/repo>`
 
@@ -316,6 +321,64 @@ export function verifyAttestedSpdxDocuments(plan, fsImpl = fs) {
   if (verified === 0)
     throw new Error('No release SBOM attestations were verified.')
   return { verified }
+}
+
+function markdownCode(value) {
+  return `\`${String(value).replaceAll('`', '\\`')}\``
+}
+
+export function renderScanContextSummary({
+  databaseStatus,
+  plan,
+  fsImpl = fs,
+}) {
+  const releases = new Map()
+  let hasDebianBookworm = false
+  for (const entry of plan?.entries ?? []) {
+    const report = readJson(entry.reportPath, fsImpl)
+    const distroName = String(report?.distro?.name ?? 'unknown')
+    const distroVersion = String(report?.distro?.version ?? 'unknown')
+    const distro = `${distroName} ${distroVersion}`
+    if (distroName === 'debian' && distroVersion === '12') {
+      hasDebianBookworm = true
+    }
+    const byDistro = releases.get(entry.releaseTag) ?? new Map()
+    const images = byDistro.get(distro) ?? []
+    images.push(entry.imageName)
+    byDistro.set(distro, images)
+    releases.set(entry.releaseTag, byDistro)
+  }
+
+  const databaseValidity =
+    databaseStatus?.valid === true ? 'valid' : 'reported invalid'
+  const lines = [
+    '## Container vulnerability scan context',
+    '',
+    `- Grype database: ${databaseValidity}; schema ${markdownCode(databaseStatus?.schemaVersion ?? 'unknown')}; built ${markdownCode(databaseStatus?.built ?? 'unknown')}.`,
+    '- `No vulnerability database update available` is informational: the update check found no database newer than the active one.',
+    '',
+    '| Release | Detected distribution | Images |',
+    '| --- | --- | --- |',
+  ]
+  for (const [releaseTag, byDistro] of releases) {
+    for (const [distro, images] of byDistro) {
+      lines.push(
+        `| ${markdownCode(releaseTag)} | ${markdownCode(distro)} | ${images.map(markdownCode).join(', ')} |`,
+      )
+    }
+  }
+
+  if (hasDebianBookworm) {
+    lines.push(
+      '',
+      '> [!NOTE]',
+      '> Grype labels Debian 12 packages as coming from an “EOL distro” because regular Debian Security Team support has ended. Debian 12 Bookworm remains under reduced-scope LTS security maintenance through ' +
+        `${DEBIAN_BOOKWORM_LTS_END}. The warning does not mean the Grype database update failed, but package and architecture coverage should be checked against Debian LTS support.`,
+      `> Sources: [Debian lifecycle](${DEBIAN_BOOKWORM_LIFECYCLE_URL}) and [Bookworm LTS coverage](${DEBIAN_BOOKWORM_LTS_URL}).`,
+    )
+  }
+
+  return `${lines.join('\n')}\n`
 }
 
 function findingIdentity(finding) {
@@ -881,6 +944,14 @@ export async function main(args, dependencies = {}) {
         { ...verification, verifiedAt: new Date().toISOString() },
         fsImpl,
       )
+    } else if (command === 'summarize') {
+      const summary = renderScanContextSummary({
+        databaseStatus: readJson(options['db-status'], fsImpl),
+        fsImpl,
+        plan: readJson(options.plan, fsImpl),
+      })
+      consoleObj.log(summary.trimEnd())
+      fsImpl.appendFileSync(options.summary, summary)
     } else if (command === 'evaluate') {
       const result = evaluateSupportedReleaseFindings({
         exceptionDocument: readJson(options.exceptions, fsImpl),


### PR DESCRIPTION
## Description

- add a post-scan context summary to the continuous container vulnerability monitor
- explain that a missing Grype database update means the active database is already current
- map every monitored release to its detected distribution and image set
- explain Debian 12 regular-support EOL versus Bookworm LTS when relevant
- publish the same context in the GitHub Actions job summary

The original Grype warnings remain enabled so genuine end-of-life signals are not hidden.

## Related Issues

None.

## Reviewer Notes

- `npm run check`
- focused monitor and GitHub Actions workflow-security tests: 37 passed
- exercised the new summary against the retained evidence from run 30759680216
- no manual test update is needed because this changes CI diagnostics only

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

The change preserves fail-closed scanning and existing EOL alerts, reads only generated Grype evidence, and does not expose secrets or vulnerability details beyond the workflow's existing diagnostics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/804)
<!-- Reviewable:end -->
