### PR TITLE
fix: use ephemeral GHCR credential helper

### DIFF
--- a/.github/actions/container-vulnerability-gate/action.yml
+++ b/.github/actions/container-vulnerability-gate/action.yml
@@ -80,7 +80,7 @@ runs:
       id: grype
       uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
       with:
-        cache-db: true
+        cache-db: false
 
     - name: Scan complete candidate SBOMs with current Grype database
       shell: bash

--- a/.github/actions/ghcr-credential-helper/action.yml
+++ b/.github/actions/ghcr-credential-helper/action.yml
@@ -1,0 +1,53 @@
+name: Configure ephemeral GHCR credentials
+description: Use the GitHub Actions token through a Docker credential helper.
+
+inputs:
+  token:
+    description: Short-lived token used to authenticate to GHCR.
+    required: true
+  username:
+    description: GitHub username associated with the token.
+    required: true
+
+outputs:
+  authfile:
+    description: Docker-compatible auth file configured with the helper.
+    value: ${{ steps.configure.outputs.authfile }}
+
+runs:
+  using: composite
+  steps:
+    - name: Configure credential helper and log in
+      id: configure
+      shell: bash
+      env:
+        GHCR_TOKEN: ${{ inputs.token }}
+        GHCR_USERNAME: ${{ inputs.username }}
+      run: |
+        set -euo pipefail
+        umask 077
+        docker_config="${RUNNER_TEMP}/docker-ghcr"
+        helper_dir="${RUNNER_TEMP}/docker-credential-helpers"
+        helper_name="docker-credential-ghcr-env"
+
+        install -d -m 700 "${docker_config}" "${helper_dir}"
+        install -m 700 \
+          "${GITHUB_ACTION_PATH}/${helper_name}" \
+          "${helper_dir}/${helper_name}"
+        jq -n \
+          '{auths: {}, credHelpers: {"ghcr.io": "ghcr-env"}}' \
+          > "${docker_config}/config.json"
+
+        export DOCKER_CONFIG="${docker_config}"
+        export PATH="${helper_dir}:${PATH}"
+        printf '%s' "${GHCR_TOKEN}" |
+          docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
+        if jq -e 'any(.auths[]?; has("auth"))' \
+          "${docker_config}/config.json" > /dev/null; then
+          echo 'Docker persisted GHCR credentials instead of using the helper.' >&2
+          exit 1
+        fi
+
+        echo "${helper_dir}" >> "${GITHUB_PATH}"
+        echo "DOCKER_CONFIG=${docker_config}" >> "${GITHUB_ENV}"
+        echo "authfile=${docker_config}/config.json" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/ghcr-credential-helper/docker-credential-ghcr-env
+++ b/.github/actions/ghcr-credential-helper/docker-credential-ghcr-env
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+operation="${1:-}"
+username="${GHCR_USERNAME:-${GITHUB_ACTOR:-}}"
+token="${GHCR_TOKEN:-${GH_TOKEN:-}}"
+
+require_credentials() {
+  if [[ -z "${username}" || -z "${token}" ]]; then
+    echo 'GHCR username and token must be available in the environment.' >&2
+    exit 1
+  fi
+}
+
+require_ghcr() {
+  local server="${1}"
+  case "${server}" in
+    ghcr.io | https://ghcr.io | https://ghcr.io/v1/)
+      ;;
+    *)
+      echo "Credentials are unavailable for ${server}." >&2
+      exit 1
+      ;;
+  esac
+}
+
+case "${operation}" in
+  store)
+    payload="$(cat)"
+    server="$(jq -r '.ServerURL // empty' <<< "${payload}")"
+    require_ghcr "${server}"
+    jq -e \
+      '(.Username | type == "string" and length > 0) and
+       (.Secret | type == "string" and length > 0)' \
+      <<< "${payload}" > /dev/null
+    ;;
+  get)
+    server="$(cat)"
+    require_ghcr "${server}"
+    require_credentials
+    jq -cn \
+      --arg username "${username}" \
+      --arg secret "${token}" \
+      '{Username: $username, Secret: $secret}'
+    ;;
+  erase)
+    server="$(cat)"
+    require_ghcr "${server}"
+    ;;
+  list)
+    require_credentials
+    jq -cn --arg username "${username}" '{"ghcr.io": $username}'
+    ;;
+  *)
+    echo "Unsupported credential-helper operation: ${operation}" >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -333,18 +333,15 @@ jobs:
       - name: Log in to GHCR after validation gates
         id: ghcr-login
         if: success()
-        env:
-          GHCR_TOKEN: ${{ github.token }}
-        run: |
-          echo "${GHCR_TOKEN}" |
-            docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
-          authfile="${HOME}/.docker/config.json"
-          test -s "${authfile}"
-          echo "authfile=${authfile}" >> "${GITHUB_OUTPUT}"
+        uses: ./.github/actions/ghcr-credential-helper
+        with:
+          token: ${{ github.token }}
+          username: ${{ github.actor }}
 
       - name: Promote unchanged candidate OCI artifacts and verify digests
         if: success()
         env:
+          GHCR_TOKEN: ${{ github.token }}
           REGISTRY_AUTH_FILE: ${{ steps.ghcr-login.outputs.authfile }}
         run: |
           node scripts/release/promote-container-candidates.mjs \

--- a/.github/workflows/container-vulnerability-monitor.yml
+++ b/.github/workflows/container-vulnerability-monitor.yml
@@ -65,11 +65,10 @@ jobs:
             --output "${EVIDENCE_ROOT}/scan-plan.json"
 
       - name: Log in to GHCR for digest verification
-        env:
-          GHCR_TOKEN: ${{ github.token }}
-        run: |
-          echo "${GHCR_TOKEN}" |
-            docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+        uses: ./.github/actions/ghcr-credential-helper
+        with:
+          token: ${{ github.token }}
+          username: ${{ github.actor }}
 
       - name: Verify published SBOM attestations
         run: |

--- a/.github/workflows/container-vulnerability-monitor.yml
+++ b/.github/workflows/container-vulnerability-monitor.yml
@@ -95,7 +95,7 @@ jobs:
         id: grype
         uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:
-          cache-db: true
+          cache-db: false
 
       - name: Scan every supported release SBOM
         env:

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -84,6 +84,7 @@
     "nodev",
     "nosuid",
     "nullrang",
+    "octocat",
     "OPTOUT",
     "sidoperation",
     "Traverseringen",

--- a/tests/unit/ghcr-credential-helper.test.ts
+++ b/tests/unit/ghcr-credential-helper.test.ts
@@ -1,0 +1,85 @@
+import { spawnSync } from 'node:child_process'
+import { statSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const HELPER = path.join(
+  process.cwd(),
+  '.github',
+  'actions',
+  'ghcr-credential-helper',
+  'docker-credential-ghcr-env',
+)
+
+function runHelper(
+  operation: string,
+  input: string,
+  env: Record<string, string> = {},
+) {
+  return spawnSync(HELPER, [operation], {
+    encoding: 'utf8',
+    env: {
+      NODE_ENV: 'test',
+      PATH: process.env.PATH,
+      ...env,
+    },
+    input,
+  })
+}
+
+describe('GHCR environment credential helper', () => {
+  it('is executable and returns the explicitly scoped credentials', () => {
+    expect(statSync(HELPER).mode & 0o111).not.toBe(0)
+
+    const result = runHelper('get', 'ghcr.io', {
+      GHCR_TOKEN: 'short-lived-token',
+      GHCR_USERNAME: 'octocat',
+    })
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toEqual({
+      Secret: 'short-lived-token',
+      Username: 'octocat',
+    })
+  })
+
+  it('falls back to the standard GitHub Actions environment', () => {
+    const result = runHelper('get', 'https://ghcr.io', {
+      GH_TOKEN: 'github-actions-token',
+      GITHUB_ACTOR: 'github-actions[bot]',
+    })
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout)).toEqual({
+      Secret: 'github-actions-token',
+      Username: 'github-actions[bot]',
+    })
+  })
+
+  it('accepts Docker store and erase calls without persisting the secret', () => {
+    const store = runHelper(
+      'store',
+      JSON.stringify({
+        Secret: 'short-lived-token',
+        ServerURL: 'ghcr.io',
+        Username: 'octocat',
+      }),
+    )
+    const erase = runHelper('erase', 'ghcr.io')
+
+    expect(store.status).toBe(0)
+    expect(store.stdout).toBe('')
+    expect(erase.status).toBe(0)
+    expect(erase.stdout).toBe('')
+  })
+
+  it('rejects requests for other registries', () => {
+    const result = runHelper('get', 'docker.io', {
+      GHCR_TOKEN: 'short-lived-token',
+      GHCR_USERNAME: 'octocat',
+    })
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('Credentials are unavailable for docker.io')
+  })
+})

--- a/tests/unit/github-actions-workflow-security.test.ts
+++ b/tests/unit/github-actions-workflow-security.test.ts
@@ -668,7 +668,17 @@ describe('GitHub Actions workflow security', () => {
     expect(verifyAttestationIndex).toBeLessThan(releaseIndex)
 
     expect(steps[loginIndex]?.id).toBe('ghcr-login')
+    expect(steps[loginIndex]?.uses).toBe(
+      './.github/actions/ghcr-credential-helper',
+    )
+    expect(steps[loginIndex]?.with).toEqual({
+      token: ['${{', 'github.token', '}}'].join(' '),
+      username: ['${{', 'github.actor', '}}'].join(' '),
+    })
     expect(steps[promotionIndex]?.if).toBe('success()')
+    expect(steps[promotionIndex]?.env?.GHCR_TOKEN).toBe(
+      ['${{', 'github.token', '}}'].join(' '),
+    )
     expect(steps[promotionIndex]?.env?.REGISTRY_AUTH_FILE).toBe(
       ['${{', 'steps.ghcr-login.outputs.authfile', '}}'].join(' '),
     )
@@ -725,6 +735,13 @@ describe('GitHub Actions workflow security', () => {
     expect(job?.if).toBe("github.ref == 'refs/heads/main'")
 
     expect(step('Select supported published releases')).toBeDefined()
+    expect(step('Log in to GHCR for digest verification')).toMatchObject({
+      uses: './.github/actions/ghcr-credential-helper',
+      with: {
+        token: ['${{', 'github.token', '}}'].join(' '),
+        username: ['${{', 'github.actor', '}}'].join(' '),
+      },
+    })
     expect(step('Verify published SBOM attestations')).toBeDefined()
     expect(step('Scan every supported release SBOM')).toBeDefined()
     const installGrype = step('Install pinned Grype')

--- a/tests/unit/github-actions-workflow-security.test.ts
+++ b/tests/unit/github-actions-workflow-security.test.ts
@@ -633,6 +633,11 @@ describe('GitHub Actions workflow security', () => {
         step.name ===
         'Scan complete candidate SBOMs with current Grype database',
     )
+    expect(
+      gateSteps.find(step => step.name === 'Install pinned Grype')?.with?.[
+        'cache-db'
+      ],
+    ).toBe(false)
     const scanRun = String(scanStep?.run)
     expect(scanRun).toContain('for attempt in 1 2 3; do')
     expect(scanRun).toContain(
@@ -747,7 +752,7 @@ describe('GitHub Actions workflow security', () => {
     const installGrype = step('Install pinned Grype')
     expect(installGrype).toMatchObject({
       id: 'grype',
-      with: { 'cache-db': true },
+      with: { 'cache-db': false },
     })
     expect(installGrype?.uses).toMatch(
       /^anchore\/scan-action\/download-grype@[a-f\d]{40}$/u,


### PR DESCRIPTION
## Description

- Configure a repository-local Docker credential helper for GHCR on each runner.
- Keep the short-lived GitHub token in the step environment instead of Docker `config.json`.
- Reuse the helper for vulnerability monitoring and release promotion.
- Disable Grype database caching so scans use the explicitly updated database.
- Add credential-helper protocol and workflow contract tests.

## Related Issues

None.

## Reviewer Notes

Validation completed:

- `npx vitest run tests/unit/github-actions-workflow-security.test.ts tests/unit/ghcr-credential-helper.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm run format:check`
- `npm run spell:check`
- `bash -n .github/actions/ghcr-credential-helper/docker-credential-ghcr-env`

The helper only serves credentials for GHCR and the composite action fails if Docker writes an `auth` value to its generated configuration.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
No operator upgrade notes are required.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/807)
<!-- Reviewable:end -->