### PR TITLE
build(deps): update npm toolchain to 12.0.2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
       "nodeGitTagPrefix": "v",
       "version": "24",
       "nvmVersion": "latest",
-      "npmVersion": "12.0.1"
+      "npmVersion": "12.0.2"
     },
     "ghcr.io/devcontainers/features/dotnet:2": {
       "version": "8.0"

--- a/.devcontainer/elevated/devcontainer.json
+++ b/.devcontainer/elevated/devcontainer.json
@@ -24,7 +24,7 @@
       "nodeGitTagPrefix": "v",
       "version": "24",
       "nvmVersion": "latest",
-      "npmVersion": "12.0.1"
+      "npmVersion": "12.0.2"
     },
     "ghcr.io/devcontainers/features/dotnet:2": {
       "version": "8.0"

--- a/containers/hsa-directory-mock/package.json
+++ b/containers/hsa-directory-mock/package.json
@@ -2,13 +2,13 @@
   "name": "@kravhantering/hsa-directory-mock",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "npm@12.0.1",
+  "packageManager": "npm@12.0.2",
   "type": "module",
   "description": "SOAP GetHsaPerson mock for the HSA directory",
   "devEngines": {
     "packageManager": {
       "name": "npm",
-      "version": "12.0.1",
+      "version": "12.0.2",
       "onFail": "error"
     }
   },

--- a/containers/hsa-person-lookup-adapter/package.json
+++ b/containers/hsa-person-lookup-adapter/package.json
@@ -2,13 +2,13 @@
   "name": "@kravhantering/hsa-person-lookup-adapter",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "npm@12.0.1",
+  "packageManager": "npm@12.0.2",
   "type": "module",
   "description": "REST to SOAP GetHsaPerson adapter for HSA person lookup",
   "devEngines": {
     "packageManager": {
       "name": "npm",
-      "version": "12.0.1",
+      "version": "12.0.2",
       "onFail": "error"
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@dagrejs/dagre": "^3.0.0",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@dagrejs/dagre": "^3.1.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@react-pdf/renderer": "^4.5.1",
         "@tailwindcss/typography": "^0.5.20",
         "content-disposition": "^2.0.1",
-        "framer-motion": "^12.42.2",
+        "framer-motion": "^12.43.0",
         "iron-session": "^8.0.4",
-        "jose": "^6.2.5",
+        "jose": "^6.2.8",
         "lucide-react": "^1.27.0",
         "mssql": "^12.7.0",
         "next": "^16.2.12",
@@ -33,7 +33,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.5.6",
         "@cspell/dict-sv": "^2.3.2",
-        "@playwright/test": "^1.62.0",
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/node": "^4.3.3",
         "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/jest-dom": "^7.0.0",
@@ -41,9 +41,9 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/mssql": "^12.3.0",
         "@types/node": "^24.13.3",
-        "@types/oidc-provider": "^9.5.0",
-        "@types/react": "^19.2.17",
-        "@types/react-dom": "^19.2.3",
+        "@types/oidc-provider": "^9.11.0",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
         "@viscalyx/developer-mode-core": "^0.2.2",
         "@viscalyx/developer-mode-react": "^0.2.0",
         "@vitest/coverage-v8": "^4.1.10",
@@ -1416,18 +1416,18 @@
       }
     },
     "node_modules/@dagrejs/dagre": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
-      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.1.0.tgz",
+      "integrity": "sha512-22SWJOfiQVCSFF0qN43SMiYS7Ch9Z6HZoO8+5PycGzGgmtdXIvHoZ2DoT5BweVGf+wwHxBFZu4eO0do0RIYQaw==",
       "license": "MIT",
       "dependencies": {
-        "@dagrejs/graphlib": "4.0.1"
+        "@dagrejs/graphlib": "4.0.3"
       }
     },
     "node_modules/@dagrejs/graphlib": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
-      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.3.tgz",
+      "integrity": "sha512-9kvysNliOxG5m3lr1Qq5uCc+SYxx+BaLDM2SDGkgoZvKJ1bSESzbZ3gn4rSxqX1xR07swcSdeuGyKYQhAURxAA==",
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
@@ -2173,12 +2173,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -2213,22 +2213,25 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
       },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@next/env": {
@@ -2763,13 +2766,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
-      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.0"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4184,9 +4187,9 @@
       }
     },
     "node_modules/@types/oidc-provider": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/@types/oidc-provider/-/oidc-provider-9.5.0.tgz",
-      "integrity": "sha512-eEzCRVTSqIHD9Bo/qRJ4XQWQ5Z/zBcG+Z2cGJluRsSuWx1RJihqRyPxhIEpMXTwPzHYRTQkVp7hwisQOwzzSAg==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@types/oidc-provider/-/oidc-provider-9.11.0.tgz",
+      "integrity": "sha512-wZMEmCGh8WGKYSUpxJgpPLIKTe4972OJUlWXaNzy5+vvnU097i8ijzApgHLihdg56cQ+PV+USYYcnh3W8kVISA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4210,18 +4213,18 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -6269,12 +6272,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.42.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
-      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
+      "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.42.2",
+        "motion-dom": "^12.43.0",
         "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
@@ -7139,9 +7142,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.5.tgz",
-      "integrity": "sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -8881,9 +8884,9 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.42.2",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
-      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
+      "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.39.0"
@@ -9383,13 +9386,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
-      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9402,9 +9405,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
-      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kravhantering",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "npm@12.0.1",
+  "packageManager": "npm@12.0.2",
   "description": "En webbapplikation för kravhantering som stödjer företagets kravmodell och kravprocess",
   "license": "MIT",
   "author": "Viscalyx",
@@ -12,7 +12,7 @@
   "devEngines": {
     "packageManager": {
       "name": "npm",
-      "version": "12.0.1",
+      "version": "12.0.2",
       "onFail": "error"
     }
   },
@@ -156,14 +156,14 @@
     "lint:py": "pyright --project pyrightconfig.json"
   },
   "dependencies": {
-    "@dagrejs/dagre": "^3.0.0",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@dagrejs/dagre": "^3.1.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@react-pdf/renderer": "^4.5.1",
     "@tailwindcss/typography": "^0.5.20",
     "content-disposition": "^2.0.1",
-    "framer-motion": "^12.42.2",
+    "framer-motion": "^12.43.0",
     "iron-session": "^8.0.4",
-    "jose": "^6.2.5",
+    "jose": "^6.2.8",
     "lucide-react": "^1.27.0",
     "mssql": "^12.7.0",
     "next": "^16.2.12",
@@ -180,7 +180,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.6",
     "@cspell/dict-sv": "^2.3.2",
-    "@playwright/test": "^1.62.0",
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/node": "^4.3.3",
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/jest-dom": "^7.0.0",
@@ -188,9 +188,9 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/mssql": "^12.3.0",
     "@types/node": "^24.13.3",
-    "@types/oidc-provider": "^9.5.0",
-    "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3",
+    "@types/oidc-provider": "^9.11.0",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
     "@viscalyx/developer-mode-core": "^0.2.2",
     "@viscalyx/developer-mode-react": "^0.2.0",
     "@vitest/coverage-v8": "^4.1.10",
@@ -222,8 +222,6 @@
     "which causes 'npm ci' to fail with EBADPLATFORM in CI."
   ],
   "overrides": {
-    "@hono/node-server": "2.0.12",
-    "brace-expansion": "5.0.8",
     "postcss": "8.5.23",
     "sharp": "0.35.3"
   },
@@ -231,8 +229,6 @@
     "Overrides pin transitive dependencies that still resolve to vulnerable versions.",
     "Remove each override when the parent dependency updates to include the fix natively.",
     "Document below this. Example: @swc/helpers: next@16.1.6 pins 0.5.15, but next-intl's @swc/core@^1.15.2 peer-requires >=0.5.17. Override to 0.5.19 resolves the conflict.",
-    "@hono/node-server: @modelcontextprotocol/sdk@1.29.0 resolves @hono/node-server@1.19.14. Override maps vulnerable releases through 2.0.9 to 2.0.12 for GHSA-frvp-7c67-39w9 and GHSA-9mqv-5hh9-4cgg.",
-    "brace-expansion: rimraf@6.1.3 resolves brace-expansion@5.0.7 through glob@13.0.6 and minimatch@10.2.5. Override maps vulnerable releases through 5.0.7 to 5.0.8 for GHSA-mh99-v99m-4gvg.",
     "postcss: next@16.2.12 pins postcss@8.4.31 when unforced. Override maps the vulnerable Next postcss pin to 8.5.23 for GHSA-qx2v-qp2m-jg93 and satisfies @tailwindcss/postcss@4.3.3's ^8.5.16 requirement.",
     "sharp: next@16.2.12 resolves sharp@0.34.5. Override maps vulnerable sharp <0.35.0 to 0.35.3 for GHSA-f88m-g3jw-g9cj."
   ],

--- a/scripts/__tests__/dependency-drift.test.mjs
+++ b/scripts/__tests__/dependency-drift.test.mjs
@@ -399,7 +399,7 @@ describe('drift detection', () => {
     write(
       root,
       'package.json',
-      JSON.stringify({ packageManager: 'npm@12.0.1' }),
+      JSON.stringify({ packageManager: 'npm@12.0.2' }),
     )
 
     await expect(
@@ -413,7 +413,7 @@ describe('drift detection', () => {
       ),
     ).resolves.toMatchObject({
       available: { version: '12.1.0' },
-      current: { version: '12.0.1' },
+      current: { version: '12.0.2' },
       drift: true,
     })
   })
@@ -631,7 +631,7 @@ describe('issue contract', () => {
   })
 
   it('formats npm and immutable image state', () => {
-    expect(formatState({ version: '12.0.1' })).toBe('npm 12.0.1')
+    expect(formatState({ version: '12.0.2' })).toBe('npm 12.0.2')
     expect(
       formatState({
         imageId: digest('a'),

--- a/scripts/__tests__/install-repository-npm.test.mjs
+++ b/scripts/__tests__/install-repository-npm.test.mjs
@@ -18,8 +18,8 @@ afterEach(() => {
 
 describe('repository npm bootstrap', () => {
   it('accepts only an exact npm packageManager declaration', () => {
-    expect(packageManagerVersion({ packageManager: 'npm@12.0.1' })).toBe(
-      '12.0.1',
+    expect(packageManagerVersion({ packageManager: 'npm@12.0.2' })).toBe(
+      '12.0.2',
     )
     expect(() =>
       packageManagerVersion({ packageManager: 'npm@latest' }),
@@ -36,19 +36,19 @@ describe('repository npm bootstrap', () => {
     temporaryDirectories.push(root)
     fs.writeFileSync(
       path.join(root, 'package.json'),
-      '{"packageManager":"npm@12.0.1"}\n',
+      '{"packageManager":"npm@12.0.2"}\n',
     )
     const execFileSync = vi
       .fn()
       .mockReturnValueOnce('')
-      .mockReturnValueOnce('12.0.1\n')
+      .mockReturnValueOnce('12.0.2\n')
     vi.spyOn(console, 'log').mockImplementation(() => {})
 
-    expect(installRepositoryNpm(root, execFileSync)).toBe('12.0.1')
+    expect(installRepositoryNpm(root, execFileSync)).toBe('12.0.2')
     expect(execFileSync).toHaveBeenNthCalledWith(
       1,
       'npm',
-      ['install', '--global', 'npm@12.0.1'],
+      ['install', '--global', 'npm@12.0.2'],
       {
         cwd: expect.stringContaining('repository-npm-bootstrap-'),
         stdio: 'inherit',
@@ -70,7 +70,7 @@ describe('repository npm bootstrap', () => {
     temporaryDirectories.push(root)
     fs.writeFileSync(
       path.join(root, 'package.json'),
-      '{"packageManager":"npm@12.0.1"}\n',
+      '{"packageManager":"npm@12.0.2"}\n',
     )
     const execFileSync = vi
       .fn()
@@ -78,7 +78,7 @@ describe('repository npm bootstrap', () => {
       .mockReturnValueOnce('11.0.0\n')
 
     expect(() => installRepositoryNpm(root, execFileSync)).toThrow(
-      'Expected npm 12.0.1',
+      'Expected npm 12.0.2',
     )
   })
 })


### PR DESCRIPTION
## Description

- Update the canonical npm toolchain from 12.0.1 to 12.0.2 across the root package, nested HSA packages, and both devcontainer profiles.
- Refresh compatible direct dependencies and the generated lockfile.
- Remove the now-redundant `@hono/node-server` and `brace-expansion` overrides.
- Update npm bootstrap and dependency-drift test expectations.

## Related Issues

Closes #809

## Reviewer Notes

- `npm ci`
- `npm approve-scripts --allow-scripts-pending` — no pending packages
- `npm run check` — passed, including 4,845 unit tests and both HSA support suites
- `npm audit` — 0 vulnerabilities
- npm drift detector — current 12.0.2, available 12.0.2, `drift: false`
- Playwright 1.62.1 browser inventory confirms matching Chromium revision 1234

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
No operator upgrade notes.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->
