### PR TITLE
chore: refresh production Node image digest

### DIFF
--- a/containers/app/Dockerfile
+++ b/containers/app/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:24-trixie-slim@sha256:ae91dcc111a68c9d2d81ff2a17bda61be126426176fde6fe7d08ab13b7f50573 AS dependencies
+FROM node:24-trixie-slim@sha256:10c950bed4f33b3cedac92b6a46a14f18b8bf4bed18affbf86c871d9bc0d0a91 AS dependencies
 
 ENV NEXT_TELEMETRY_DISABLED=1
 WORKDIR /workspace
@@ -30,7 +30,7 @@ ENV NODE_ENV=production
 COPY . .
 RUN npm run build
 
-FROM node:24-trixie-slim@sha256:ae91dcc111a68c9d2d81ff2a17bda61be126426176fde6fe7d08ab13b7f50573 AS db-job-dependencies
+FROM node:24-trixie-slim@sha256:10c950bed4f33b3cedac92b6a46a14f18b8bf4bed18affbf86c871d9bc0d0a91 AS db-job-dependencies
 
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
@@ -60,7 +60,7 @@ NODE
 npm ci --omit=dev --omit=optional --ignore-scripts --no-audit --no-fund
 EOF
 
-FROM node:24-trixie-slim@sha256:ae91dcc111a68c9d2d81ff2a17bda61be126426176fde6fe7d08ab13b7f50573 AS app-runtime
+FROM node:24-trixie-slim@sha256:10c950bed4f33b3cedac92b6a46a14f18b8bf4bed18affbf86c871d9bc0d0a91 AS app-runtime
 
 RUN rm -rf /usr/local/lib/node_modules/npm \
   && rm -f /usr/local/bin/npm /usr/local/bin/npx
@@ -80,7 +80,7 @@ USER node
 EXPOSE 3000
 CMD ["node", "server.js"]
 
-FROM node:24-trixie-slim@sha256:ae91dcc111a68c9d2d81ff2a17bda61be126426176fde6fe7d08ab13b7f50573 AS db-job
+FROM node:24-trixie-slim@sha256:10c950bed4f33b3cedac92b6a46a14f18b8bf4bed18affbf86c871d9bc0d0a91 AS db-job
 
 RUN rm -rf /usr/local/lib/node_modules/npm \
   && rm -f /usr/local/bin/npm /usr/local/bin/npx
@@ -103,7 +103,7 @@ USER node
 ENTRYPOINT ["node", "scripts/db-sqlserver-admin.mjs"]
 CMD ["health"]
 
-FROM node:24-trixie-slim@sha256:ae91dcc111a68c9d2d81ff2a17bda61be126426176fde6fe7d08ab13b7f50573 AS demo-seed
+FROM node:24-trixie-slim@sha256:10c950bed4f33b3cedac92b6a46a14f18b8bf4bed18affbf86c871d9bc0d0a91 AS demo-seed
 
 RUN rm -rf /usr/local/lib/node_modules/npm \
   && rm -f /usr/local/bin/npm /usr/local/bin/npx

--- a/containers/hsa-directory-mock/Dockerfile
+++ b/containers/hsa-directory-mock/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:24-trixie-slim@sha256:ae91dcc111a68c9d2d81ff2a17bda61be126426176fde6fe7d08ab13b7f50573 AS dependencies
+FROM node:24-trixie-slim@sha256:10c950bed4f33b3cedac92b6a46a14f18b8bf4bed18affbf86c871d9bc0d0a91 AS dependencies
 
 ENV NODE_ENV=production
 WORKDIR /app
@@ -9,7 +9,7 @@ COPY package.json package-lock.json .npmrc ./
 RUN npm install --global "npm@$(node -p 'require("./package.json").packageManager.slice(4)')"
 RUN npm ci --omit=dev --ignore-scripts --no-audit --no-fund
 
-FROM node:24-trixie-slim@sha256:ae91dcc111a68c9d2d81ff2a17bda61be126426176fde6fe7d08ab13b7f50573
+FROM node:24-trixie-slim@sha256:10c950bed4f33b3cedac92b6a46a14f18b8bf4bed18affbf86c871d9bc0d0a91
 
 RUN rm -rf /usr/local/lib/node_modules/npm \
   && rm -f /usr/local/bin/npm /usr/local/bin/npx

--- a/containers/hsa-person-lookup-adapter/Dockerfile
+++ b/containers/hsa-person-lookup-adapter/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:24-trixie-slim@sha256:ae91dcc111a68c9d2d81ff2a17bda61be126426176fde6fe7d08ab13b7f50573 AS dependencies
+FROM node:24-trixie-slim@sha256:10c950bed4f33b3cedac92b6a46a14f18b8bf4bed18affbf86c871d9bc0d0a91 AS dependencies
 
 ENV NODE_ENV=production
 WORKDIR /app
@@ -9,7 +9,7 @@ COPY package.json package-lock.json .npmrc ./
 RUN npm install --global "npm@$(node -p 'require("./package.json").packageManager.slice(4)')"
 RUN npm ci --omit=dev --ignore-scripts --no-audit --no-fund
 
-FROM node:24-trixie-slim@sha256:ae91dcc111a68c9d2d81ff2a17bda61be126426176fde6fe7d08ab13b7f50573
+FROM node:24-trixie-slim@sha256:10c950bed4f33b3cedac92b6a46a14f18b8bf4bed18affbf86c871d9bc0d0a91
 
 RUN rm -rf /usr/local/lib/node_modules/npm \
   && rm -f /usr/local/bin/npm /usr/local/bin/npx

--- a/package-lock.json
+++ b/package-lock.json
@@ -4789,9 +4789,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "which causes 'npm ci' to fail with EBADPLATFORM in CI."
   ],
   "overrides": {
+    "brace-expansion": "5.0.9",
     "postcss": "8.5.23",
     "sharp": "0.35.3"
   },
@@ -229,6 +230,7 @@
     "Overrides pin transitive dependencies that still resolve to vulnerable versions.",
     "Remove each override when the parent dependency updates to include the fix natively.",
     "Document below this. Example: @swc/helpers: next@16.1.6 pins 0.5.15, but next-intl's @swc/core@^1.15.2 peer-requires >=0.5.17. Override to 0.5.19 resolves the conflict.",
+    "brace-expansion: rimraf@6.1.3 resolves brace-expansion@5.0.8 through glob and minimatch. Override to 5.0.9 for GHSA-rgw5-rvv9-x895.",
     "postcss: next@16.2.12 pins postcss@8.4.31 when unforced. Override maps the vulnerable Next postcss pin to 8.5.23 for GHSA-qx2v-qp2m-jg93 and satisfies @tailwindcss/postcss@4.3.3's ^8.5.16 requirement.",
     "sharp: next@16.2.12 resolves sharp@0.34.5. Override maps vulnerable sharp <0.35.0 to 0.35.3 for GHSA-f88m-g3jw-g9cj."
   ],


### PR DESCRIPTION
## Description

- Pin every production Node base reference to the current Linux/AMD64 manifest for `node:24-trixie-slim`.
- Restore the platform-specific immutable identity expected by the production Node dependency-drift detector.
- Keep the app, database jobs, demo seed, and both HSA support images synchronized.

## Related Issues

Fixes #669

## Reviewer Notes

Verified locally:

- The live `production-node` detector reports `drift: false`.
- `npm run check` passes with 4,845 tests passed and 75 skipped, plus 31 HSA support tests passed.
- All five Linux/AMD64 runtime images build successfully with the refreshed digest.
- Each built image reports `architecture=amd64`, runs Node 24.18.1, and has no runtime npm binary.
- Dependency-maintenance coverage and policy validation passes.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
<!-- No operator upgrade notes. -->
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/877)
<!-- Reviewable:end -->
