### PR TITLE
fix: authenticate approval-side workstation response packages

### DIFF
--- a/.env.azure.development.example
+++ b/.env.azure.development.example
@@ -48,6 +48,10 @@ AZURE_DEV_VM_SSH_HOST_ALIAS=kravhantering-azure-dev
 # Use a public-key path or an inline key:: value. Never use private-key content.
 # AZURE_DEV_GIT_SSH_SIGNING_KEY=~/.ssh/id_ed25519.pub
 
+# Expected workstation-package approver public key. Provision this file through
+# a trusted channel and set its path only in .env.azure.development.local.
+# AZURE_DEV_WORKSTATION_APPROVER_PUBLIC_KEY_PATH=~/.ssh/kravhantering_azure_dev_approver_ed25519.pub
+
 # Optional non-secret Tailscale settings.
 # AZURE_DEV_VM_CONNECTIVITY_MODE=tailscale
 # AZURE_DEV_TAILSCALE_TAILNET=

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -31,6 +31,7 @@
     "installerartester",
     "kodbaserad",
     "kravliste",
+    "kravpkg",
     "kravpaketsfilterraden",
     "kravunderlagssidan",
     "mellanlagringsfil",

--- a/docs/development/azure-vm-remote-ssh-development.md
+++ b/docs/development/azure-vm-remote-ssh-development.md
@@ -1028,8 +1028,10 @@ sequenceDiagram
     User->>Source: Confirm verification code
     Source->>Azure: Add named CIDR rule
     Source->>VM: Add destination public key
-    Source-->>User: ASCII-armored destination-key-encrypted age package
+    Source->>Source: Sign encrypted payload with managed SSH identity
+    Source-->>User: Signed and encrypted .kravpkg response
     User->>Destination: Transfer attachment or armored text
+    Destination->>Destination: Verify expected approver signature
     Destination->>Destination: extract-workstation-package
     Destination-->>User: Private README and selected files
     User->>Destination: Copy and configure files manually
@@ -1037,22 +1039,37 @@ sequenceDiagram
     Destination-->>User: Readiness report and code command
 ```
 
-The request is Base64-encoded text, not encrypted. Schema 2 records the selected
-mode with the public onboarding data:
+The request is Base64-encoded text, not encrypted. Schema 3 records the selected
+mode, expected approver fingerprint, and public onboarding data:
 
 ```text
 -----BEGIN KRAVHANTERING WORKSTATION REQUEST-----
-Version: 2
+Version: 3
 
 <Base64 payload>
 -----END KRAVHANTERING WORKSTATION REQUEST-----
 ```
 
 The request is signed by the destination key. Its schema binds the absolute
-destination private-key path alongside the intended use and public onboarding
-data. The approving user must still compare the displayed fingerprint or
-verification code because an attacker could replace the entire request with a
-separately signed request.
+destination private-key path and expected approver public-key fingerprint
+alongside the intended use and public onboarding data. The approving user must
+still compare the displayed fingerprint or verification code because an
+attacker could replace the entire request with a separately signed request.
+
+Before creating the request, provision the approving workstation's managed SSH
+public key on the destination through a trusted channel. Store it outside the
+repository and set its ignored local path in
+`.env.azure.development.local`:
+
+```dotenv
+AZURE_DEV_WORKSTATION_APPROVER_PUBLIC_KEY_PATH=~/.ssh/kravhantering_azure_dev_approver_ed25519.pub
+```
+
+The command rejects a missing, unreadable, or invalid key file before creating
+the destination key. The configured key is the sole response trust anchor;
+keys or fingerprints carried by a response cannot replace it. Rotating the
+approver key invalidates every pending request, so provision the new public key
+and create a new request after rotation.
 
 ### Create the destination request
 
@@ -1145,14 +1162,17 @@ Approve a request file:
 ```powershell
 ./scripts/azure-dev.ps1 -Command approve-workstation `
   -RequestPath "<request-file>" `
-  -OutputPath "<response-package>.age"
+  -OutputPath "<response-package>.kravpkg"
 ```
 
 Omit `-RequestPath` to paste the text request interactively. Approval displays
 and honors the signed mode, workstation, CIDR, destination private-key path,
 public-key fingerprint, and verification code. A change requires a new request.
 Approval refuses Tailscale environments before changing the package or
-environment because transfer supports public SSH only.
+environment because transfer supports public SSH only. It also refuses the
+request before package creation or access mutation unless the public half of
+the managed `AZURE_DEV_VM_SSH_PRIVATE_KEY_PATH` identity matches the approver
+fingerprint bound into the request.
 
 For either mode, the approver may independently include `GH_TOKEN` and
 `COPILOT_GITHUB_TOKEN` from the current process. Both are excluded by default.
@@ -1168,8 +1188,10 @@ never contains a private Git signing key.
 Approval temporarily starts a stopped VM when the user confirms, restores its
 original power state, adds and verifies the named CIDR and public key, and
 creates an ASCII-armored response package encrypted to the destination
-workstation's SSH public key. The package can only be decrypted with the
-private key that remains on that workstation.
+workstation's SSH public key and signed with the managed approval identity. The
+package can only be decrypted with the private key that remains on the
+destination, and the destination accepts it only when the configured approver
+public key verifies the signature.
 
 The package contents depend on the signed mode:
 
@@ -1183,20 +1205,21 @@ The package contents depend on the signed mode:
   those destination values without changing the source. Otherwise packaging
   creates a minimal two-value local file.
 
-The `.age` response is plain ASCII text in the native `age` armor format:
+The `.kravpkg` response is one plain ASCII schema-3 envelope. It carries the
+exact native `age` armored payload and an SSH signature over those exact bytes:
 
 ```text
------BEGIN AGE ENCRYPTED FILE-----
-<armored encrypted payload>
------END AGE ENCRYPTED FILE-----
+-----BEGIN KRAVHANTERING WORKSTATION PACKAGE-----
+Version: 3
+
+<Base64 response envelope>
+-----END KRAVHANTERING WORKSTATION PACKAGE-----
 ```
 
 Transfer it as a normal attachment or copy the complete block through a
 text-only channel. When copying text, save the complete block as a plain-text
-`.age` file on the destination workstation without changing the markers. The
-encrypted contents can be copied safely, but the armored representation is
-about one-third larger than the binary form. `age` detects and decrypts the
-armored file automatically.
+`.kravpkg` file on the destination workstation without changing the markers.
+Do not split the signature into a sidecar file.
 
 ### Extract and configure manually
 
@@ -1204,15 +1227,22 @@ On the destination workstation:
 
 ```powershell
 ./scripts/azure-dev.ps1 -Command extract-workstation-package `
-  -PackagePath "<response-package>.age" `
+  -PackagePath "<response-package>.kravpkg" `
   -DestinationPath "<private-extraction-directory>"
 ```
 
-Extraction validates the package, rejects unsafe archive paths, and writes every
-validated manifest entry, including permitted environment files, only under the
-selected destination. It does not automatically apply those files to the
-repository, configure the environment, update SSH configuration, edit shell
-profiles, install tokens, or launch VS Code.
+Extraction first parses the schema-3 envelope and verifies the signature over
+the encrypted payload with `AZURE_DEV_WORKSTATION_APPROVER_PUBLIC_KEY_PATH`.
+Only then does it invoke `age`, open the archive, or create the destination.
+Missing or malformed armor, missing or invalid signatures, modified payloads,
+and a changed approver key fail without retaining plaintext. Provision the
+expected key and regenerate both request and response; unsigned schema-2
+`.age` responses are intentionally incompatible. After authentication,
+extraction validates the package, rejects unsafe archive paths, and writes
+every validated manifest entry, including permitted environment files, only
+under the selected destination. It does not automatically apply those files
+to the repository, configure the environment, update SSH configuration, edit
+shell profiles, install tokens, or launch VS Code.
 
 On Windows, extraction removes inherited access rules from the new destination,
 grants only the current user full control, and validates the protected ACL
@@ -1257,7 +1287,7 @@ After manual configuration, validate readiness:
   -DestinationPath "<private-extraction-directory>"
 ```
 
-For connect-only, readiness determines the mode from the extracted schema 2
+For connect-only, readiness determines the mode from the extracted schema 3
 manifest before loading configuration. A partially applied local file can
 therefore report the missing fixed host, alias, destination private key,
 verified `known_hosts` entries, exact managed SSH block, and any required

--- a/docs/development/azure-vm-remote-ssh-internals.md
+++ b/docs/development/azure-vm-remote-ssh-internals.md
@@ -363,14 +363,15 @@ Workstation-scoped commands derive their default name from
 accept `-WorkstationName` as an optional override. The workstation name is not
 stored in an environment file.
 
-Request and package schemas roll forward together. Schema 2 rejects every
+Request and package schemas roll forward together. Schema 3 rejects every
 older request or package with regeneration instructions; there is no
 compatibility parser or legacy default. The request is canonical JSON wrapped
 in an ASCII-armored Base64 envelope. It contains no secret or private key and
 binds `intendedUse` to `connect-only` or `manage-environment`. It also binds the
-absolute destination-generated private-key path, which approval copies into the
-manifest and packaged local configuration without resolving the approver's
-home directory.
+absolute destination-generated private-key path and the configured approver
+public-key fingerprint. Approval copies the destination path into the manifest
+and packaged local configuration without resolving the approver's home
+directory.
 `ssh-keygen -Y sign` signs the payload with namespace
 `kravhantering-workstation-request`; approval verifies that signature against
 the embedded public key. This proves possession and detects corruption. It
@@ -385,17 +386,40 @@ the returned package. No receipt or summary artifact is created.
 
 Approval displays and honors the signed intended use. It rejects Tailscale
 before package or environment mutation because transfer supports public SSH
-only. A requested mode change requires a new signed request.
+only. Before prerequisites, VM state changes, package creation, or access
+mutation, it requires the public half of the managed VM SSH identity to match
+the approver fingerprint bound into the request. A requested mode change or
+approver-key rotation requires a new signed request.
 
 The response package is a ZIP payload encrypted with `age` to the destination
-workstation's SSH public key and emitted in the native ASCII-armored format.
+workstation's SSH public key. Approval signs the exact encrypted bytes with
+`ssh-keygen -Y sign` under namespace `kravhantering-workstation-package`, then
+emits the payload and detached SSH signature in one ASCII-armored `.kravpkg`
+envelope. The approval key is the managed `AZURE_DEV_VM_SSH_PRIVATE_KEY_PATH`
+identity; Git commit-signing identities are unrelated.
+
+The destination provisions the expected approval public-key file through a
+trusted channel and records its ignored local path in
+`AZURE_DEV_WORKSTATION_APPROVER_PUBLIC_KEY_PATH`. This configured key is the
+sole trust anchor. Extraction parses the schema-3 envelope, verifies its
+fingerprint and signature over the exact encrypted bytes, and only then invokes
+`age` or opens archive content. Envelope key material cannot replace the
+configured key. Missing configuration, legacy native `.age` input, malformed
+armor or signatures, signature or payload changes, and key mismatch fail
+before decryption and destination creation. Temporary encrypted and decrypted
+files are removed on every failure. Rotation invalidates pending requests and
+responses; provisioning the new public key and regenerating both artifacts is
+the recovery path.
+
 A compatible `age` 1.2.1 or later must be installed manually and available on
 `PATH`. The module validates the installed version but never downloads,
 installs, or manages the tool. Decryption auto-detects the armored input.
 
 The manifest binds the package to the request ID, workstation, intended use,
 environment, fixed public host, destination private-key path, destination
-public-key fingerprint, and 24-hour expiry. Entry names are an allowlist.
+public-key fingerprint, verified approver fingerprint, and 24-hour expiry. The
+manifest approver fingerprint must equal the identity that verified the outer
+envelope. Entry names are an allowlist.
 Extraction rejects rooted paths, backslashes, `..`, duplicates, undeclared
 entries, missing declared entries, oversized entries, unsupported schemas, and
 expired packages. It extracts only into a new user-selected directory. On

--- a/scripts/__tests__/test-powershell-integration.test.mjs
+++ b/scripts/__tests__/test-powershell-integration.test.mjs
@@ -27,6 +27,7 @@ describe('isolated PowerShell integration-test runner', () => {
   it('runs tests offline with a read-only repository and explicit opt-in', () => {
     const args = createPesterTestArgs({
       moduleCache: '/tmp/pester-modules',
+      passwdFile: '/tmp/pester-passwd',
       repositoryRoot: '/repo',
       resultDir: '/repo/test-results/pester',
     })
@@ -39,8 +40,13 @@ describe('isolated PowerShell integration-test runner', () => {
     expect(command).toContain(
       'source=/tmp/pester-modules,target=/pester-modules,readonly',
     )
+    expect(command).toContain(
+      'source=/tmp/pester-passwd,target=/etc/passwd,readonly',
+    )
     expect(command).toContain('KRAVHANTERING_PESTER_INTEGRATION=1')
     expect(command).toContain('PSModulePath=/pester-modules')
+    expect(command).toContain("'tests/powershell/Unit'")
+    expect(command).toContain("'tests/powershell/Integration'")
     expect(command).toContain('$configuration.Should.DisableV5 = $true')
     expect(command).not.toContain('/var/run/docker.sock')
     expect(command).not.toMatch(/(?:GH_TOKEN|COPILOT_GITHUB_TOKEN)=/u)

--- a/scripts/azure-dev/AzureDev.Config.psm1
+++ b/scripts/azure-dev/AzureDev.Config.psm1
@@ -161,7 +161,7 @@ function Test-AzureDevSshPublicKey {
     $expectedFieldCount = $null
     $expectedCurve = $null
     $expectedPointLength = $null
-    switch ($embeddedAlgorithm) {
+    switch -CaseSensitive ($embeddedAlgorithm) {
       'ssh-ed25519' {
         return $fieldLengths.Count -eq 1 -and $fieldLengths[0] -eq 32
       }

--- a/scripts/azure-dev/AzureDev.Config.psm1
+++ b/scripts/azure-dev/AzureDev.Config.psm1
@@ -105,7 +105,42 @@ function Test-AzureDevSshPublicKey {
 
   try {
     $decoded = [Convert]::FromBase64String($parts[1])
-    return $decoded.Length -gt 0
+    if ($decoded.Length -lt 8) {
+      return $false
+    }
+
+    $algorithmLength =
+      ([uint32]$decoded[0] -shl 24) -bor
+      ([uint32]$decoded[1] -shl 16) -bor
+      ([uint32]$decoded[2] -shl 8) -bor
+      [uint32]$decoded[3]
+    if (
+      $algorithmLength -eq 0 -or
+      $algorithmLength -gt ($decoded.Length - 8)
+    ) {
+      return $false
+    }
+
+    $strictUtf8 = [Text.UTF8Encoding]::new($false, $true)
+    $embeddedAlgorithm = $strictUtf8.GetString(
+      $decoded,
+      4,
+      [int]$algorithmLength
+    )
+    if ($embeddedAlgorithm -cne $parts[0]) {
+      return $false
+    }
+
+    $fieldOffset = 4 + [int]$algorithmLength
+    $fieldLength =
+      ([uint32]$decoded[$fieldOffset] -shl 24) -bor
+      ([uint32]$decoded[$fieldOffset + 1] -shl 16) -bor
+      ([uint32]$decoded[$fieldOffset + 2] -shl 8) -bor
+      [uint32]$decoded[$fieldOffset + 3]
+    return (
+      $fieldLength -gt 0 -and
+      $fieldLength -le ($decoded.Length - $fieldOffset - 4)
+    )
   } catch {
     return $false
   }

--- a/scripts/azure-dev/AzureDev.Config.psm1
+++ b/scripts/azure-dev/AzureDev.Config.psm1
@@ -131,15 +131,118 @@ function Test-AzureDevSshPublicKey {
       return $false
     }
 
-    $fieldOffset = 4 + [int]$algorithmLength
-    $fieldLength =
-      ([uint32]$decoded[$fieldOffset] -shl 24) -bor
-      ([uint32]$decoded[$fieldOffset + 1] -shl 16) -bor
-      ([uint32]$decoded[$fieldOffset + 2] -shl 8) -bor
-      [uint32]$decoded[$fieldOffset + 3]
+    $fieldOffsets = @()
+    $fieldLengths = @()
+    $offset = 4 + [int]$algorithmLength
+    while ($offset -lt $decoded.Length) {
+      if (($decoded.Length - $offset) -lt 4) {
+        return $false
+      }
+      $fieldLength =
+        ([uint32]$decoded[$offset] -shl 24) -bor
+        ([uint32]$decoded[$offset + 1] -shl 16) -bor
+        ([uint32]$decoded[$offset + 2] -shl 8) -bor
+        [uint32]$decoded[$offset + 3]
+      $offset += 4
+      if (
+        $fieldLength -eq 0 -or
+        $fieldLength -gt ($decoded.Length - $offset)
+      ) {
+        return $false
+      }
+      $fieldOffsets += $offset
+      $fieldLengths += [int]$fieldLength
+      $offset += [int]$fieldLength
+    }
+    if ($offset -ne $decoded.Length) {
+      return $false
+    }
+
+    $expectedFieldCount = $null
+    $expectedCurve = $null
+    $expectedPointLength = $null
+    switch ($embeddedAlgorithm) {
+      'ssh-ed25519' {
+        return $fieldLengths.Count -eq 1 -and $fieldLengths[0] -eq 32
+      }
+      'sk-ssh-ed25519@openssh.com' {
+        return (
+          $fieldLengths.Count -eq 2 -and
+          $fieldLengths[0] -eq 32 -and
+          $fieldLengths[1] -gt 0
+        )
+      }
+      'ssh-rsa' {
+        $expectedFieldCount = 2
+      }
+      'ssh-dss' {
+        $expectedFieldCount = 4
+      }
+      'ecdsa-sha2-nistp256' {
+        $expectedCurve = 'nistp256'
+        $expectedPointLength = 65
+      }
+      'ecdsa-sha2-nistp384' {
+        $expectedCurve = 'nistp384'
+        $expectedPointLength = 97
+      }
+      'ecdsa-sha2-nistp521' {
+        $expectedCurve = 'nistp521'
+        $expectedPointLength = 133
+      }
+      'sk-ecdsa-sha2-nistp256@openssh.com' {
+        if ($fieldLengths.Count -ne 3) {
+          return $false
+        }
+        $curve = $strictUtf8.GetString(
+          $decoded,
+          $fieldOffsets[0],
+          $fieldLengths[0]
+        )
+        return (
+          $curve -ceq 'nistp256' -and
+          $fieldLengths[1] -eq 65 -and
+          $decoded[$fieldOffsets[1]] -eq 4 -and
+          $fieldLengths[2] -gt 0
+        )
+      }
+      default {
+        return $false
+      }
+    }
+
+    if ($null -ne $expectedFieldCount) {
+      if ($fieldLengths.Count -ne $expectedFieldCount) {
+        return $false
+      }
+      for ($index = 0; $index -lt $fieldLengths.Count; $index += 1) {
+        $firstByte = $decoded[$fieldOffsets[$index]]
+        if (($firstByte -band 0x80) -ne 0) {
+          return $false
+        }
+        if (
+          $fieldLengths[$index] -gt 1 -and
+          $firstByte -eq 0 -and
+          ($decoded[$fieldOffsets[$index] + 1] -band 0x80) -eq 0
+        ) {
+          return $false
+        }
+      }
+      return $true
+    }
+
+    if ($fieldLengths.Count -ne 2) {
+      return $false
+    }
+    $curve = $strictUtf8.GetString(
+      $decoded,
+      $fieldOffsets[0],
+      $fieldLengths[0]
+    )
     return (
-      $fieldLength -gt 0 -and
-      $fieldLength -le ($decoded.Length - $fieldOffset - 4)
+      $curve -ceq $expectedCurve -and
+      $fieldLengths[1] -eq $expectedPointLength -and
+      $decoded[$fieldOffsets[1]] -eq 4
     )
   } catch {
     return $false

--- a/scripts/azure-dev/AzureDev.Config.psm1
+++ b/scripts/azure-dev/AzureDev.Config.psm1
@@ -20,6 +20,7 @@ function Get-AzureDevDefaultConfig {
     AZURE_DEV_TAILSCALE_AUTH_KEY = ''
     AZURE_DEV_TAILSCALE_TAILNET = ''
     AZURE_DEV_UBUNTU_PRO_TOKEN = ''
+    AZURE_DEV_WORKSTATION_APPROVER_PUBLIC_KEY_PATH = ''
     AZURE_DEV_VM_ENVIRONMENT_ID = 'personal'
     AZURE_DEV_VM_NAME_PREFIX = 'krav-dev'
     AZURE_DEV_VM_NAME = 'krav-dev-vm'
@@ -391,6 +392,16 @@ function Get-AzureDevConfig {
   $privateKeyPath = Resolve-AzureDevPath `
     -Path $values.AZURE_DEV_VM_SSH_PRIVATE_KEY_PATH
   $publicKeyPath = "$privateKeyPath.pub"
+  $workstationApproverPublicKeyPath = if (
+    [string]::IsNullOrWhiteSpace(
+      $values.AZURE_DEV_WORKSTATION_APPROVER_PUBLIC_KEY_PATH
+    )
+  ) {
+    ''
+  } else {
+    Resolve-AzureDevPath `
+      -Path $values.AZURE_DEV_WORKSTATION_APPROVER_PUBLIC_KEY_PATH
+  }
   $environmentId = $values.AZURE_DEV_VM_ENVIRONMENT_ID
 
   $config = [pscustomobject]@{
@@ -414,6 +425,7 @@ function Get-AzureDevConfig {
     SshHostName = $values.AZURE_DEV_VM_SSH_HOST_NAME
     SshPrivateKeyPath = $privateKeyPath
     SshPublicKeyPath = $publicKeyPath
+    WorkstationApproverPublicKeyPath = $workstationApproverPublicKeyPath
     AutoStopEnabled = ConvertTo-AzureDevBoolean `
       -Value $values.AZURE_DEV_VM_AUTO_STOP_ENABLED `
       -DefaultValue $true

--- a/scripts/azure-dev/AzureDev.Workstation.psm1
+++ b/scripts/azure-dev/AzureDev.Workstation.psm1
@@ -1660,6 +1660,7 @@ function Approve-AzureDevWorkstation {
   $rule = $null
   $ruleExisted = $false
   $keyAdded = $false
+  $packageCreated = $false
   try {
     if ($restoreStoppedState) {
       Start-AzureDevAzureVm -Context $Context
@@ -1672,6 +1673,7 @@ function Approve-AzureDevWorkstation {
       -Context $Context `
       -Request $request `
       -OutputPath $OutputPath
+    $packageCreated = $true
     $candidate = New-AzureDevSshAccessRuleSpec `
       -WorkstationName $request.workstation `
       -AccessName $request.access `
@@ -1710,7 +1712,7 @@ function Approve-AzureDevWorkstation {
         -RuleName $rule.name `
         -Confirm:$false
     }
-    if (Test-Path -LiteralPath $OutputPath) {
+    if ($packageCreated -and (Test-Path -LiteralPath $OutputPath)) {
       Remove-Item -LiteralPath $OutputPath -Force
     }
     throw

--- a/scripts/azure-dev/AzureDev.Workstation.psm1
+++ b/scripts/azure-dev/AzureDev.Workstation.psm1
@@ -817,6 +817,7 @@ function Test-AzureDevWorkstationPackageSignature {
   [CmdletBinding()]
   param(
     [Parameter(Mandatory = $true)]
+    [AllowEmptyCollection()]
     [byte[]]$Payload,
 
     [Parameter(Mandatory = $true)]
@@ -825,6 +826,10 @@ function Test-AzureDevWorkstationPackageSignature {
     [Parameter(Mandatory = $true)]
     [string]$PublicKey
   )
+
+  if ($Payload.Length -eq 0) {
+    return $false
+  }
 
   $temporaryDirectory = Join-Path `
     ([IO.Path]::GetTempPath()) `

--- a/scripts/azure-dev/AzureDev.Workstation.psm1
+++ b/scripts/azure-dev/AzureDev.Workstation.psm1
@@ -5,10 +5,13 @@ Set-StrictMode -Version Latest
 $script:RequestBegin = '-----BEGIN KRAVHANTERING WORKSTATION REQUEST-----'
 $script:RequestEnd = '-----END KRAVHANTERING WORKSTATION REQUEST-----'
 $script:RequestNamespace = 'kravhantering-workstation-request'
-$script:RequestSchema = 2
-$script:PackageSchema = 2
+$script:PackageBegin = '-----BEGIN KRAVHANTERING WORKSTATION PACKAGE-----'
+$script:PackageEnd = '-----END KRAVHANTERING WORKSTATION PACKAGE-----'
+$script:PackageNamespace = 'kravhantering-workstation-package'
+$script:RequestSchema = 3
+$script:PackageSchema = 3
 $script:MaximumPackageBytes = 50MB
-$script:MaximumArmoredPackageBytes = 70MB
+$script:MaximumArmoredPackageBytes = 95MB
 $script:MaximumEntryBytes = 5MB
 
 function Confirm-AzureDevWorkstationAction {
@@ -315,6 +318,26 @@ function Get-AzureDevPublicKeyFingerprint {
   return "SHA256:$encoded"
 }
 
+function Test-AzureDevPublicKeyFingerprint {
+  [CmdletBinding()]
+  param(
+    [AllowNull()]
+    [string]$Fingerprint
+  )
+
+  if ($Fingerprint -notmatch '^SHA256:[A-Za-z0-9+/]{43}$') {
+    return $false
+  }
+  try {
+    $digest = [Convert]::FromBase64String(
+      $Fingerprint.Substring(7) + '='
+    )
+    return $digest.Length -eq 32
+  } catch {
+    return $false
+  }
+}
+
 function Get-AzureDevVerificationCode {
   [CmdletBinding()]
   param(
@@ -332,6 +355,65 @@ function Get-AzureDevVerificationCode {
   }
   $hex = ([BitConverter]::ToString($digest) -replace '-', '').ToLowerInvariant()
   return "$($hex.Substring(0, 4))-$($hex.Substring(4, 4))-$($hex.Substring(8, 4))-$($hex.Substring(12, 4))"
+}
+
+function Get-AzureDevWorkstationApproverPublicKey {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [pscustomobject]$Context
+  )
+
+  $path = [string]$Context.Config.WorkstationApproverPublicKeyPath
+  if ([string]::IsNullOrWhiteSpace($path)) {
+    throw (
+      'AZURE_DEV_WORKSTATION_APPROVER_PUBLIC_KEY_PATH is required. ' +
+      'Provision the expected approver public key through a trusted channel.'
+    )
+  }
+  if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+    throw "The configured workstation approver public-key file was not found: $path"
+  }
+  try {
+    $publicKey = (Get-Content -LiteralPath $path -Raw -ErrorAction Stop).Trim()
+  } catch {
+    throw "The configured workstation approver public-key file could not be read: $path"
+  }
+  if (-not (Test-AzureDevSshPublicKey -Value $publicKey)) {
+    throw "The configured workstation approver public-key file is invalid: $path"
+  }
+  return $publicKey
+}
+
+function Get-AzureDevManagedWorkstationApprovalIdentity {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [pscustomobject]$Context
+  )
+
+  $privateKeyPath = [string]$Context.Config.SshPrivateKeyPath
+  $publicKeyPath = [string]$Context.Config.SshPublicKeyPath
+  if (
+    [string]::IsNullOrWhiteSpace($privateKeyPath) -or
+    -not (Test-Path -LiteralPath $privateKeyPath -PathType Leaf) -or
+    [string]::IsNullOrWhiteSpace($publicKeyPath) -or
+    -not (Test-Path -LiteralPath $publicKeyPath -PathType Leaf)
+  ) {
+    throw (
+      'The managed approval SSH identity is unavailable. Ensure the ' +
+      'configured VM SSH private key and matching public-key file exist.'
+    )
+  }
+  $publicKey = (Get-Content -LiteralPath $publicKeyPath -Raw).Trim()
+  if (-not (Test-AzureDevSshPublicKey -Value $publicKey)) {
+    throw "The managed approval SSH public-key file is invalid: $publicKeyPath"
+  }
+  return [PSCustomObject]@{
+    PrivateKeyPath = $privateKeyPath
+    PublicKey = $publicKey
+    Fingerprint = Get-AzureDevPublicKeyFingerprint -PublicKey $publicKey
+  }
 }
 
 function ConvertTo-AzureDevArmoredRequest {
@@ -367,6 +449,122 @@ function ConvertTo-AzureDevArmoredRequest {
     $lines
     $script:RequestEnd
   ) -join [Environment]::NewLine
+}
+
+function ConvertTo-AzureDevArmoredPackage {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [byte[]]$Payload,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Signature,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ApproverPublicKeyFingerprint
+  )
+
+  $envelope = [ordered]@{
+    schema = $script:PackageSchema
+    approverPublicKeyFingerprint = $ApproverPublicKeyFingerprint
+    payload = [Convert]::ToBase64String($Payload)
+    signature = [Convert]::ToBase64String(
+      [Text.Encoding]::ASCII.GetBytes($Signature)
+    )
+  } | ConvertTo-Json -Compress
+  $encoded = [Convert]::ToBase64String(
+    [Text.Encoding]::UTF8.GetBytes($envelope)
+  )
+  $lines = for ($offset = 0; $offset -lt $encoded.Length; $offset += 64) {
+    $length = [Math]::Min(64, $encoded.Length - $offset)
+    $encoded.Substring($offset, $length)
+  }
+  return @(
+    $script:PackageBegin
+    "Version: $script:PackageSchema"
+    ''
+    $lines
+    $script:PackageEnd
+  ) -join [Environment]::NewLine
+}
+
+function Read-AzureDevArmoredPackage {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  $malformedMessage = (
+    'The workstation package envelope or signature is malformed. Create and ' +
+    'approve a new request, then extract the regenerated .kravpkg response.'
+  )
+  try {
+    $armored = Get-Content -LiteralPath $Path -Raw
+    $pattern = (
+      '(?s)^' + [regex]::Escape($script:PackageBegin) +
+      '\s+Version:\s*(?<armorVersion>\d+)\s+' +
+      '(?<armorPayload>.+?)\s+' +
+      [regex]::Escape($script:PackageEnd) + '\s*$'
+    )
+    $armorMatch = [regex]::Match($armored, $pattern)
+    if (-not $armorMatch.Success) {
+      throw $malformedMessage
+    }
+    if (
+      [int]$armorMatch.Groups['armorVersion'].Value -ne
+      $script:PackageSchema
+    ) {
+      throw (
+        'The workstation package envelope schema is unsupported. Create and ' +
+        'approve a new request, then extract the regenerated .kravpkg response.'
+      )
+    }
+    $encoded = $armorMatch.Groups['armorPayload'].Value -replace '\s', ''
+    $envelopeJson = [Text.Encoding]::UTF8.GetString(
+      [Convert]::FromBase64String($encoded)
+    )
+    $envelope = $envelopeJson | ConvertFrom-Json
+    if ($envelope.schema -ne $script:PackageSchema) {
+      throw (
+        'The workstation package envelope schema is unsupported. Create and ' +
+        'approve a new request, then extract the regenerated .kravpkg response.'
+      )
+    }
+    $payload = [Convert]::FromBase64String([string]$envelope.payload)
+    $signature = [Text.Encoding]::ASCII.GetString(
+      [Convert]::FromBase64String([string]$envelope.signature)
+    )
+    if (
+      $payload.Length -eq 0 -or
+      -not (
+        Test-AzureDevPublicKeyFingerprint `
+          -Fingerprint ([string]$envelope.approverPublicKeyFingerprint)
+      ) -or
+      $signature -notmatch (
+        '(?s)^-----BEGIN SSH SIGNATURE-----\r?\n' +
+        '[A-Za-z0-9+/=\r\n]+\r?\n' +
+        '-----END SSH SIGNATURE-----\r?\n?$'
+      )
+    ) {
+      throw $malformedMessage
+    }
+    return [PSCustomObject]@{
+      Payload = $payload
+      Signature = $signature
+      ApproverPublicKeyFingerprint = [string](
+        $envelope.approverPublicKeyFingerprint
+      )
+    }
+  } catch {
+    if (
+      $_.Exception.Message -like
+      'The workstation package envelope schema is unsupported.*'
+    ) {
+      throw
+    }
+    throw $malformedMessage
+  }
 }
 
 function New-AzureDevWorkstationRequest {
@@ -406,6 +604,10 @@ function New-AzureDevWorkstationRequest {
     SshPrivateKeyPath = $keyPath
     SshPublicKeyPath = "$keyPath.pub"
   }
+  $approverPublicKey = Get-AzureDevWorkstationApproverPublicKey `
+    -Context $Context
+  $approverPublicKeyFingerprint = Get-AzureDevPublicKeyFingerprint `
+    -PublicKey $approverPublicKey
   New-AzureDevSshKey -Config $keyConfig
   $publicKey = Get-AzureDevSshPublicKey -Config $keyConfig
   $fingerprint = Get-AzureDevPublicKeyFingerprint -PublicKey $publicKey
@@ -431,6 +633,7 @@ function New-AzureDevWorkstationRequest {
     destinationPrivateKeyPath = $keyPath
     publicKey = $publicKey
     publicKeyFingerprint = $fingerprint
+    approverPublicKeyFingerprint = $approverPublicKeyFingerprint
   }
   $payload = $request | ConvertTo-Json -Compress
   $temporaryDirectory = Join-Path `
@@ -499,6 +702,7 @@ function New-AzureDevWorkstationRequest {
   Write-Host "Requested CIDR: $resolvedCidr"
   Write-Host "SSH private key: $keyPath"
   Write-Host "Public-key fingerprint: $fingerprint"
+  Write-Host "Expected approver fingerprint: $approverPublicKeyFingerprint"
   Write-Host "Verification code: $verificationCode"
   Write-Host (
     'Keep this shell open or temporarily save these details until approval ' +
@@ -609,6 +813,78 @@ function Test-AzureDevWorkstationRequestSignature {
   }
 }
 
+function Test-AzureDevWorkstationPackageSignature {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [byte[]]$Payload,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Signature,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PublicKey
+  )
+
+  $temporaryDirectory = Join-Path `
+    ([IO.Path]::GetTempPath()) `
+    "krav-package-verify-$([guid]::NewGuid().ToString('N'))"
+  try {
+    New-AzureDevPrivateDirectory -Path $temporaryDirectory
+    $allowedSignersPath = Join-Path $temporaryDirectory 'allowed_signers'
+    $signaturePath = Join-Path $temporaryDirectory 'package.sig'
+    Set-AzureDevPrivateContent `
+      -Path $allowedSignersPath `
+      -Value "approver $PublicKey" `
+      -Encoding ASCII
+    Set-AzureDevPrivateContent `
+      -Path $signaturePath `
+      -Value $Signature `
+      -Encoding ASCII
+
+    $start = [Diagnostics.ProcessStartInfo]::new()
+    $start.FileName = 'ssh-keygen'
+    foreach ($argument in @(
+        '-Y',
+        'verify',
+        '-f',
+        $allowedSignersPath,
+        '-I',
+        'approver',
+        '-n',
+        $script:PackageNamespace,
+        '-s',
+        $signaturePath
+      )) {
+      $start.ArgumentList.Add($argument)
+    }
+    $start.RedirectStandardInput = $true
+    $start.RedirectStandardOutput = $true
+    $start.RedirectStandardError = $true
+    $start.UseShellExecute = $false
+    $process = $null
+    try {
+      $process = [Diagnostics.Process]::Start($start)
+      $standardOutput = $process.StandardOutput.ReadToEndAsync()
+      $standardError = $process.StandardError.ReadToEndAsync()
+      $process.StandardInput.BaseStream.Write($Payload, 0, $Payload.Length)
+      $process.StandardInput.Close()
+      $process.WaitForExit()
+      $standardOutput.GetAwaiter().GetResult() | Out-Null
+      $standardError.GetAwaiter().GetResult() | Out-Null
+      return $process.ExitCode -eq 0
+    } finally {
+      if ($null -ne $process) {
+        $process.Dispose()
+      }
+    }
+  } finally {
+    if (Test-Path -LiteralPath $temporaryDirectory) {
+      Remove-Item -LiteralPath $temporaryDirectory -Recurse -Force
+    }
+  }
+}
+
 function Read-AzureDevWorkstationRequest {
   [CmdletBinding()]
   param(
@@ -666,6 +942,14 @@ function Read-AzureDevWorkstationRequest {
   }
   if ($request.intendedUse -notin @('connect-only', 'manage-environment')) {
     throw 'The workstation request intended use is invalid.'
+  }
+  if (
+    -not (
+      Test-AzureDevPublicKeyFingerprint `
+        -Fingerprint ([string]$request.approverPublicKeyFingerprint)
+    )
+  ) {
+    throw 'The workstation request approver public-key fingerprint is invalid.'
   }
   Assert-AzureDevDestinationPrivateKeyPath `
     -Path $request.destinationPrivateKeyPath `
@@ -981,6 +1265,20 @@ function New-AzureDevWorkstationPackage {
   if (-not $PSCmdlet.ShouldProcess($OutputPath, 'Create encrypted workstation package')) {
     return
   }
+  if (Test-Path -LiteralPath $OutputPath) {
+    throw "Package output already exists: $OutputPath"
+  }
+  $approvalIdentity = Get-AzureDevManagedWorkstationApprovalIdentity `
+    -Context $Context
+  if (
+    $approvalIdentity.Fingerprint -cne
+    $Request.approverPublicKeyFingerprint
+  ) {
+    throw (
+      'The managed approval identity does not match the approver identity ' +
+      'bound to the signed request.'
+    )
+  }
   $age = Get-AzureDevAgePath
   $temporaryDirectory = Join-Path `
     ([IO.Path]::GetTempPath()) `
@@ -1191,6 +1489,7 @@ function New-AzureDevWorkstationPackage {
       sshHostName = $hostName
       destinationPrivateKeyPath = $destinationPrivateKey
       publicKeyFingerprint = $Request.publicKeyFingerprint
+      approverPublicKeyFingerprint = $approvalIdentity.Fingerprint
       signingRequired = $signingRequired
       signingPublicKeyFingerprint = $signingPublicKeyFingerprint
       platform = $Request.platform
@@ -1205,16 +1504,61 @@ function New-AzureDevWorkstationPackage {
       -Encoding UTF8
     $zipPath = Join-Path $temporaryDirectory 'payload.zip'
     [IO.Compression.ZipFile]::CreateFromDirectory($payloadPath, $zipPath)
-    if (Test-Path -LiteralPath $OutputPath) {
-      throw "Package output already exists: $OutputPath"
-    }
+    $encryptedPayloadPath = Join-Path $temporaryDirectory 'payload.age'
     $encryptResult = Invoke-AzureDevNativeCommand `
       -FilePath $age `
-      -Arguments @('-a', '-R', $recipientPath, '-o', $OutputPath, $zipPath)
+      -Arguments @(
+        '-a',
+        '-R',
+        $recipientPath,
+        '-o',
+        $encryptedPayloadPath,
+        $zipPath
+      )
     if ($encryptResult.ExitCode -ne 0) {
       throw "Could not encrypt the workstation package: $($encryptResult.Text.Trim())"
     }
-    Set-AzureDevPrivatePermissions -Path $OutputPath
+    $signResult = Invoke-AzureDevNativeCommand `
+      -FilePath 'ssh-keygen' `
+      -Arguments @(
+        '-Y',
+        'sign',
+        '-f',
+        $approvalIdentity.PrivateKeyPath,
+        '-n',
+        $script:PackageNamespace,
+        $encryptedPayloadPath
+      )
+    if ($signResult.ExitCode -ne 0) {
+      throw "Could not sign the workstation package: $($signResult.Text.Trim())"
+    }
+    $signaturePath = "$encryptedPayloadPath.sig"
+    if (-not (Test-Path -LiteralPath $signaturePath -PathType Leaf)) {
+      throw 'Could not sign the workstation package: signature output is missing.'
+    }
+    $signature = Get-Content -LiteralPath $signaturePath -Raw
+    $encryptedPayload = [IO.File]::ReadAllBytes($encryptedPayloadPath)
+    if (
+      -not (
+        Test-AzureDevWorkstationPackageSignature `
+          -Payload $encryptedPayload `
+          -Signature $signature `
+          -PublicKey $approvalIdentity.PublicKey
+      )
+    ) {
+      throw (
+        'Could not verify the workstation package signature against the ' +
+        'managed approval identity.'
+      )
+    }
+    $armored = ConvertTo-AzureDevArmoredPackage `
+      -Payload $encryptedPayload `
+      -Signature $signature `
+      -ApproverPublicKeyFingerprint $approvalIdentity.Fingerprint
+    Set-AzureDevPrivateContent `
+      -Path $OutputPath `
+      -Value $armored `
+      -Encoding ASCII
   } finally {
     if (Test-Path -LiteralPath $temporaryDirectory) {
       Remove-Item -LiteralPath $temporaryDirectory -Recurse -Force
@@ -1240,12 +1584,28 @@ function Approve-AzureDevWorkstation {
       'Tailscale; no package or environment changes were made.'
     )
   }
+  $approvalIdentity = Get-AzureDevManagedWorkstationApprovalIdentity `
+    -Context $Context
+  if (
+    $approvalIdentity.Fingerprint -cne
+    $request.approverPublicKeyFingerprint
+  ) {
+    throw (
+      'The managed approval identity does not match the approver identity ' +
+      'bound to the signed request. Regenerate the request after provisioning ' +
+      'the expected approver public key.'
+    )
+  }
   Test-AzureDevPrerequisites -Context $Context
   Write-Host "Workstation: $($request.workstation)"
   Write-Host "Intended use: $($request.intendedUse)"
   Write-Host "Requested CIDR: $($request.cidr)"
   Write-Host "SSH private key: $($request.destinationPrivateKeyPath)"
   Write-Host "Public-key fingerprint: $($request.publicKeyFingerprint)"
+  Write-Host (
+    'Expected approver fingerprint: ' +
+    $request.approverPublicKeyFingerprint
+  )
   Write-Host (
     'Verification code: ' +
     (Get-AzureDevVerificationCode $request.publicKeyFingerprint)
@@ -1274,7 +1634,7 @@ function Approve-AzureDevWorkstation {
     New-AzureDevPrivateDirectory -Path $packageDirectory
     $OutputPath = Join-Path `
       $packageDirectory `
-      "$($request.workstation)-workstation-package.age"
+      "$($request.workstation)-workstation-package.kravpkg"
   }
 
   $initialPowerState = Get-AzureDevVmPowerState -Config $Context.Config
@@ -1357,7 +1717,8 @@ function Approve-AzureDevWorkstation {
   Write-Host "ASCII-armored encrypted response package: $OutputPath"
   Write-Host (
     'Transfer the file as an attachment or copy its complete ' +
-    'BEGIN/END AGE ENCRYPTED FILE block through a text-only channel.'
+    'BEGIN/END KRAVHANTERING WORKSTATION PACKAGE block through a text-only ' +
+    'channel.'
   )
   Write-Host (
     'After transfer, remove the encrypted source package: ' +
@@ -1800,12 +2161,35 @@ function Expand-AzureDevWorkstationPackage {
   ) {
     return
   }
+  $envelope = Read-AzureDevArmoredPackage -Path $PackagePath
+  $approverPublicKey = Get-AzureDevWorkstationApproverPublicKey `
+    -Context $Context
+  $approverPublicKeyFingerprint = Get-AzureDevPublicKeyFingerprint `
+    -PublicKey $approverPublicKey
+  if (
+    $envelope.ApproverPublicKeyFingerprint -cne
+    $approverPublicKeyFingerprint -or
+    -not (
+      Test-AzureDevWorkstationPackageSignature `
+        -Payload $envelope.Payload `
+        -Signature $envelope.Signature `
+        -PublicKey $approverPublicKey
+    )
+  ) {
+    throw (
+      'The workstation package approval signature is invalid for the ' +
+      'configured approver identity.'
+    )
+  }
   $age = Get-AzureDevAgePath
   $temporaryDirectory = Join-Path `
     ([IO.Path]::GetTempPath()) `
     "krav-extract-$([guid]::NewGuid().ToString('N'))"
   try {
     New-AzureDevPrivateDirectory -Path $temporaryDirectory
+    $encryptedPayloadPath = Join-Path $temporaryDirectory 'payload.age'
+    [IO.File]::WriteAllBytes($encryptedPayloadPath, $envelope.Payload)
+    Set-AzureDevPrivatePermissions -Path $encryptedPayloadPath
     $zipPath = Join-Path $temporaryDirectory 'payload.zip'
     $decryptArguments = New-Object System.Collections.Generic.List[string]
     $decryptArguments.Add('-d')
@@ -1818,7 +2202,7 @@ function Expand-AzureDevWorkstationPackage {
     }
     $decryptArguments.Add('-o')
     $decryptArguments.Add($zipPath)
-    $decryptArguments.Add($PackagePath)
+    $decryptArguments.Add($encryptedPayloadPath)
     $decryptResult = Invoke-AzureDevNativeCommand `
       -FilePath $age `
       -Arguments @($decryptArguments)
@@ -1856,6 +2240,15 @@ function Expand-AzureDevWorkstationPackage {
         $reader.Dispose()
       }
       Assert-AzureDevWorkstationPackageManifest -Manifest $manifest
+      if (
+        $manifest.approverPublicKeyFingerprint -cne
+        $approverPublicKeyFingerprint
+      ) {
+        throw (
+          'The workstation package manifest approver identity does not match ' +
+          'the verified package signature.'
+        )
+      }
       if (
         [datetimeoffset]$manifest.expiresAt -lt
         [datetimeoffset]::UtcNow

--- a/scripts/test-powershell-integration.mjs
+++ b/scripts/test-powershell-integration.mjs
@@ -63,6 +63,7 @@ export function createPesterInstallArgs({ moduleCache }) {
 
 export function createPesterTestArgs({
   moduleCache,
+  passwdFile,
   repositoryRoot,
   resultDir,
 }) {
@@ -70,7 +71,7 @@ export function createPesterTestArgs({
     "$ErrorActionPreference = 'Stop'",
     `Import-Module Pester -RequiredVersion ${PESTER_VERSION} -Force`,
     '$configuration = New-PesterConfiguration',
-    "$configuration.Run.Path = 'tests/powershell/Integration'",
+    "$configuration.Run.Path = @('tests/powershell/Unit', 'tests/powershell/Integration')",
     '$configuration.Run.Exit = $true',
     "$configuration.Output.Verbosity = 'Detailed'",
     "$configuration.Output.StackTraceVerbosity = 'Full'",
@@ -94,6 +95,7 @@ export function createPesterTestArgs({
     ...bindMount(repositoryRoot, '/workspace', true),
     ...bindMount(moduleCache, '/pester-modules', true),
     ...bindMount(resultDir, '/workspace/test-results/pester'),
+    ...(passwdFile ? bindMount(passwdFile, '/etc/passwd', true) : []),
     '--workdir',
     '/workspace',
     '--env',
@@ -139,6 +141,7 @@ export function runPowerShellIntegrationTests({
   try {
     const resolvedRepositoryRoot = fs.realpathSync(repositoryRoot)
     const moduleCache = path.join(temporaryRoot, 'modules')
+    const passwdFile = path.join(temporaryRoot, 'passwd')
     const resultDir = path.join(
       resolvedRepositoryRoot,
       'test-results',
@@ -146,6 +149,16 @@ export function runPowerShellIntegrationTests({
     )
     fs.mkdirSync(moduleCache, { recursive: true })
     fs.mkdirSync(resultDir, { recursive: true })
+    if (
+      typeof process.getuid === 'function' &&
+      typeof process.getgid === 'function'
+    ) {
+      fs.writeFileSync(
+        passwdFile,
+        `pester:x:${process.getuid()}:${process.getgid()}:Pester:/tmp/pester-home:/bin/sh\n`,
+        { mode: 0o600 },
+      )
+    }
     const resolvedResultDir = fs.realpathSync(resultDir)
     const relativeResultDir = path.relative(
       resolvedRepositoryRoot,
@@ -166,6 +179,7 @@ export function runPowerShellIntegrationTests({
     runDocker(
       createPesterTestArgs({
         moduleCache,
+        passwdFile: fs.existsSync(passwdFile) ? passwdFile : undefined,
         repositoryRoot: resolvedRepositoryRoot,
         resultDir: resolvedResultDir,
       }),

--- a/tests/powershell/Integration/AzureDev.Workstation.Transfer.TestHelper.ps1
+++ b/tests/powershell/Integration/AzureDev.Workstation.Transfer.TestHelper.ps1
@@ -21,9 +21,23 @@ function Invoke-TestAzureDevNativeCommand {
     $Arguments[0] -eq '-Y' -and
     $Arguments[1] -eq 'sign'
   ) {
+    $payloadBytes = [System.IO.File]::ReadAllBytes(
+      [string]$Arguments[-1]
+    )
+    $hasher = [System.Security.Cryptography.SHA256]::Create()
+    try {
+      $digest = $hasher.ComputeHash($payloadBytes)
+    } finally {
+      $hasher.Dispose()
+    }
+    $signatureBody = [System.Convert]::ToBase64String($digest)
     Set-Content `
       -LiteralPath "$([string]$Arguments[-1]).sig" `
-      -Value 'test signature'
+      -Value @(
+        '-----BEGIN SSH SIGNATURE-----'
+        $signatureBody
+        '-----END SSH SIGNATURE-----'
+      )
     return [PSCustomObject]@{ ExitCode = 0; Text = '' }
   }
   if ($FilePath -eq 'ssh-keyscan') {
@@ -46,8 +60,10 @@ function Invoke-TestAzureDevNativeCommand {
   }
 
   if ($Arguments[0] -eq '-d') {
+    $State.DecryptCalls += 1
     $packagePath = [string]$Arguments[-1]
-    $encryptedPackage = $State.EncryptedPackages[$packagePath]
+    $encryptedPackageId = Get-Content -LiteralPath $packagePath -Raw
+    $encryptedPackage = $State.EncryptedPackages[$encryptedPackageId]
     if ($null -eq $encryptedPackage) {
       return [PSCustomObject]@{
         ExitCode = 1
@@ -109,10 +125,35 @@ function Invoke-TestAzureDevNativeCommand {
   }
   $recipientPath = [string]$Arguments[$recipientOptionIndex + 1]
   $outputPath = [string]$Arguments[$outputOptionIndex + 1]
-  $State.EncryptedPackages[$outputPath] = [PSCustomObject]@{
+  $encryptedPackageId = "encrypted-$($State.EncryptedPackages.Count)"
+  $State.EncryptedPackages[$encryptedPackageId] = [PSCustomObject]@{
     Recipient = (Get-Content -LiteralPath $recipientPath -Raw).Trim()
     ZipBytes = [System.IO.File]::ReadAllBytes($zipPath)
   }
-  [System.IO.File]::WriteAllText($outputPath, 'encrypted')
+  $State.LastRecipient = (Get-Content -LiteralPath $recipientPath -Raw).Trim()
+  [System.IO.File]::WriteAllText($outputPath, $encryptedPackageId)
   return [PSCustomObject]@{ ExitCode = 0; Text = '' }
+}
+
+function Test-TestAzureDevWorkstationPackageSignature {
+  param(
+    [Parameter(Mandatory = $true)]
+    [byte[]]$Payload,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Signature
+  )
+
+  $hasher = [System.Security.Cryptography.SHA256]::Create()
+  try {
+    $digest = $hasher.ComputeHash($Payload)
+  } finally {
+    $hasher.Dispose()
+  }
+  $expectedBody = [System.Convert]::ToBase64String($digest)
+  return $Signature -match (
+    '(?s)^-----BEGIN SSH SIGNATURE-----\r?\n' +
+    [regex]::Escape($expectedBody) +
+    '\r?\n-----END SSH SIGNATURE-----\r?\n?$'
+  )
 }

--- a/tests/powershell/Integration/AzureDev.Workstation.Transfer.TestHelper.ps1
+++ b/tests/powershell/Integration/AzureDev.Workstation.Transfer.TestHelper.ps1
@@ -1,17 +1,17 @@
 function Invoke-TestAzureDevNativeCommand {
   param(
     [Parameter(Mandatory = $true)]
-    [string]$FilePath,
+    [System.String]$FilePath,
 
     [Parameter(Mandatory = $true)]
-    [object[]]$Arguments,
+    [System.Object[]]$Arguments,
 
     [Parameter(Mandatory = $true)]
-    [PSCustomObject]$State,
+    [System.Management.Automation.PSObject]$State,
 
-    [switch]$SupportSigning,
+    [System.Management.Automation.SwitchParameter]$SupportSigning,
 
-    [switch]$SupportChmod
+    [System.Management.Automation.SwitchParameter]$SupportChmod
   )
 
   if (
@@ -22,7 +22,7 @@ function Invoke-TestAzureDevNativeCommand {
     $Arguments[1] -eq 'sign'
   ) {
     $payloadBytes = [System.IO.File]::ReadAllBytes(
-      [string]$Arguments[-1]
+      [System.String]$Arguments[-1]
     )
     $hasher = [System.Security.Cryptography.SHA256]::Create()
     try {
@@ -32,28 +32,28 @@ function Invoke-TestAzureDevNativeCommand {
     }
     $signatureBody = [System.Convert]::ToBase64String($digest)
     Set-Content `
-      -LiteralPath "$([string]$Arguments[-1]).sig" `
+      -LiteralPath "$([System.String]$Arguments[-1]).sig" `
       -Value @(
         '-----BEGIN SSH SIGNATURE-----'
         $signatureBody
         '-----END SSH SIGNATURE-----'
       )
-    return [PSCustomObject]@{ ExitCode = 0; Text = '' }
+    return [System.Management.Automation.PSObject]@{ ExitCode = 0; Text = '' }
   }
   if ($FilePath -eq 'ssh-keyscan') {
-    return [PSCustomObject]@{
+    return [System.Management.Automation.PSObject]@{
       ExitCode = 0
-      Text = '203.0.113.10 ssh-ed25519 AAAAexpected'
+      Text = '203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
     }
   }
   if ($FilePath -eq 'ssh-keygen') {
-    return [PSCustomObject]@{
+    return [System.Management.Automation.PSObject]@{
       ExitCode = 0
       Text = '256 SHA256:host-key 203.0.113.10 (ED25519)'
     }
   }
   if ($SupportChmod -and $FilePath -eq 'chmod') {
-    return [PSCustomObject]@{ ExitCode = 0; Text = '' }
+    return [System.Management.Automation.PSObject]@{ ExitCode = 0; Text = '' }
   }
   if ($FilePath -ne 'age-test') {
     throw "Unexpected native command in transfer test: $FilePath"
@@ -61,11 +61,11 @@ function Invoke-TestAzureDevNativeCommand {
 
   if ($Arguments[0] -eq '-d') {
     $State.DecryptCalls += 1
-    $packagePath = [string]$Arguments[-1]
+    $packagePath = [System.String]$Arguments[-1]
     $encryptedPackageId = Get-Content -LiteralPath $packagePath -Raw
     $encryptedPackage = $State.EncryptedPackages[$encryptedPackageId]
     if ($null -eq $encryptedPackage) {
-      return [PSCustomObject]@{
+      return [System.Management.Automation.PSObject]@{
         ExitCode = 1
         Text = 'Unknown encrypted package.'
       }
@@ -76,7 +76,7 @@ function Invoke-TestAzureDevNativeCommand {
       if ($Arguments[$index] -ne '-i') {
         continue
       }
-      $identityPath = [string]$Arguments[$index + 1]
+      $identityPath = [System.String]$Arguments[$index + 1]
       if (
         $State.IdentityRecipients.ContainsKey($identityPath) -and
         $State.IdentityRecipients[$identityPath] -ceq
@@ -87,7 +87,7 @@ function Invoke-TestAzureDevNativeCommand {
       }
     }
     if (-not $recipientMatched) {
-      return [PSCustomObject]@{
+      return [System.Management.Automation.PSObject]@{
         ExitCode = 1
         Text = 'No identity matched the package recipient.'
       }
@@ -98,13 +98,13 @@ function Invoke-TestAzureDevNativeCommand {
       throw 'age-test invocation did not include the -o option.'
     }
     [System.IO.File]::WriteAllBytes(
-      [string]$Arguments[$outputOptionIndex + 1],
+      [System.String]$Arguments[$outputOptionIndex + 1],
       [System.Byte[]]$encryptedPackage.ZipBytes
     )
-    return [PSCustomObject]@{ ExitCode = 0; Text = '' }
+    return [System.Management.Automation.PSObject]@{ ExitCode = 0; Text = '' }
   }
 
-  $zipPath = [string]$Arguments[-1]
+  $zipPath = [System.String]$Arguments[-1]
   $captured = @{}
   $archive = [System.IO.Compression.ZipFile]::OpenRead($zipPath)
   foreach ($entry in $archive.Entries) {
@@ -123,25 +123,25 @@ function Invoke-TestAzureDevNativeCommand {
   if ($outputOptionIndex -lt 0) {
     throw 'age-test invocation did not include the -o option.'
   }
-  $recipientPath = [string]$Arguments[$recipientOptionIndex + 1]
-  $outputPath = [string]$Arguments[$outputOptionIndex + 1]
+  $recipientPath = [System.String]$Arguments[$recipientOptionIndex + 1]
+  $outputPath = [System.String]$Arguments[$outputOptionIndex + 1]
   $encryptedPackageId = "encrypted-$($State.EncryptedPackages.Count)"
-  $State.EncryptedPackages[$encryptedPackageId] = [PSCustomObject]@{
+  $State.EncryptedPackages[$encryptedPackageId] = [System.Management.Automation.PSObject]@{
     Recipient = (Get-Content -LiteralPath $recipientPath -Raw).Trim()
     ZipBytes = [System.IO.File]::ReadAllBytes($zipPath)
   }
   $State.LastRecipient = (Get-Content -LiteralPath $recipientPath -Raw).Trim()
   [System.IO.File]::WriteAllText($outputPath, $encryptedPackageId)
-  return [PSCustomObject]@{ ExitCode = 0; Text = '' }
+  return [System.Management.Automation.PSObject]@{ ExitCode = 0; Text = '' }
 }
 
 function Test-TestAzureDevWorkstationPackageSignature {
   param(
     [Parameter(Mandatory = $true)]
-    [byte[]]$Payload,
+    [System.Byte[]]$Payload,
 
     [Parameter(Mandatory = $true)]
-    [string]$Signature
+    [System.String]$Signature
   )
 
   $hasher = [System.Security.Cryptography.SHA256]::Create()
@@ -153,7 +153,7 @@ function Test-TestAzureDevWorkstationPackageSignature {
   $expectedBody = [System.Convert]::ToBase64String($digest)
   return $Signature -match (
     '(?s)^-----BEGIN SSH SIGNATURE-----\r?\n' +
-    [regex]::Escape($expectedBody) +
+    [System.Text.RegularExpressions.Regex]::Escape($expectedBody) +
     '\r?\n-----END SSH SIGNATURE-----\r?\n?$'
   )
 }

--- a/tests/powershell/Integration/Public/AzureDev.Workstation.Transfer.Tests.ps1
+++ b/tests/powershell/Integration/Public/AzureDev.Workstation.Transfer.Tests.ps1
@@ -26,6 +26,10 @@ Describe `
     )
     Import-Module (
       Join-Path $script:repositoryRoot `
+        'scripts/azure-dev/AzureDev.Config.psm1'
+    ) -Force -ErrorAction Stop
+    Import-Module (
+      Join-Path $script:repositoryRoot `
         'scripts/azure-dev/AzureDev.Azure.psm1'
     ) -Force -ErrorAction Stop
 
@@ -71,16 +75,65 @@ Describe `
       }
       return [PSCustomObject]@{
         Entries = $global:mockAzureDevWorkstationState.CapturedPackage
-        Recipient = $global:mockAzureDevWorkstationState.EncryptedPackages[
-          $OutputPath
-        ].Recipient
+        Recipient = $global:mockAzureDevWorkstationState.LastRecipient
       }
+    }
+
+    function Get-TestWorkstationPackageEnvelope {
+      param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+      )
+
+      $encoded = @(
+        Get-Content -LiteralPath $Path |
+          Where-Object {
+            -not [string]::IsNullOrWhiteSpace($_) -and
+            $_ -notmatch '^-----' -and
+            $_ -notmatch '^Version:'
+          }
+      ) -join ''
+      $json = [System.Text.Encoding]::UTF8.GetString(
+        [System.Convert]::FromBase64String($encoded)
+      )
+      return $json | ConvertFrom-Json
+    }
+
+    function Set-TestWorkstationPackageEnvelope {
+      param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [PSCustomObject]$Envelope
+      )
+
+      $json = $Envelope | ConvertTo-Json -Compress
+      $encoded = [System.Convert]::ToBase64String(
+        [System.Text.Encoding]::UTF8.GetBytes($json)
+      )
+      $lines = for (
+        $offset = 0
+        $offset -lt $encoded.Length
+        $offset += 64
+      ) {
+        $length = [System.Math]::Min(64, $encoded.Length - $offset)
+        $encoded.Substring($offset, $length)
+      }
+      Set-Content -LiteralPath $Path -Value @(
+        '-----BEGIN KRAVHANTERING WORKSTATION PACKAGE-----'
+        'Version: 3'
+        ''
+        $lines
+        '-----END KRAVHANTERING WORKSTATION PACKAGE-----'
+      )
     }
   }
 
   AfterAll {
     Get-Module $script:moduleName -All | Remove-Module -Force
     Get-Module 'AzureDev.Azure' -All | Remove-Module -Force
+    Get-Module 'AzureDev.Config' -All | Remove-Module -Force
     Remove-Variable `
       -Name mockAzureDevNativeCommandEmulator `
       -Scope Global `
@@ -121,6 +174,15 @@ Describe `
     $script:destinationKeyPath = Join-Path `
       $TestDrive `
       'kravhantering_azure_dev_destination_ed25519'
+    $script:approvalKeyPath = Join-Path `
+      $TestDrive `
+      'kravhantering_azure_dev_approval_ed25519'
+    Set-Content `
+      -LiteralPath $script:approvalKeyPath `
+      -Value 'managed approval private key'
+    Set-Content `
+      -LiteralPath "$script:approvalKeyPath.pub" `
+      -Value 'ssh-ed25519 AAAAapprover'
     $script:context = [PSCustomObject]@{
       Yes = $false
       Config = [PSCustomObject]@{
@@ -133,7 +195,10 @@ Describe `
         TenantId = '00000000-0000-0000-0000-000000000002'
         ResourceGroup = 'approver-rg'
         VmName = 'krav-dev-vm'
-        SshPrivateKeyPath = $script:destinationKeyPath
+        SshPrivateKeyPath = $script:approvalKeyPath
+        SshPublicKeyPath = "$script:approvalKeyPath.pub"
+        WorkstationApproverPublicKeyPath = "$script:approvalKeyPath.pub"
+        PackageIdentityPath = $script:destinationKeyPath
       }
     }
     $script:request = [PSCustomObject]@{
@@ -143,6 +208,11 @@ Describe `
       destinationPrivateKeyPath = $script:destinationKeyPath
       publicKey = 'ssh-ed25519 AAAAdestination'
       publicKeyFingerprint = 'SHA256:destination'
+      approverPublicKeyFingerprint = InModuleScope -ScriptBlock {
+        Set-StrictMode -Version 1.0
+        Get-AzureDevPublicKeyFingerprint `
+          -PublicKey 'ssh-ed25519 AAAAapprover'
+      }
       platform = 'linux'
       architecture = 'x64'
     }
@@ -150,8 +220,10 @@ Describe `
     $global:mockAzureDevWorkstationState = [PSCustomObject]@{
       ApprovedPrompts = @()
       CapturedPackage = $null
+      DecryptCalls = 0
       EncryptedPackages = @{}
       IdentityRecipients = @{}
+      LastRecipient = ''
     }
 
     Mock `
@@ -164,8 +236,17 @@ Describe `
     Mock -CommandName Get-AzureDevAccount
     Mock `
       -CommandName Get-AzureDevWorkstationPackageIdentityPaths `
-      -MockWith { @($Context.Config.SshPrivateKeyPath) }
+      -MockWith {
+        @($Context.Config.PackageIdentityPath)
+      }
     Mock -CommandName Write-AzureDevExtractedReadme
+    Mock `
+      -CommandName Test-AzureDevWorkstationPackageSignature `
+      -MockWith {
+        return Test-TestAzureDevWorkstationPackageSignature `
+          -Payload $Payload `
+          -Signature $Signature
+      }
     Mock `
       -CommandName Confirm-AzureDevWorkstationAction `
       -MockWith {
@@ -180,7 +261,8 @@ Describe `
         & $global:mockAzureDevNativeCommandEmulator `
           -FilePath $FilePath `
           -Arguments $Arguments `
-          -State $global:mockAzureDevWorkstationState
+          -State $global:mockAzureDevWorkstationState `
+          -SupportSigning
       }
   }
 
@@ -203,7 +285,7 @@ Describe `
 
   Context 'When process tokens have not been approved for transfer' {
     It 'Should exclude both process tokens' {
-      $packagePath = Join-Path $TestDrive 'default.age'
+      $packagePath = Join-Path $TestDrive 'default.kravpkg'
       $package = New-TestWorkstationPackage `
         -Context $script:context `
         -Request $script:request `
@@ -238,7 +320,7 @@ Describe `
 
   Context 'When one process token has been approved for transfer' {
     It 'Should include only <IncludedToken>' -ForEach $tokenCases {
-      $packagePath = Join-Path $TestDrive "$IncludedToken.age"
+      $packagePath = Join-Path $TestDrive "$IncludedToken.kravpkg"
       $package = New-TestWorkstationPackage `
         -Context $script:context `
         -Request $script:request `
@@ -258,7 +340,7 @@ Describe `
         'Include GH_TOKEN from the current process?',
         'Include COPILOT_GITHUB_TOKEN from the current process?'
       )
-      $packagePath = Join-Path $TestDrive 'both-tokens.age'
+      $packagePath = Join-Path $TestDrive 'both-tokens.kravpkg'
       $package = New-TestWorkstationPackage `
         -Context $script:context `
         -Request $script:request `
@@ -273,7 +355,10 @@ Describe `
         $TestDrive `
         'kravhantering_azure_dev_wrong_ed25519'
       $wrongContext = [PSCustomObject]@{
-        Config = [PSCustomObject]@{ SshPrivateKeyPath = $wrongKeyPath }
+        Config = [PSCustomObject]@{
+          PackageIdentityPath = $wrongKeyPath
+          WorkstationApproverPublicKeyPath = "$script:approvalKeyPath.pub"
+        }
       }
       $global:mockAzureDevWorkstationState.IdentityRecipients[$wrongKeyPath] =
         'ssh-ed25519 AAAAwrong'
@@ -313,5 +398,196 @@ Describe `
       (Test-Path -LiteralPath $destination) | Should-BeFalse
     }
 
+  }
+
+  Context 'When a response package is unsigned' {
+    It 'Should reject the legacy payload before decryption' {
+      $packagePath = Join-Path $TestDrive 'unsigned.age'
+      Set-Content `
+        -LiteralPath $packagePath `
+        -Value @(
+          '-----BEGIN AGE ENCRYPTED FILE-----'
+          'dW5zaWduZWQ='
+          '-----END AGE ENCRYPTED FILE-----'
+        )
+      $destination = Join-Path $TestDrive 'unsigned-extraction'
+
+      {
+        Expand-AzureDevWorkstationPackage `
+          -Context $script:context `
+          -PackagePath $packagePath `
+          -DestinationPath $destination `
+          -Confirm:$false
+      } | Should-Throw -ExceptionMessage (
+        'The workstation package envelope or signature is malformed.*'
+      )
+      $global:mockAzureDevWorkstationState.DecryptCalls |
+        Should-Be -Expected 0
+      Test-Path -LiteralPath $destination | Should-BeFalse
+    }
+
+    It 'Should reject an envelope with a missing signature before decryption' {
+      $packagePath = Join-Path $TestDrive 'missing-signature.kravpkg'
+      $null = New-TestWorkstationPackage `
+        -Context $script:context `
+        -Request $script:request `
+        -OutputPath $packagePath
+      $envelope = Get-TestWorkstationPackageEnvelope -Path $packagePath
+      $envelope.signature = ''
+      Set-TestWorkstationPackageEnvelope `
+        -Path $packagePath `
+        -Envelope $envelope
+      $destination = Join-Path $TestDrive 'missing-signature-extraction'
+
+      {
+        Expand-AzureDevWorkstationPackage `
+          -Context $script:context `
+          -PackagePath $packagePath `
+          -DestinationPath $destination `
+          -Confirm:$false
+      } | Should-Throw -ExceptionMessage (
+        'The workstation package envelope or signature is malformed.*'
+      )
+      $global:mockAzureDevWorkstationState.DecryptCalls |
+        Should-Be -Expected 0
+      Test-Path -LiteralPath $destination | Should-BeFalse
+    }
+  }
+
+  BeforeDiscovery {
+    $tamperCases = @(
+      @{ TamperTarget = 'payload' },
+      @{ TamperTarget = 'signature' }
+    )
+  }
+
+  Context 'When a signed response package is modified' {
+    It `
+      'Should reject the modified <TamperTarget> before decryption' `
+      -ForEach $tamperCases {
+      $packagePath = Join-Path $TestDrive "tampered-$TamperTarget.kravpkg"
+      $null = New-TestWorkstationPackage `
+        -Context $script:context `
+        -Request $script:request `
+        -OutputPath $packagePath
+      $envelope = Get-TestWorkstationPackageEnvelope -Path $packagePath
+      if ($TamperTarget -eq 'payload') {
+        $payload = [System.Convert]::FromBase64String($envelope.payload)
+        $payload[0] = $payload[0] -bxor 1
+        $envelope.payload = [System.Convert]::ToBase64String($payload)
+      } else {
+        $signature = [System.Text.Encoding]::ASCII.GetString(
+          [System.Convert]::FromBase64String($envelope.signature)
+        )
+        $signature = $signature -replace '(?m)^([A-Za-z0-9+/])', 'A'
+        $envelope.signature = [System.Convert]::ToBase64String(
+          [System.Text.Encoding]::ASCII.GetBytes($signature)
+        )
+      }
+      Set-TestWorkstationPackageEnvelope `
+        -Path $packagePath `
+        -Envelope $envelope
+      $destination = Join-Path $TestDrive "$TamperTarget-extraction"
+
+      {
+        Expand-AzureDevWorkstationPackage `
+          -Context $script:context `
+          -PackagePath $packagePath `
+          -DestinationPath $destination `
+          -Confirm:$false
+      } | Should-Throw -ExceptionMessage (
+        'The workstation package approval signature is invalid*'
+      )
+      $global:mockAzureDevWorkstationState.DecryptCalls |
+        Should-Be -Expected 0
+      Test-Path -LiteralPath $destination | Should-BeFalse
+    }
+  }
+
+  Context 'When the configured approver key has changed' {
+    It 'Should reject the pending package before decryption' {
+      $packagePath = Join-Path $TestDrive 'rotated-key.kravpkg'
+      $null = New-TestWorkstationPackage `
+        -Context $script:context `
+        -Request $script:request `
+        -OutputPath $packagePath
+      Set-Content `
+        -LiteralPath "$script:approvalKeyPath.pub" `
+        -Value 'ssh-ed25519 AAAArotated1'
+      $destination = Join-Path $TestDrive 'rotated-key-extraction'
+
+      {
+        Expand-AzureDevWorkstationPackage `
+          -Context $script:context `
+          -PackagePath $packagePath `
+          -DestinationPath $destination `
+          -Confirm:$false
+      } | Should-Throw -ExceptionMessage (
+        'The workstation package approval signature is invalid*'
+      )
+      $global:mockAzureDevWorkstationState.DecryptCalls |
+        Should-Be -Expected 0
+      Test-Path -LiteralPath $destination | Should-BeFalse
+    }
+  }
+
+  Context 'When the decrypted manifest names another approver' {
+    It 'Should reject the package and remove decrypted output' {
+      $packagePath = Join-Path $TestDrive 'manifest-mismatch.kravpkg'
+      $null = New-TestWorkstationPackage `
+        -Context $script:context `
+        -Request $script:request `
+        -OutputPath $packagePath
+      $envelope = Get-TestWorkstationPackageEnvelope -Path $packagePath
+      $encryptedPackageId = [System.Text.Encoding]::UTF8.GetString(
+        [System.Convert]::FromBase64String($envelope.payload)
+      )
+      $encryptedPackage =
+        $global:mockAzureDevWorkstationState.EncryptedPackages[
+          $encryptedPackageId
+        ]
+      $sourceZipPath = Join-Path $TestDrive 'manifest-source.zip'
+      $payloadDirectory = Join-Path $TestDrive 'manifest-payload'
+      $modifiedZipPath = Join-Path $TestDrive 'manifest-modified.zip'
+      [System.IO.File]::WriteAllBytes(
+        $sourceZipPath,
+        $encryptedPackage.ZipBytes
+      )
+      [System.IO.Compression.ZipFile]::ExtractToDirectory(
+        $sourceZipPath,
+        $payloadDirectory
+      )
+      $manifestPath = Join-Path $payloadDirectory 'manifest.json'
+      $manifest = Get-Content -LiteralPath $manifestPath -Raw |
+        ConvertFrom-Json
+      $manifest.approverPublicKeyFingerprint = 'SHA256:' + ('A' * 43)
+      Set-Content `
+        -LiteralPath $manifestPath `
+        -Value ($manifest | ConvertTo-Json -Depth 8)
+      [System.IO.Compression.ZipFile]::CreateFromDirectory(
+        $payloadDirectory,
+        $modifiedZipPath
+      )
+      $encryptedPackage.ZipBytes = [System.IO.File]::ReadAllBytes(
+        $modifiedZipPath
+      )
+      $global:mockAzureDevWorkstationState.IdentityRecipients[
+        $script:destinationKeyPath
+      ] = $script:request.publicKey
+      $destination = Join-Path $TestDrive 'manifest-mismatch-extraction'
+
+      {
+        Expand-AzureDevWorkstationPackage `
+          -Context $script:context `
+          -PackagePath $packagePath `
+          -DestinationPath $destination `
+          -Confirm:$false
+      } | Should-Throw -ExceptionMessage (
+        'The workstation package manifest approver identity does not match*'
+      )
+      $global:mockAzureDevWorkstationState.DecryptCalls |
+        Should-Be -Expected 1
+      Test-Path -LiteralPath $destination | Should-BeFalse
+    }
   }
 }

--- a/tests/powershell/Integration/Public/AzureDev.Workstation.Transfer.Tests.ps1
+++ b/tests/powershell/Integration/Public/AzureDev.Workstation.Transfer.Tests.ps1
@@ -43,19 +43,42 @@ Describe `
       Join-Path $script:repositoryRoot `
         'scripts/azure-dev/AzureDev.Workstation.psm1'
     ) -Force -ErrorAction Stop
+    $script:approverPublicKey = (
+      'ssh-ed25519 ' +
+      'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+    )
+    $script:destinationPublicKey = (
+      'ssh-ed25519 ' +
+      'AAAAC3NzaC1lZDI1NTE5AAAAIElRFe/K9qM55tJk2DRl7IsDK+cTTRpJ5nNiN2g358Z4'
+    )
+    $script:wrongPublicKey = (
+      'ssh-ed25519 ' +
+      'AAAAC3NzaC1lZDI1NTE5AAAAINkMOfviqHtQivWNECpHCBn472BbZ/TaFf75Zcxnabsy'
+    )
+    $script:signatureFixture = @'
+-----BEGIN SSH SIGNATURE-----
+U1NIU0lHAAAAAQAAADMAAAALc3NoLWVkMjU1MTkAAAAgrgZqTfFKgIMEFMP9QOw9rOTWw3
+dN8aJm225ldtOBB1oAAAAha3JhdmhhbnRlcmluZy13b3Jrc3RhdGlvbi1wYWNrYWdlAAAA
+AAAAAAZzaGE1MTIAAABTAAAAC3NzaC1lZDI1NTE5AAAAQKkNHeuk3RSlM/B/0PyBTeOYr3
+61eD3vvH1aJEXPI9KxaOJSf7X0Euiv34mtAidW4vXkAeqj7djkBIcZyGAxwwY=
+-----END SSH SIGNATURE-----
+'@
+    $script:packageSignatureVerifier = InModuleScope -ScriptBlock {
+      (Get-Command Test-AzureDevWorkstationPackageSignature).ScriptBlock
+    }
 
     function New-TestWorkstationPackage {
       param(
         [Parameter(Mandatory = $true)]
-        [PSCustomObject]$Context,
+        [System.Management.Automation.PSObject]$Context,
 
         [Parameter(Mandatory = $true)]
-        [PSCustomObject]$Request,
+        [System.Management.Automation.PSObject]$Request,
 
         [Parameter(Mandatory = $true)]
-        [string]$OutputPath,
+        [System.String]$OutputPath,
 
-        [string[]]$ApprovedPrompts = @()
+        [System.String[]]$ApprovedPrompts = @()
       )
 
       $global:mockAzureDevWorkstationState.ApprovedPrompts =
@@ -73,7 +96,7 @@ Describe `
           -OutputPath $OutputPath `
           -Confirm:$false
       }
-      return [PSCustomObject]@{
+      return [System.Management.Automation.PSObject]@{
         Entries = $global:mockAzureDevWorkstationState.CapturedPackage
         Recipient = $global:mockAzureDevWorkstationState.LastRecipient
       }
@@ -82,13 +105,13 @@ Describe `
     function Get-TestWorkstationPackageEnvelope {
       param(
         [Parameter(Mandatory = $true)]
-        [string]$Path
+        [System.String]$Path
       )
 
       $encoded = @(
         Get-Content -LiteralPath $Path |
           Where-Object {
-            -not [string]::IsNullOrWhiteSpace($_) -and
+            -not [System.String]::IsNullOrWhiteSpace($_) -and
             $_ -notmatch '^-----' -and
             $_ -notmatch '^Version:'
           }
@@ -102,10 +125,10 @@ Describe `
     function Set-TestWorkstationPackageEnvelope {
       param(
         [Parameter(Mandatory = $true)]
-        [string]$Path,
+        [System.String]$Path,
 
         [Parameter(Mandatory = $true)]
-        [PSCustomObject]$Envelope
+        [System.Management.Automation.PSObject]$Envelope
       )
 
       $json = $Envelope | ConvertTo-Json -Compress
@@ -182,10 +205,10 @@ Describe `
       -Value 'managed approval private key'
     Set-Content `
       -LiteralPath "$script:approvalKeyPath.pub" `
-      -Value 'ssh-ed25519 AAAAapprover'
-    $script:context = [PSCustomObject]@{
+      -Value $script:approverPublicKey
+    $script:context = [System.Management.Automation.PSObject]@{
       Yes = $false
-      Config = [PSCustomObject]@{
+      Config = [System.Management.Automation.PSObject]@{
         RepoRoot = $script:repoRoot
         EnvironmentFilePath = $script:primaryPath
         LocalEnvironmentFilePath = $script:localPath
@@ -201,23 +224,25 @@ Describe `
         PackageIdentityPath = $script:destinationKeyPath
       }
     }
-    $script:request = [PSCustomObject]@{
+    $script:request = [System.Management.Automation.PSObject]@{
       requestId = [System.Guid]::NewGuid().ToString()
       workstation = 'destination'
       intendedUse = 'connect-only'
       destinationPrivateKeyPath = $script:destinationKeyPath
-      publicKey = 'ssh-ed25519 AAAAdestination'
+      publicKey = $script:destinationPublicKey
       publicKeyFingerprint = 'SHA256:destination'
-      approverPublicKeyFingerprint = InModuleScope -ScriptBlock {
+      approverPublicKeyFingerprint = InModuleScope -Parameters @{
+        PublicKey = $script:approverPublicKey
+      } -ScriptBlock {
         Set-StrictMode -Version 1.0
         Get-AzureDevPublicKeyFingerprint `
-          -PublicKey 'ssh-ed25519 AAAAapprover'
+          -PublicKey $PublicKey
       }
       platform = 'linux'
       architecture = 'x64'
     }
 
-    $global:mockAzureDevWorkstationState = [PSCustomObject]@{
+    $global:mockAzureDevWorkstationState = [System.Management.Automation.PSObject]@{
       ApprovedPrompts = @()
       CapturedPackage = $null
       DecryptCalls = 0
@@ -281,6 +306,48 @@ Describe `
       $script:originalCopilotToken,
       'Process'
     )
+  }
+
+  Context 'When verifying an OpenSSH package signature' {
+    It 'Should accept the exact signed binary payload and namespace' {
+      $payload = [System.Convert]::FromBase64String(
+        'YWdlLWVuY3J5cHRlZC1wYXlsb2FkLWZpeHR1cmUK'
+      )
+
+      $verified = & $script:packageSignatureVerifier `
+        -Payload $payload `
+        -Signature $script:signatureFixture `
+        -PublicKey $script:approverPublicKey
+
+      $verified | Should-BeTrue
+    }
+
+    It 'Should reject a modified binary payload' {
+      $payload = [System.Convert]::FromBase64String(
+        'YWdlLWVuY3J5cHRlZC1wYXlsb2FkLWZpeHR1cmUK'
+      )
+      $payload[0] = $payload[0] -bxor 1
+
+      $verified = & $script:packageSignatureVerifier `
+        -Payload $payload `
+        -Signature $script:signatureFixture `
+        -PublicKey $script:approverPublicKey
+
+      $verified | Should-BeFalse
+    }
+
+    It 'Should reject a signature from a different trusted key' {
+      $payload = [System.Convert]::FromBase64String(
+        'YWdlLWVuY3J5cHRlZC1wYXlsb2FkLWZpeHR1cmUK'
+      )
+
+      $verified = & $script:packageSignatureVerifier `
+        -Payload $payload `
+        -Signature $script:signatureFixture `
+        -PublicKey $script:wrongPublicKey
+
+      $verified | Should-BeFalse
+    }
   }
 
   Context 'When process tokens have not been approved for transfer' {
@@ -354,14 +421,14 @@ Describe `
       $wrongKeyPath = Join-Path `
         $TestDrive `
         'kravhantering_azure_dev_wrong_ed25519'
-      $wrongContext = [PSCustomObject]@{
-        Config = [PSCustomObject]@{
+      $wrongContext = [System.Management.Automation.PSObject]@{
+        Config = [System.Management.Automation.PSObject]@{
           PackageIdentityPath = $wrongKeyPath
           WorkstationApproverPublicKeyPath = "$script:approvalKeyPath.pub"
         }
       }
       $global:mockAzureDevWorkstationState.IdentityRecipients[$wrongKeyPath] =
-        'ssh-ed25519 AAAAwrong'
+        $script:wrongPublicKey
       $wrongDestination = Join-Path $TestDrive 'wrong-key-extraction'
 
       {
@@ -513,7 +580,7 @@ Describe `
         -OutputPath $packagePath
       Set-Content `
         -LiteralPath "$script:approvalKeyPath.pub" `
-        -Value 'ssh-ed25519 AAAArotated1'
+        -Value $script:wrongPublicKey
       $destination = Join-Path $TestDrive 'rotated-key-extraction'
 
       {

--- a/tests/powershell/Integration/Public/AzureDev.Workstation.TransferBehavior.Tests.ps1
+++ b/tests/powershell/Integration/Public/AzureDev.Workstation.TransferBehavior.Tests.ps1
@@ -144,6 +144,10 @@ Describe `
           return '203.0.113.10'
         }
 
+        function script:Wait-AzureDevSsh {
+          return $true
+        }
+
         function script:Get-AzureDevAccount {
           return $null
         }
@@ -537,6 +541,55 @@ Describe `
       )
       Should-NotInvoke -CommandName Get-AzureDevVmPowerState -Scope It
       Should-NotInvoke -CommandName New-AzureDevWorkstationPackage -Scope It
+    }
+  }
+
+  Context 'When workstation package creation fails' {
+    BeforeEach {
+      Mock -CommandName Read-AzureDevWorkstationRequest -MockWith {
+        return [System.Management.Automation.PSObject]@{
+          workstation = 'destination'
+          intendedUse = 'connect-only'
+          cidr = '198.51.100.4/32'
+          destinationPrivateKeyPath = '/tmp/destination-key'
+          publicKey = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIElRFe/K9qM55tJk2DRl7IsDK+cTTRpJ5nNiN2g358Z4'
+          publicKeyFingerprint = 'SHA256:destination'
+          approverPublicKeyFingerprint = 'SHA256:' + ('A' * 43)
+        }
+      }
+      Mock -CommandName Test-AzureDevPrerequisites
+      Mock -CommandName Get-AzureDevVmPowerState -MockWith { 'running' }
+      Mock -CommandName New-AzureDevWorkstationPackage -MockWith {
+        throw 'Package generation failed.'
+      }
+    }
+
+    It 'Should preserve an existing output package' {
+      $context = New-TestTransferContext `
+        -RepositoryRoot (Join-Path $TestDrive 'generation-failure-repo') `
+        -DestinationKeyPath (Join-Path $TestDrive 'destination-key')
+      Initialize-TestWorkstationModule `
+        -DestinationHome (Join-Path $TestDrive 'generation-failure-home')
+      $outputPath = Join-Path $TestDrive 'existing.kravpkg'
+      Set-Content `
+        -LiteralPath $outputPath `
+        -Value 'existing package' `
+        -NoNewline
+
+      {
+        Approve-AzureDevWorkstation `
+          -Context $context `
+          -RequestPath (Join-Path $TestDrive 'request.kravreq') `
+          -OutputPath $outputPath `
+          -Confirm:$false
+      } | Should-Throw -ExceptionMessage 'Package generation failed.'
+      Get-Content -LiteralPath $outputPath -Raw |
+        Should-BeString -Expected 'existing package' -CaseSensitive
+      Should-Invoke `
+        -CommandName New-AzureDevWorkstationPackage `
+        -Exactly `
+        -Times 1 `
+        -Scope It
     }
   }
 

--- a/tests/powershell/Integration/Public/AzureDev.Workstation.TransferBehavior.Tests.ps1
+++ b/tests/powershell/Integration/Public/AzureDev.Workstation.TransferBehavior.Tests.ps1
@@ -50,7 +50,7 @@ Describe `
     function Initialize-TestWorkstationModule {
       param(
         [Parameter(Mandatory = $true)]
-        [string]$DestinationHome
+        [System.String]$DestinationHome
       )
 
       & $script:workstationModule {
@@ -64,7 +64,7 @@ Describe `
           -Name HOME `
           -Value $MockDestinationHome `
           -Scope Script
-        $script:mockAzureDevWorkstationState = [PSCustomObject]@{
+        $script:mockAzureDevWorkstationState = [System.Management.Automation.PSObject]@{
           CapturedPackage = $null
           DecryptCalls = 0
           EncryptedPackages = @{}
@@ -83,9 +83,9 @@ Describe `
         function script:ConvertTo-AzureDevAccessName {
           param(
             [Parameter(Mandatory = $true)]
-            [string]$Value,
+            [System.String]$Value,
 
-            [string]$Label
+            [System.String]$Label
           )
 
           return $Value
@@ -94,7 +94,7 @@ Describe `
         function script:Get-AzureDevWorkstationCidr {
           param(
             [Parameter(Mandatory = $true)]
-            [string]$Cidr
+            [System.String]$Cidr
           )
 
           return $Cidr
@@ -103,7 +103,7 @@ Describe `
         function script:New-AzureDevSshKey {
           param(
             [Parameter(Mandatory = $true)]
-            [PSCustomObject]$Config
+            [System.Management.Automation.PSObject]$Config
           )
 
           $null = New-Item `
@@ -117,19 +117,19 @@ Describe `
         function script:Get-AzureDevSshPublicKey {
           param(
             [Parameter(Mandatory = $true)]
-            [PSCustomObject]$Config
+            [System.Management.Automation.PSObject]$Config
           )
 
-          return 'ssh-ed25519 AAAAdestination'
+          return 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIElRFe/K9qM55tJk2DRl7IsDK+cTTRpJ5nNiN2g358Z4'
         }
 
         function script:Get-AzureDevPublicKeyFingerprint {
           param(
             [Parameter(Mandatory = $true)]
-            [string]$PublicKey
+            [System.String]$PublicKey
           )
 
-          if ($PublicKey -eq 'ssh-ed25519 AAAAapprover') {
+          if ($PublicKey -eq 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda') {
             return 'SHA256:' + ('A' * 43)
           }
           return 'SHA256:destination'
@@ -138,7 +138,7 @@ Describe `
         function script:Get-AzureDevPublicIpAddress {
           param(
             [Parameter(Mandatory = $true)]
-            [PSCustomObject]$Config
+            [System.Management.Automation.PSObject]$Config
           )
 
           return '203.0.113.10'
@@ -151,10 +151,10 @@ Describe `
         function script:Invoke-AzureDevNativeCommand {
           param(
             [Parameter(Mandatory = $true)]
-            [string]$FilePath,
+            [System.String]$FilePath,
 
             [Parameter(Mandatory = $true)]
-            [object[]]$Arguments
+            [System.Object[]]$Arguments
           )
 
           & $script:mockAzureDevNativeCommandEmulator `
@@ -168,13 +168,13 @@ Describe `
         function script:Test-AzureDevWorkstationPackageSignature {
           param(
             [Parameter(Mandatory = $true)]
-            [byte[]]$Payload,
+            [System.Byte[]]$Payload,
 
             [Parameter(Mandatory = $true)]
-            [string]$Signature,
+            [System.String]$Signature,
 
             [Parameter(Mandatory = $true)]
-            [string]$PublicKey
+            [System.String]$PublicKey
           )
 
           return & $script:mockAzureDevPackageSignatureVerifier `
@@ -190,10 +190,10 @@ Describe `
     function New-TestTransferContext {
       param(
         [Parameter(Mandatory = $true)]
-        [string]$RepositoryRoot,
+        [System.String]$RepositoryRoot,
 
         [Parameter(Mandatory = $true)]
-        [string]$DestinationKeyPath
+        [System.String]$DestinationKeyPath
       )
 
       $primaryPath = Join-Path `
@@ -214,7 +214,7 @@ Describe `
         'approver_ed25519.pub'
       Set-Content `
         -LiteralPath $approverPublicKeyPath `
-        -Value 'ssh-ed25519 AAAAapprover'
+        -Value 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
       $managedApprovalKeyPath = Join-Path `
         $RepositoryRoot `
         'managed_approval_ed25519'
@@ -223,12 +223,12 @@ Describe `
         -Value 'managed approval private key'
       Set-Content `
         -LiteralPath "$managedApprovalKeyPath.pub" `
-        -Value 'ssh-ed25519 AAAAapprover'
+        -Value 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
 
-      return [PSCustomObject]@{
+      return [System.Management.Automation.PSObject]@{
         Yes = $true
         StateDirectory = Join-Path $RepositoryRoot 'state'
-        Config = [PSCustomObject]@{
+        Config = [System.Management.Automation.PSObject]@{
           RepoRoot = $RepositoryRoot
           EnvironmentFilePath = $primaryPath
           LocalEnvironmentFilePath = $localPath
@@ -249,13 +249,13 @@ Describe `
     function Read-TestArmoredRequest {
       param(
         [Parameter(Mandatory = $true)]
-        [string]$Path
+        [System.String]$Path
       )
 
       $armorLines = @(
         Get-Content -LiteralPath $Path |
           Where-Object {
-            -not [string]::IsNullOrWhiteSpace($_) -and
+            -not [System.String]::IsNullOrWhiteSpace($_) -and
             $_ -notmatch '^-----' -and
             $_ -notmatch '^Version:'
           }
@@ -398,7 +398,7 @@ Describe `
         -DestinationKeyPath $destinationKeyPath
       Set-Content `
         -LiteralPath $context.Config.WorkstationApproverPublicKeyPath `
-        -Value 'not an SSH public key'
+        -Value 'ssh-ed25519 QQ=='
 
       {
         New-AzureDevWorkstationRequest `
@@ -446,12 +446,12 @@ Describe `
       $context = New-TestTransferContext `
         -RepositoryRoot (Join-Path $TestDrive 'package-repo') `
         -DestinationKeyPath $destinationKeyPath
-      $request = [PSCustomObject]@{
+      $request = [System.Management.Automation.PSObject]@{
         requestId = [System.Guid]::NewGuid().ToString('N')
         workstation = 'destination'
         intendedUse = $IntendedUse
         destinationPrivateKeyPath = $destinationKeyPath
-        publicKey = 'ssh-ed25519 AAAAdestination'
+        publicKey = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIElRFe/K9qM55tJk2DRl7IsDK+cTTRpJ5nNiN2g358Z4'
         publicKeyFingerprint = 'SHA256:destination'
         approverPublicKeyFingerprint = 'SHA256:' + ('A' * 43)
         platform = 'linux'
@@ -474,7 +474,7 @@ Describe `
       $mockCaptured = & $script:workstationModule {
         return $script:mockAzureDevWorkstationState.CapturedPackage
       }
-      $localContent = [string]$mockCaptured[
+      $localContent = [System.String]$mockCaptured[
         'files/.env.azure.development.local'
       ]
       $manifest = $mockCaptured['manifest.json'] | ConvertFrom-Json
@@ -506,12 +506,12 @@ Describe `
   Context 'When an approver identity does not match the signed request' {
     BeforeEach {
       Mock -CommandName Read-AzureDevWorkstationRequest -MockWith {
-        return [PSCustomObject]@{
+        return [System.Management.Automation.PSObject]@{
           workstation = 'destination'
           intendedUse = 'connect-only'
           cidr = '198.51.100.4/32'
           destinationPrivateKeyPath = '/tmp/destination-key'
-          publicKey = 'ssh-ed25519 AAAAdestination'
+          publicKey = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIElRFe/K9qM55tJk2DRl7IsDK+cTTRpJ5nNiN2g358Z4'
           publicKeyFingerprint = 'SHA256:destination'
           approverPublicKeyFingerprint = 'SHA256:different-approver'
         }
@@ -553,7 +553,7 @@ Describe `
         -Value '# existing local configuration'
       $readmeRoot = Join-Path $TestDrive 'readme'
       $null = New-Item -ItemType Directory -Path $readmeRoot -Force
-      $manifest = [PSCustomObject]@{
+      $manifest = [System.Management.Automation.PSObject]@{
         intendedUse = 'connect-only'
         destinationPrivateKeyPath = $destinationKeyPath
         workstation = 'destination'
@@ -635,12 +635,12 @@ Describe `
       $installedPath = Join-Path $TestDrive 'known_hosts'
       Set-Content `
         -LiteralPath $expectedPath `
-        -Value '203.0.113.10 ssh-ed25519 AAAAexpected'
+        -Value '203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
       Set-Content `
         -LiteralPath $installedPath `
         -Value @(
-          '203.0.113.10 ssh-ed25519 AAAAdifferent',
-          'unrelated.example ssh-rsa AAAAunrelated'
+          '203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINkMOfviqHtQivWNECpHCBn472BbZ/TaFf75Zcxnabsy',
+          'unrelated.example ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIElRFe/K9qM55tJk2DRl7IsDK+cTTRpJ5nNiN2g358Z4'
         )
 
       $mismatchAccepted = InModuleScope -Parameters @{
@@ -655,7 +655,11 @@ Describe `
       }
       Add-Content `
         -LiteralPath $installedPath `
-        -Value '203.0.113.10   ssh-ed25519   AAAAexpected comment'
+        -Value (
+          '203.0.113.10   ssh-ed25519   ' +
+          'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda ' +
+          'comment'
+        )
       $exactAccepted = InModuleScope -Parameters @{
         TestExpectedPath = $expectedPath
         TestInstalledPath = $installedPath
@@ -699,7 +703,7 @@ Describe `
         -Force
       Set-Content `
         -LiteralPath (Join-Path $packageReference 'vm-known-hosts') `
-        -Value '203.0.113.10 ssh-ed25519 AAAAexpected'
+        -Value '203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
       $manifest = [ordered]@{
         schema = 3
         kind = 'kravhantering-azure-dev-workstation-package'
@@ -716,7 +720,7 @@ Describe `
       Set-Content `
         -LiteralPath (Join-Path $packageRoot 'manifest.json') `
         -Value ($manifest | ConvertTo-Json)
-      $context = [PSCustomObject]@{ Config = $partialConfig }
+      $context = [System.Management.Automation.PSObject]@{ Config = $partialConfig }
       $script:readinessInformation = @()
 
       {
@@ -727,7 +731,7 @@ Describe `
       } | Should-Throw -ExceptionMessage 'Workstation access is not ready.'
       $readinessOutput = @(
         $script:readinessInformation |
-          ForEach-Object { [string]$_.MessageData }
+          ForEach-Object { [System.String]$_.MessageData }
       ) -join [System.Environment]::NewLine
 
       foreach ($expectedOutput in @(
@@ -761,10 +765,10 @@ Describe `
         -Value 'AZURE_DEV_VM_CONNECTIVITY_MODE=public-ssh'
       Set-Content `
         -LiteralPath (Join-Path $packageReference 'vm-known-hosts') `
-        -Value '203.0.113.10 ssh-ed25519 AAAAexpected'
+        -Value '203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
       Set-Content `
         -LiteralPath (Join-Path $readinessSsh 'known_hosts') `
-        -Value '203.0.113.10 ssh-ed25519 AAAAdifferent'
+        -Value '203.0.113.10 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINkMOfviqHtQivWNECpHCBn472BbZ/TaFf75Zcxnabsy'
       $manifest = [ordered]@{
         schema = 3
         kind = 'kravhantering-azure-dev-workstation-package'

--- a/tests/powershell/Integration/Public/AzureDev.Workstation.TransferBehavior.Tests.ps1
+++ b/tests/powershell/Integration/Public/AzureDev.Workstation.TransferBehavior.Tests.ps1
@@ -20,6 +20,8 @@ Describe `
       '../AzureDev.Workstation.Transfer.TestHelper.ps1')
     $script:mockAzureDevNativeCommandEmulator =
       (Get-Command Invoke-TestAzureDevNativeCommand).ScriptBlock
+    $script:mockAzureDevPackageSignatureVerifier =
+      (Get-Command Test-TestAzureDevWorkstationPackageSignature).ScriptBlock
     $script:moduleName = 'AzureDev.Workstation'
     $script:repositoryRoot = [System.IO.Path]::GetFullPath(
       (Join-Path $PSScriptRoot '../../../..')
@@ -52,7 +54,11 @@ Describe `
       )
 
       & $script:workstationModule {
-        param($MockDestinationHome, $MockNativeCommandEmulator)
+        param(
+          $MockDestinationHome,
+          $MockNativeCommandEmulator,
+          $MockPackageSignatureVerifier
+        )
 
         Set-Variable `
           -Name HOME `
@@ -60,11 +66,15 @@ Describe `
           -Scope Script
         $script:mockAzureDevWorkstationState = [PSCustomObject]@{
           CapturedPackage = $null
+          DecryptCalls = 0
           EncryptedPackages = @{}
           IdentityRecipients = @{}
+          LastRecipient = ''
         }
         $script:mockAzureDevNativeCommandEmulator =
           $MockNativeCommandEmulator
+        $script:mockAzureDevPackageSignatureVerifier =
+          $MockPackageSignatureVerifier
 
         function script:Get-AzureDevAgePath {
           return 'age-test'
@@ -119,6 +129,9 @@ Describe `
             [string]$PublicKey
           )
 
+          if ($PublicKey -eq 'ssh-ed25519 AAAAapprover') {
+            return 'SHA256:' + ('A' * 43)
+          }
           return 'SHA256:destination'
         }
 
@@ -151,7 +164,27 @@ Describe `
             -SupportSigning `
             -SupportChmod
         }
-      } $DestinationHome $script:mockAzureDevNativeCommandEmulator
+
+        function script:Test-AzureDevWorkstationPackageSignature {
+          param(
+            [Parameter(Mandatory = $true)]
+            [byte[]]$Payload,
+
+            [Parameter(Mandatory = $true)]
+            [string]$Signature,
+
+            [Parameter(Mandatory = $true)]
+            [string]$PublicKey
+          )
+
+          return & $script:mockAzureDevPackageSignatureVerifier `
+            -Payload $Payload `
+            -Signature $Signature
+        }
+      } `
+        $DestinationHome `
+        $script:mockAzureDevNativeCommandEmulator `
+        $script:mockAzureDevPackageSignatureVerifier
     }
 
     function New-TestTransferContext {
@@ -176,6 +209,21 @@ Describe `
       Set-Content `
         -LiteralPath $primaryPath `
         -Value 'AZURE_DEV_VM_RESOURCE_GROUP=approver-rg'
+      $approverPublicKeyPath = Join-Path `
+        $RepositoryRoot `
+        'approver_ed25519.pub'
+      Set-Content `
+        -LiteralPath $approverPublicKeyPath `
+        -Value 'ssh-ed25519 AAAAapprover'
+      $managedApprovalKeyPath = Join-Path `
+        $RepositoryRoot `
+        'managed_approval_ed25519'
+      Set-Content `
+        -LiteralPath $managedApprovalKeyPath `
+        -Value 'managed approval private key'
+      Set-Content `
+        -LiteralPath "$managedApprovalKeyPath.pub" `
+        -Value 'ssh-ed25519 AAAAapprover'
 
       return [PSCustomObject]@{
         Yes = $true
@@ -190,7 +238,10 @@ Describe `
           TenantId = '00000000-0000-0000-0000-000000000002'
           ResourceGroup = 'approver-rg'
           VmName = 'krav-dev-vm'
-          SshPrivateKeyPath = $DestinationKeyPath
+          SshPrivateKeyPath = $managedApprovalKeyPath
+          SshPublicKeyPath = "$managedApprovalKeyPath.pub"
+          WorkstationApproverPublicKeyPath = $approverPublicKeyPath
+          ConnectivityMode = 'public-ssh'
         }
       }
     }
@@ -278,6 +329,108 @@ Describe `
 
       $signedRequest.destinationPrivateKeyPath |
         Should-BeString -Expected $destinationKeyPath -CaseSensitive
+      $signedRequest.approverPublicKeyFingerprint |
+        Should-BeString `
+          -Expected ('SHA256:' + ('A' * 43)) `
+          -CaseSensitive
+    }
+
+    It 'Should reject a missing approver trust anchor before creating a key' {
+      $destinationHome = Join-Path $TestDrive 'missing-destination-home'
+      Initialize-TestWorkstationModule -DestinationHome $destinationHome
+      $destinationKeyPath = Join-Path `
+        (Join-Path $destinationHome '.ssh') `
+        'kravhantering_azure_dev_destination_ed25519'
+      $context = New-TestTransferContext `
+        -RepositoryRoot (Join-Path $TestDrive 'missing-approver-repo') `
+        -DestinationKeyPath $destinationKeyPath
+      $context.Config.WorkstationApproverPublicKeyPath = ''
+
+      {
+        New-AzureDevWorkstationRequest `
+          -Context $context `
+          -WorkstationName 'destination' `
+          -IntendedUse 'connect-only' `
+          -Cidr '198.51.100.4/32' `
+          -OutputPath (Join-Path $TestDrive 'missing-approver.kravreq') `
+          -Confirm:$false
+      } | Should-Throw -ExceptionMessage (
+        'AZURE_DEV_WORKSTATION_APPROVER_PUBLIC_KEY_PATH is required.*'
+      )
+      Test-Path -LiteralPath $destinationKeyPath | Should-BeFalse
+    }
+
+    It 'Should reject an unavailable approver key before creating a key' {
+      $destinationHome = Join-Path $TestDrive 'unavailable-approver-home'
+      Initialize-TestWorkstationModule -DestinationHome $destinationHome
+      $destinationKeyPath = Join-Path `
+        (Join-Path $destinationHome '.ssh') `
+        'kravhantering_azure_dev_destination_ed25519'
+      $context = New-TestTransferContext `
+        -RepositoryRoot (Join-Path $TestDrive 'unavailable-approver-repo') `
+        -DestinationKeyPath $destinationKeyPath
+      $context.Config.WorkstationApproverPublicKeyPath = Join-Path `
+        $TestDrive `
+        'unavailable-approver.pub'
+
+      {
+        New-AzureDevWorkstationRequest `
+          -Context $context `
+          -WorkstationName 'destination' `
+          -IntendedUse 'connect-only' `
+          -Cidr '198.51.100.4/32' `
+          -OutputPath (Join-Path $TestDrive 'unavailable.kravreq') `
+          -Confirm:$false
+      } | Should-Throw -ExceptionMessage (
+        'The configured workstation approver public-key file was not found:*'
+      )
+      Test-Path -LiteralPath $destinationKeyPath | Should-BeFalse
+    }
+
+    It 'Should reject an invalid approver key before creating a key' {
+      $destinationHome = Join-Path $TestDrive 'invalid-approver-home'
+      Initialize-TestWorkstationModule -DestinationHome $destinationHome
+      $destinationKeyPath = Join-Path `
+        (Join-Path $destinationHome '.ssh') `
+        'kravhantering_azure_dev_destination_ed25519'
+      $context = New-TestTransferContext `
+        -RepositoryRoot (Join-Path $TestDrive 'invalid-approver-repo') `
+        -DestinationKeyPath $destinationKeyPath
+      Set-Content `
+        -LiteralPath $context.Config.WorkstationApproverPublicKeyPath `
+        -Value 'not an SSH public key'
+
+      {
+        New-AzureDevWorkstationRequest `
+          -Context $context `
+          -WorkstationName 'destination' `
+          -IntendedUse 'connect-only' `
+          -Cidr '198.51.100.4/32' `
+          -OutputPath (Join-Path $TestDrive 'invalid.kravreq') `
+          -Confirm:$false
+      } | Should-Throw -ExceptionMessage (
+        'The configured workstation approver public-key file is invalid:*'
+      )
+      Test-Path -LiteralPath $destinationKeyPath | Should-BeFalse
+    }
+  }
+
+  Context 'When an unsigned legacy request is read' {
+    It 'Should require request and response regeneration' {
+      $requestPath = Join-Path $TestDrive 'legacy-schema-2.kravreq'
+      Set-Content -LiteralPath $requestPath -Value @(
+        '-----BEGIN KRAVHANTERING WORKSTATION REQUEST-----'
+        'Version: 2'
+        ''
+        'e30='
+        '-----END KRAVHANTERING WORKSTATION REQUEST-----'
+      )
+
+      {
+        Read-AzureDevWorkstationRequest -Path $requestPath
+      } | Should-Throw -ExceptionMessage (
+        'The workstation request schema is unsupported. Regenerate the request*'
+      )
     }
   }
 
@@ -300,10 +453,11 @@ Describe `
         destinationPrivateKeyPath = $destinationKeyPath
         publicKey = 'ssh-ed25519 AAAAdestination'
         publicKeyFingerprint = 'SHA256:destination'
+        approverPublicKeyFingerprint = 'SHA256:' + ('A' * 43)
         platform = 'linux'
         architecture = 'x64'
       }
-      $outputPath = Join-Path $TestDrive "$IntendedUse.age"
+      $outputPath = Join-Path $TestDrive "$IntendedUse.kravpkg"
 
       $null = InModuleScope -Parameters @{
         TestContext = $context
@@ -324,12 +478,21 @@ Describe `
         'files/.env.azure.development.local'
       ]
       $manifest = $mockCaptured['manifest.json'] | ConvertFrom-Json
+      $armoredPackage = Get-Content -LiteralPath $outputPath -Raw
 
       $localContent.Contains(
         "AZURE_DEV_VM_SSH_PRIVATE_KEY_PATH=$destinationKeyPath"
       ) | Should-BeTrue
       $manifest.destinationPrivateKeyPath |
         Should-BeString -Expected $destinationKeyPath -CaseSensitive
+      $manifest.approverPublicKeyFingerprint |
+        Should-BeString `
+          -Expected ('SHA256:' + ('A' * 43)) `
+          -CaseSensitive
+      $armoredPackage.StartsWith(
+        '-----BEGIN KRAVHANTERING WORKSTATION PACKAGE-----'
+      ) | Should-BeTrue
+      Test-Path -LiteralPath "$outputPath.sig" | Should-BeFalse
       if ($IntendedUse -eq 'connect-only') {
         @($mockCaptured.Keys) | Should-NotContainCollection `
           'files/.env.azure.development'
@@ -337,6 +500,43 @@ Describe `
         @($mockCaptured.Keys) | Should-ContainCollection `
           'files/.env.azure.development'
       }
+    }
+  }
+
+  Context 'When an approver identity does not match the signed request' {
+    BeforeEach {
+      Mock -CommandName Read-AzureDevWorkstationRequest -MockWith {
+        return [PSCustomObject]@{
+          workstation = 'destination'
+          intendedUse = 'connect-only'
+          cidr = '198.51.100.4/32'
+          destinationPrivateKeyPath = '/tmp/destination-key'
+          publicKey = 'ssh-ed25519 AAAAdestination'
+          publicKeyFingerprint = 'SHA256:destination'
+          approverPublicKeyFingerprint = 'SHA256:different-approver'
+        }
+      }
+      Mock -CommandName Test-AzureDevPrerequisites
+      Mock -CommandName Get-AzureDevVmPowerState -MockWith { 'running' }
+      Mock -CommandName New-AzureDevWorkstationPackage
+    }
+
+    It 'Should reject the request before package creation or access mutation' {
+      $context = New-TestTransferContext `
+        -RepositoryRoot (Join-Path $TestDrive 'mismatch-repo') `
+        -DestinationKeyPath (Join-Path $TestDrive 'destination-key')
+
+      {
+        Approve-AzureDevWorkstation `
+          -Context $context `
+          -RequestPath (Join-Path $TestDrive 'mismatch.kravreq') `
+          -OutputPath (Join-Path $TestDrive 'mismatch.kravpkg') `
+          -Confirm:$false
+      } | Should-Throw -ExceptionMessage (
+        'The managed approval identity does not match the approver identity*'
+      )
+      Should-NotInvoke -CommandName Get-AzureDevVmPowerState -Scope It
+      Should-NotInvoke -CommandName New-AzureDevWorkstationPackage -Scope It
     }
   }
 
@@ -501,7 +701,7 @@ Describe `
         -LiteralPath (Join-Path $packageReference 'vm-known-hosts') `
         -Value '203.0.113.10 ssh-ed25519 AAAAexpected'
       $manifest = [ordered]@{
-        schema = 2
+        schema = 3
         kind = 'kravhantering-azure-dev-workstation-package'
         workstation = 'destination'
         intendedUse = 'connect-only'
@@ -566,7 +766,7 @@ Describe `
         -LiteralPath (Join-Path $readinessSsh 'known_hosts') `
         -Value '203.0.113.10 ssh-ed25519 AAAAdifferent'
       $manifest = [ordered]@{
-        schema = 2
+        schema = 3
         kind = 'kravhantering-azure-dev-workstation-package'
         workstation = 'destination'
         intendedUse = 'connect-only'

--- a/tests/powershell/Integration/Public/AzureDev.Workstation.TransferBehavior.Tests.ps1
+++ b/tests/powershell/Integration/Public/AzureDev.Workstation.TransferBehavior.Tests.ps1
@@ -398,7 +398,7 @@ Describe `
         -DestinationKeyPath $destinationKeyPath
       Set-Content `
         -LiteralPath $context.Config.WorkstationApproverPublicKeyPath `
-        -Value 'ssh-ed25519 QQ=='
+        -Value 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAAUE='
 
       {
         New-AzureDevWorkstationRequest `

--- a/tests/powershell/Integration/Public/Test-AzureDevSshPublicKey.Tests.ps1
+++ b/tests/powershell/Integration/Public/Test-AzureDevSshPublicKey.Tests.ps1
@@ -2,7 +2,18 @@
 
 Set-StrictMode -Version Latest
 
-Describe 'Test-AzureDevSshPublicKey' -Tag 'Unit' {
+BeforeDiscovery {
+  $script:integrationEnabled =
+    [System.Environment]::GetEnvironmentVariable(
+      'KRAVHANTERING_PESTER_INTEGRATION',
+      'Process'
+    ) -ceq '1'
+}
+
+Describe `
+  'Test-AzureDevSshPublicKey' `
+  -Tag 'Integration' `
+  -Skip:(-not $script:integrationEnabled) {
   BeforeAll {
     $script:moduleName = 'AzureDev.Config'
     $script:repositoryRoot = [System.IO.Path]::GetFullPath(
@@ -17,8 +28,8 @@ Describe 'Test-AzureDevSshPublicKey' -Tag 'Unit' {
     Get-Module $script:moduleName -All | Remove-Module -Force
   }
 
-  Context 'When validating an SSH public key wire blob' {
-    It 'Should accept a structurally valid key' {
+  Context 'When the exported validator receives complete key text' {
+    It 'Should accept a complete Ed25519 public key' {
       $publicKey = (
         'ssh-ed25519 ' +
         'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
@@ -29,26 +40,9 @@ Describe 'Test-AzureDevSshPublicKey' -Tag 'Unit' {
       $result | Should-BeTrue
     }
 
-    It 'Should reject Base64 without an SSH wire-format key' {
-      $result = Test-AzureDevSshPublicKey -Value 'ssh-ed25519 QQ=='
-
-      $result | Should-BeFalse
-    }
-
-    It 'Should reject an Ed25519 blob with the wrong key size' {
+    It 'Should reject an Ed25519 blob with an unusable key field' {
       $result = Test-AzureDevSshPublicKey `
         -Value 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAAUE='
-
-      $result | Should-BeFalse
-    }
-
-    It 'Should reject a blob whose embedded algorithm does not match' {
-      $rsaLabelWithEd25519Blob = (
-        'ssh-rsa ' +
-        'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
-      )
-
-      $result = Test-AzureDevSshPublicKey -Value $rsaLabelWithEd25519Blob
 
       $result | Should-BeFalse
     }

--- a/tests/powershell/Unit/Private/ConvertTo-AzureDevArmoredPackage.Tests.ps1
+++ b/tests/powershell/Unit/Private/ConvertTo-AzureDevArmoredPackage.Tests.ps1
@@ -1,0 +1,52 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'ConvertTo-AzureDevArmoredPackage' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Workstation'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Config.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'InModuleScope:ModuleName' = $script:moduleName
+    }
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Workstation.psm1'
+    ) -Force -ErrorAction Stop
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Config' -All | Remove-Module -Force
+  }
+
+  Context 'When armoring a signed package' {
+    It 'Should emit one schema 3 ASCII envelope' {
+      $result = InModuleScope -ScriptBlock {
+        Set-StrictMode -Version 1.0
+        ConvertTo-AzureDevArmoredPackage `
+          -Payload ([System.Text.Encoding]::ASCII.GetBytes('ciphertext')) `
+          -Signature @'
+-----BEGIN SSH SIGNATURE-----
+U0lHTkFUVVJF
+-----END SSH SIGNATURE-----
+'@ `
+          -ApproverPublicKeyFingerprint (
+            'SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+          )
+      }
+
+      $result.StartsWith(
+        '-----BEGIN KRAVHANTERING WORKSTATION PACKAGE-----'
+      ) | Should-BeTrue
+      $result.Contains('Version: 3') | Should-BeTrue
+      $result.EndsWith(
+        '-----END KRAVHANTERING WORKSTATION PACKAGE-----'
+      ) | Should-BeTrue
+    }
+  }
+}

--- a/tests/powershell/Unit/Private/Get-AzureDevManagedWorkstationApprovalIdentity.Tests.ps1
+++ b/tests/powershell/Unit/Private/Get-AzureDevManagedWorkstationApprovalIdentity.Tests.ps1
@@ -1,0 +1,55 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Get-AzureDevManagedWorkstationApprovalIdentity' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Workstation'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Config.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'InModuleScope:ModuleName' = $script:moduleName
+    }
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Workstation.psm1'
+    ) -Force -ErrorAction Stop
+    $script:publicKey = (
+      'ssh-ed25519 ' +
+      'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+    )
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Config' -All | Remove-Module -Force
+  }
+
+  Context 'When the managed key pair exists' {
+    It 'Should return its public key and fingerprint' {
+      $privateKeyPath = Join-Path $TestDrive 'approver'
+      $publicKeyPath = "$privateKeyPath.pub"
+      Set-Content -LiteralPath $privateKeyPath -Value 'private fixture'
+      Set-Content -LiteralPath $publicKeyPath -Value $script:publicKey
+      $context = [System.Management.Automation.PSObject]@{
+        Config = [System.Management.Automation.PSObject]@{
+          SshPrivateKeyPath = $privateKeyPath
+          SshPublicKeyPath = $publicKeyPath
+        }
+      }
+
+      $result = InModuleScope -Parameters @{ Context = $context } -ScriptBlock {
+        Set-StrictMode -Version 1.0
+        Get-AzureDevManagedWorkstationApprovalIdentity -Context $Context
+      }
+
+      $result.PublicKey |
+        Should-BeString -Expected $script:publicKey -CaseSensitive
+      ($result.Fingerprint -match '^SHA256:[A-Za-z0-9+/]{43}$') |
+        Should-BeTrue
+    }
+  }
+}

--- a/tests/powershell/Unit/Private/Get-AzureDevManagedWorkstationApprovalIdentity.Tests.ps1
+++ b/tests/powershell/Unit/Private/Get-AzureDevManagedWorkstationApprovalIdentity.Tests.ps1
@@ -48,8 +48,10 @@ Describe 'Get-AzureDevManagedWorkstationApprovalIdentity' -Tag 'Unit' {
 
       $result.PublicKey |
         Should-BeString -Expected $script:publicKey -CaseSensitive
-      ($result.Fingerprint -match '^SHA256:[A-Za-z0-9+/]{43}$') |
-        Should-BeTrue
+      $result.Fingerprint |
+        Should-BeString `
+          -Expected 'SHA256:H8XbXBwELOKEATfqIAkkv78p9jn9xCtjmv6WPECWYw0' `
+          -CaseSensitive
     }
   }
 }

--- a/tests/powershell/Unit/Private/Get-AzureDevWorkstationApproverPublicKey.Tests.ps1
+++ b/tests/powershell/Unit/Private/Get-AzureDevWorkstationApproverPublicKey.Tests.ps1
@@ -1,0 +1,68 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Get-AzureDevWorkstationApproverPublicKey' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Workstation'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Config.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'InModuleScope:ModuleName' = $script:moduleName
+    }
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Workstation.psm1'
+    ) -Force -ErrorAction Stop
+    $script:publicKey = (
+      'ssh-ed25519 ' +
+      'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+    )
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Config' -All | Remove-Module -Force
+  }
+
+  Context 'When the configured trust anchor exists' {
+    It 'Should return the validated public key' {
+      $path = Join-Path $TestDrive 'approver.pub'
+      Set-Content -LiteralPath $path -Value $script:publicKey
+      $context = [System.Management.Automation.PSObject]@{
+        Config = [System.Management.Automation.PSObject]@{
+          WorkstationApproverPublicKeyPath = $path
+        }
+      }
+
+      $result = InModuleScope -Parameters @{ Context = $context } -ScriptBlock {
+        Set-StrictMode -Version 1.0
+        Get-AzureDevWorkstationApproverPublicKey -Context $Context
+      }
+
+      $result | Should-BeString -Expected $script:publicKey -CaseSensitive
+    }
+  }
+
+  Context 'When the configured trust anchor is malformed' {
+    It 'Should reject it' {
+      $path = Join-Path $TestDrive 'malformed.pub'
+      Set-Content -LiteralPath $path -Value 'ssh-ed25519 QQ=='
+      $context = [System.Management.Automation.PSObject]@{
+        Config = [System.Management.Automation.PSObject]@{
+          WorkstationApproverPublicKeyPath = $path
+        }
+      }
+
+      {
+        InModuleScope -Parameters @{ Context = $context } -ScriptBlock {
+          Set-StrictMode -Version 1.0
+          Get-AzureDevWorkstationApproverPublicKey -Context $Context
+        }
+      } | Should-Throw -ExceptionMessage '*public-key file is invalid*'
+    }
+  }
+}

--- a/tests/powershell/Unit/Private/Read-AzureDevArmoredPackage.Tests.ps1
+++ b/tests/powershell/Unit/Private/Read-AzureDevArmoredPackage.Tests.ps1
@@ -1,0 +1,40 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Read-AzureDevArmoredPackage' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Workstation'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Config.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'InModuleScope:ModuleName' = $script:moduleName
+    }
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Workstation.psm1'
+    ) -Force -ErrorAction Stop
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Config' -All | Remove-Module -Force
+  }
+
+  Context 'When the armor is malformed' {
+    It 'Should reject it with regeneration guidance' {
+      $path = Join-Path $TestDrive 'malformed.kravpkg'
+      Set-Content -LiteralPath $path -Value 'not an envelope'
+
+      {
+        InModuleScope -Parameters @{ Path = $path } -ScriptBlock {
+          Set-StrictMode -Version 1.0
+          Read-AzureDevArmoredPackage -Path $Path
+        }
+      } | Should-Throw -ExceptionMessage '*regenerated .kravpkg response*'
+    }
+  }
+}

--- a/tests/powershell/Unit/Private/Test-AzureDevPublicKeyFingerprint.Tests.ps1
+++ b/tests/powershell/Unit/Private/Test-AzureDevPublicKeyFingerprint.Tests.ps1
@@ -1,0 +1,47 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Test-AzureDevPublicKeyFingerprint' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Workstation'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Config.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'InModuleScope:ModuleName' = $script:moduleName
+    }
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Workstation.psm1'
+    ) -Force -ErrorAction Stop
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Config' -All | Remove-Module -Force
+  }
+
+  Context 'When validating a fingerprint' {
+    It 'Should accept a canonical SHA-256 SSH fingerprint' {
+      $result = InModuleScope -ScriptBlock {
+        Set-StrictMode -Version 1.0
+        Test-AzureDevPublicKeyFingerprint `
+          -Fingerprint 'SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+      }
+
+      $result | Should-BeTrue
+    }
+
+    It 'Should reject a truncated fingerprint' {
+      $result = InModuleScope -ScriptBlock {
+        Set-StrictMode -Version 1.0
+        Test-AzureDevPublicKeyFingerprint -Fingerprint 'SHA256:short'
+      }
+
+      $result | Should-BeFalse
+    }
+  }
+}

--- a/tests/powershell/Unit/Private/Test-AzureDevWorkstationPackageSignature.Tests.ps1
+++ b/tests/powershell/Unit/Private/Test-AzureDevWorkstationPackageSignature.Tests.ps1
@@ -1,0 +1,40 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Test-AzureDevWorkstationPackageSignature' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Workstation'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Config.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'InModuleScope:ModuleName' = $script:moduleName
+    }
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Workstation.psm1'
+    ) -Force -ErrorAction Stop
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Config' -All | Remove-Module -Force
+  }
+
+  Context 'When the encrypted payload is empty' {
+    It 'Should reject it before starting native verification' {
+      $result = InModuleScope -ScriptBlock {
+        Set-StrictMode -Version 1.0
+        Test-AzureDevWorkstationPackageSignature `
+          -Payload ([System.Byte[]]@()) `
+          -Signature 'unused' `
+          -PublicKey 'unused'
+      }
+
+      $result | Should-BeFalse
+    }
+  }
+}

--- a/tests/powershell/Unit/Public/Test-AzureDevSshPublicKey.Tests.ps1
+++ b/tests/powershell/Unit/Public/Test-AzureDevSshPublicKey.Tests.ps1
@@ -85,6 +85,18 @@ Describe 'Test-AzureDevSshPublicKey' -Tag 'Unit' {
       $result | Should-BeFalse
     }
 
+    It 'Should reject a noncanonical algorithm name casing' {
+      $publicKey = New-TestSshPublicKey `
+        -Algorithm 'SSH-ED25519' `
+        -EncodedFields @(
+          [System.Convert]::ToBase64String([System.Byte[]]::new(32))
+        )
+
+      $result = Test-AzureDevSshPublicKey -Value $publicKey
+
+      $result | Should-BeFalse
+    }
+
     It 'Should accept supported RSA and DSS MPINT structures' {
       $rsa = New-TestSshPublicKey `
         -Algorithm 'ssh-rsa' `

--- a/tests/powershell/Unit/Public/Test-AzureDevSshPublicKey.Tests.ps1
+++ b/tests/powershell/Unit/Public/Test-AzureDevSshPublicKey.Tests.ps1
@@ -1,0 +1,49 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Test-AzureDevSshPublicKey' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Config'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Config.psm1'
+    ) -Force -ErrorAction Stop
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+  }
+
+  Context 'When validating an SSH public key wire blob' {
+    It 'Should accept a structurally valid key' {
+      $publicKey = (
+        'ssh-ed25519 ' +
+        'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+      )
+
+      $result = Test-AzureDevSshPublicKey -Value $publicKey
+
+      $result | Should-BeTrue
+    }
+
+    It 'Should reject Base64 without an SSH wire-format key' {
+      $result = Test-AzureDevSshPublicKey -Value 'ssh-ed25519 QQ=='
+
+      $result | Should-BeFalse
+    }
+
+    It 'Should reject a blob whose embedded algorithm does not match' {
+      $rsaLabelWithEd25519Blob = (
+        'ssh-rsa ' +
+        'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+      )
+
+      $result = Test-AzureDevSshPublicKey -Value $rsaLabelWithEd25519Blob
+
+      $result | Should-BeFalse
+    }
+  }
+}

--- a/tests/powershell/Unit/Public/Test-AzureDevSshPublicKey.Tests.ps1
+++ b/tests/powershell/Unit/Public/Test-AzureDevSshPublicKey.Tests.ps1
@@ -11,6 +11,38 @@ Describe 'Test-AzureDevSshPublicKey' -Tag 'Unit' {
     Import-Module (
       Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Config.psm1'
     ) -Force -ErrorAction Stop
+
+    function New-TestSshPublicKey {
+      param(
+        [Parameter(Mandatory = $true)]
+        [System.String]$Algorithm,
+
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [AllowEmptyString()]
+        [System.String[]]$EncodedFields
+      )
+
+      $blob = [System.Collections.Generic.List[System.Byte]]::new()
+      $encodedParts = @(
+        [System.Convert]::ToBase64String(
+          [System.Text.Encoding]::UTF8.GetBytes($Algorithm)
+        )
+        $EncodedFields
+      )
+      foreach ($encodedPart in $encodedParts) {
+        $part = [System.Convert]::FromBase64String($encodedPart)
+        $lengthBytes = [System.BitConverter]::GetBytes(
+          [System.UInt32]$part.Length
+        )
+        if ([System.BitConverter]::IsLittleEndian) {
+          [System.Array]::Reverse($lengthBytes)
+        }
+        $blob.AddRange([System.Byte[]]$lengthBytes)
+        $blob.AddRange([System.Byte[]]$part)
+      }
+      return "$Algorithm $([System.Convert]::ToBase64String($blob.ToArray()))"
+    }
   }
 
   AfterAll {
@@ -51,6 +83,163 @@ Describe 'Test-AzureDevSshPublicKey' -Tag 'Unit' {
       $result = Test-AzureDevSshPublicKey -Value $rsaLabelWithEd25519Blob
 
       $result | Should-BeFalse
+    }
+
+    It 'Should accept supported RSA and DSS MPINT structures' {
+      $rsa = New-TestSshPublicKey `
+        -Algorithm 'ssh-rsa' `
+        -EncodedFields @('AQAB', 'AQI=')
+      $dss = New-TestSshPublicKey `
+        -Algorithm 'ssh-dss' `
+        -EncodedFields @('AQ==', 'Ag==', 'Aw==', 'BA==')
+
+      (Test-AzureDevSshPublicKey -Value $rsa) | Should-BeTrue
+      (Test-AzureDevSshPublicKey -Value $dss) | Should-BeTrue
+    }
+
+    It 'Should reject malformed RSA MPINT structures' {
+      $negative = New-TestSshPublicKey `
+        -Algorithm 'ssh-rsa' `
+        -EncodedFields @('gA==', 'AQI=')
+      $nonMinimal = New-TestSshPublicKey `
+        -Algorithm 'ssh-rsa' `
+        -EncodedFields @('AAE=', 'AQI=')
+      $missingModulus = New-TestSshPublicKey `
+        -Algorithm 'ssh-rsa' `
+        -EncodedFields @('AQAB')
+
+      (Test-AzureDevSshPublicKey -Value $negative) | Should-BeFalse
+      (Test-AzureDevSshPublicKey -Value $nonMinimal) | Should-BeFalse
+      (Test-AzureDevSshPublicKey -Value $missingModulus) | Should-BeFalse
+    }
+
+    It 'Should accept each supported ECDSA curve structure' {
+      $curveCases = @(
+        @{ Name = 'nistp256'; PointLength = 65 },
+        @{ Name = 'nistp384'; PointLength = 97 },
+        @{ Name = 'nistp521'; PointLength = 133 }
+      )
+
+      foreach ($curveCase in $curveCases) {
+        $point = [System.Byte[]]::new($curveCase.PointLength)
+        $point[0] = 4
+        $publicKey = New-TestSshPublicKey `
+          -Algorithm "ecdsa-sha2-$($curveCase.Name)" `
+          -EncodedFields @(
+            [System.Convert]::ToBase64String(
+              [System.Text.Encoding]::UTF8.GetBytes($curveCase.Name)
+            ),
+            [System.Convert]::ToBase64String($point)
+          )
+
+        (Test-AzureDevSshPublicKey -Value $publicKey) | Should-BeTrue
+      }
+    }
+
+    It 'Should reject a mismatched ECDSA curve and point structure' {
+      $point = [System.Byte[]]::new(65)
+      $point[0] = 3
+      $publicKey = New-TestSshPublicKey `
+        -Algorithm 'ecdsa-sha2-nistp256' `
+        -EncodedFields @(
+          [System.Convert]::ToBase64String(
+            [System.Text.Encoding]::UTF8.GetBytes('nistp384')
+          ),
+          [System.Convert]::ToBase64String($point)
+        )
+      $missingPoint = New-TestSshPublicKey `
+        -Algorithm 'ecdsa-sha2-nistp256' `
+        -EncodedFields @(
+          [System.Convert]::ToBase64String(
+            [System.Text.Encoding]::UTF8.GetBytes('nistp256')
+          )
+        )
+
+      (Test-AzureDevSshPublicKey -Value $publicKey) | Should-BeFalse
+      (Test-AzureDevSshPublicKey -Value $missingPoint) | Should-BeFalse
+    }
+
+    It 'Should accept supported security-key structures' {
+      $ed25519Key = [System.Byte[]]::new(32)
+      $ecdsaPoint = [System.Byte[]]::new(65)
+      $ecdsaPoint[0] = 4
+      $application = [System.Convert]::ToBase64String(
+        [System.Text.Encoding]::UTF8.GetBytes('ssh:test')
+      )
+      $ed25519 = New-TestSshPublicKey `
+        -Algorithm 'sk-ssh-ed25519@openssh.com' `
+        -EncodedFields @(
+          [System.Convert]::ToBase64String($ed25519Key),
+          $application
+        )
+      $ecdsa = New-TestSshPublicKey `
+        -Algorithm 'sk-ecdsa-sha2-nistp256@openssh.com' `
+        -EncodedFields @(
+          [System.Convert]::ToBase64String(
+            [System.Text.Encoding]::UTF8.GetBytes('nistp256')
+          ),
+          [System.Convert]::ToBase64String($ecdsaPoint),
+          $application
+        )
+
+      (Test-AzureDevSshPublicKey -Value $ed25519) | Should-BeTrue
+      (Test-AzureDevSshPublicKey -Value $ecdsa) | Should-BeTrue
+    }
+
+    It 'Should reject malformed security-key and unsupported structures' {
+      $shortEd25519Key = [System.Byte[]]::new(31)
+      $malformedSecurityKey = New-TestSshPublicKey `
+        -Algorithm 'sk-ssh-ed25519@openssh.com' `
+        -EncodedFields @(
+          [System.Convert]::ToBase64String($shortEd25519Key),
+          'YXBw'
+        )
+      $malformedEcdsaSecurityKey = New-TestSshPublicKey `
+        -Algorithm 'sk-ecdsa-sha2-nistp256@openssh.com' `
+        -EncodedFields @(
+          [System.Convert]::ToBase64String(
+            [System.Text.Encoding]::UTF8.GetBytes('nistp256')
+          ),
+          [System.Convert]::ToBase64String([System.Byte[]]::new(65))
+        )
+      $unsupported = New-TestSshPublicKey `
+        -Algorithm 'ssh-xmss@openssh.com' `
+        -EncodedFields @('AQ==')
+
+      (Test-AzureDevSshPublicKey -Value $malformedSecurityKey) |
+        Should-BeFalse
+      (Test-AzureDevSshPublicKey -Value $malformedEcdsaSecurityKey) |
+        Should-BeFalse
+      (Test-AzureDevSshPublicKey -Value $unsupported) | Should-BeFalse
+    }
+
+    It 'Should reject empty fields and trailing partial field data' {
+      $emptyField = New-TestSshPublicKey `
+        -Algorithm 'ssh-rsa' `
+        -EncodedFields @('', 'AQI=')
+      $valid = New-TestSshPublicKey `
+        -Algorithm 'ssh-ed25519' `
+        -EncodedFields @(
+          [System.Convert]::ToBase64String([System.Byte[]]::new(32))
+        )
+      $parts = $valid.Split(' ', 2)
+      $blob = [System.Collections.Generic.List[System.Byte]]::new(
+        [System.Convert]::FromBase64String($parts[1])
+      )
+      $blob.Add(0)
+      $trailingPartialField = (
+        "$($parts[0]) $([System.Convert]::ToBase64String($blob.ToArray()))"
+      )
+      $oversizedFieldBlob = [System.Convert]::FromBase64String($parts[1])
+      $oversizedFieldBlob[18] = 33
+      $oversizedField = (
+        "$($parts[0]) $([System.Convert]::ToBase64String($oversizedFieldBlob))"
+      )
+
+      (Test-AzureDevSshPublicKey -Value $emptyField) | Should-BeFalse
+      (Test-AzureDevSshPublicKey -Value $trailingPartialField) |
+        Should-BeFalse
+      (Test-AzureDevSshPublicKey -Value $oversizedField) | Should-BeFalse
     }
   }
 }


### PR DESCRIPTION
## Description

Authenticates workstation response packages end to end. Schema 3 binds the trusted approver fingerprint into signed requests, requires the managed approval identity to match, and returns one signed .kravpkg envelope whose exact encrypted payload is verified before age decryption.

Also adds strict OpenSSH public-key wire validation, cleanup and tamper regressions, focused private-function unit coverage, real OpenSSH signature verification coverage, and updated operator/developer documentation.

## Related Issues

Closes #679

## Reviewer Notes

- PowerShell unit and integration suites: 47 passed, 1 Windows-only test skipped.
- npm run check passed, including 4,845 Vitest tests and both HSA support suites.
- Standards review: pass. Spec review: pass.
- Real OpenSSH signature and RSA/ECDSA key-validation smoke tests passed.

## Operator Upgrade Impact

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
Provision AZURE_DEV_WORKSTATION_APPROVER_PUBLIC_KEY_PATH on destination workstations through a trusted channel before generating requests. Request and package schema 3 intentionally has no compatibility path with schema 2; regenerate pending requests and responses after upgrade. Existing approval key rotation requires provisioning the replacement public key before creating a new request.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/870)
<!-- Reviewable:end -->
