### PR TITLE
Enhetlig prioritetsidentitet i genererade PDF-rapporter

### DIFF
--- a/app/[locale]/requirements/reports/pdf/list/route.ts
+++ b/app/[locale]/requirements/reports/pdf/list/route.ts
@@ -149,6 +149,7 @@ function listQueryRequirementToReportData(
           version.priorityLevelId == null
             ? null
             : {
+                code: version.priorityLevelCode ?? '',
                 color: version.priorityLevelColor,
                 iconName: version.priorityLevelIconName,
                 id: version.priorityLevelId,

--- a/components/reports/pdf/PdfReportRenderer.tsx
+++ b/components/reports/pdf/PdfReportRenderer.tsx
@@ -1211,7 +1211,7 @@ function PdfPriorityBadge({
       ]}
     >
       <PdfStatusIcon color={colors.foreground} name={priority.iconName} />
-      <Text style={{ color: colors.foreground, flex: 1 }}>{label}</Text>
+      <Text style={{ color: colors.foreground }}>{label}</Text>
     </View>
   )
 }
@@ -1243,7 +1243,6 @@ function PdfPriorityInline({
       <Text
         style={{
           color: colors.foreground,
-          flex: 1,
           fontSize: 8,
           lineHeight: 1.25,
         }}

--- a/components/reports/pdf/PdfReportRenderer.tsx
+++ b/components/reports/pdf/PdfReportRenderer.tsx
@@ -16,6 +16,10 @@ import {
 import { getStatusIconNodes } from '@/lib/icons/status-icon-allowlist'
 import { formatActorDisplayNameForLocale } from '@/lib/privacy/display-name'
 import {
+  formatReportPriorityLabel,
+  getPdfPriorityColors,
+} from '@/lib/reports/priority'
+import {
   formatReportBoolean,
   getReportLabels,
   getReportMessages,
@@ -26,6 +30,7 @@ import type {
   DiffSegment,
   MetadataChange,
   ReportModel,
+  ReportPriorityIdentity,
   ReportSection,
   SuggestionReportItem,
   TimelineEntryData,
@@ -310,11 +315,11 @@ function PdfSectionRenderer({
     case 'timeline-entry':
       return <PdfTimelineEntry locale={locale} section={section} />
     case 'requirement-table':
-      return <PdfRequirementTable section={section} />
+      return <PdfRequirementTable locale={locale} section={section} />
     case 'traceability-summary':
       return <PdfTraceabilitySummary section={section} />
     case 'traceability-table':
-      return <PdfTraceabilityTable section={section} />
+      return <PdfTraceabilityTable locale={locale} section={section} />
     case 'requirement-selection-context':
       return (
         <PdfRequirementSelectionContext locale={locale} section={section} />
@@ -570,11 +575,11 @@ function PdfVersionSummary({
             value={getName(version.qualityCharacteristic)}
           />
         )}
-        {getName(version.priorityLevel) && (
-          <PdfMetadataItem
-            iconName={version.priorityLevel?.iconName}
+        {version.priorityLevel && (
+          <PdfPriorityMetadataItem
             label={labels.columns.priorityLevel}
-            value={getName(version.priorityLevel)}
+            locale={locale}
+            priority={version.priorityLevel}
           />
         )}
         <PdfMetadataItem
@@ -605,6 +610,23 @@ function PdfVersionSummary({
           </Text>
         </View>
       )}
+    </View>
+  )
+}
+
+function PdfPriorityMetadataItem({
+  label,
+  locale,
+  priority,
+}: {
+  label: string
+  locale: string
+  priority: ReportPriorityIdentity
+}) {
+  return (
+    <View style={styles.metadataItem}>
+      <Text style={styles.metadataItemLabel}>{label}: </Text>
+      <PdfPriorityBadge locale={locale} priority={priority} />
     </View>
   )
 }
@@ -683,26 +705,46 @@ function PdfMetadataChanges({
       </View>
       {section.changes.map((change, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: static metadata rows
-        <PdfMetadataChangeRow change={change} key={i} />
+        <PdfMetadataChangeRow change={change} key={i} locale={locale} />
       ))}
     </View>
   )
 }
 
-function PdfMetadataChangeRow({ change }: { change: MetadataChange }) {
+function PdfMetadataChangeRow({
+  change,
+  locale,
+}: {
+  change: MetadataChange
+  locale: string
+}) {
   return (
     <View style={styles.tableRow}>
       <Text style={[styles.tableCell, styles.tableCellField]}>
         {change.field}
       </Text>
-      <Text style={[styles.tableCell, styles.tableCellOld]}>
-        {change.oldValue ?? '\u2014'}
-      </Text>
-      <Text style={[styles.tableCell, styles.tableCellNew]}>
-        {change.newValue ?? '\u2014'}
-      </Text>
+      <View style={styles.tableCellOld}>
+        <PdfMetadataChangeValue locale={locale} value={change.oldValue} />
+      </View>
+      <View style={styles.tableCellNew}>
+        <PdfMetadataChangeValue locale={locale} value={change.newValue} />
+      </View>
     </View>
   )
+}
+
+function PdfMetadataChangeValue({
+  locale,
+  value,
+}: {
+  locale: string
+  value: MetadataChange['oldValue']
+}) {
+  if (value == null) return <Text style={styles.tableCell}>\u2014</Text>
+  if (typeof value === 'string') {
+    return <Text style={styles.tableCell}>{value}</Text>
+  }
+  return <PdfPriorityBadge locale={locale} priority={value} />
 }
 
 function PdfTimelineEntry({
@@ -764,8 +806,10 @@ export function formatTimelineDate(
 }
 
 function PdfRequirementTable({
+  locale,
   section,
 }: {
+  locale: string
   section: Extract<ReportSection, { type: 'requirement-table' }>
 }) {
   const colWidths: Record<string, string> = {
@@ -800,7 +844,12 @@ function PdfRequirementTable({
               key={col.key}
               style={{ width: columnWidth(col.key, col.width) }}
             >
-              {col.key === 'status' && row.statusColor ? (
+              {col.key === 'priorityLevel' && row.priorityLevel ? (
+                <PdfPriorityInline
+                  locale={locale}
+                  priority={row.priorityLevel}
+                />
+              ) : col.key === 'status' && row.statusColor ? (
                 <PdfBadge
                   color={row.statusColor}
                   iconName={row.statusIconName}
@@ -889,8 +938,10 @@ function PdfTraceabilitySummary({
 }
 
 function PdfTraceabilityTable({
+  locale,
   section,
 }: {
+  locale: string
   section: Extract<ReportSection, { type: 'traceability-table' }>
 }) {
   return (
@@ -944,10 +995,26 @@ function PdfTraceabilityTable({
               label={section.labels.deviation}
               value={row.deviation}
             />
-            <PdfTraceabilityField
-              label={section.labels.priorityLevel}
-              value={row.priorityLevel}
-            />
+            <View style={{ width: '48%' }}>
+              <Text
+                style={{
+                  color: '#64748b',
+                  fontFamily: 'Helvetica-Bold',
+                  fontSize: 7,
+                  marginBottom: 1,
+                }}
+              >
+                {section.labels.priorityLevel}
+              </Text>
+              {row.priorityLevel ? (
+                <PdfPriorityInline
+                  locale={locale}
+                  priority={row.priorityLevel}
+                />
+              ) : (
+                <Text style={{ color: '#94a3b8', fontSize: 8 }}>\u2014</Text>
+              )}
+            </View>
             <PdfTraceabilityField
               label={section.labels.verification}
               value={row.verification}
@@ -1116,6 +1183,77 @@ function PdfStatusIcon({
   )
 }
 
+function PdfPriorityBadge({
+  backdrop = '#ffffff',
+  locale,
+  priority,
+}: {
+  backdrop?: string
+  locale: string
+  priority: ReportPriorityIdentity
+}) {
+  const label = formatReportPriorityLabel(priority, locale)
+  if (!label) return null
+  const colors = getPdfPriorityColors(priority.color, backdrop, 'badge')
+
+  return (
+    <View
+      style={[
+        styles.badge,
+        {
+          alignItems: 'center',
+          alignSelf: 'flex-start',
+          backgroundColor: colors.background,
+          flexDirection: 'row',
+          gap: 2,
+          maxWidth: '100%',
+        },
+      ]}
+    >
+      <PdfStatusIcon color={colors.foreground} name={priority.iconName} />
+      <Text style={{ color: colors.foreground, flex: 1 }}>{label}</Text>
+    </View>
+  )
+}
+
+function PdfPriorityInline({
+  backdrop = '#ffffff',
+  locale,
+  priority,
+}: {
+  backdrop?: string
+  locale: string
+  priority: ReportPriorityIdentity
+}) {
+  const label = formatReportPriorityLabel(priority, locale)
+  if (!label) return null
+  const colors = getPdfPriorityColors(priority.color, backdrop, 'inline')
+
+  return (
+    <View
+      style={{
+        alignItems: 'flex-start',
+        backgroundColor: colors.background,
+        flexDirection: 'row',
+        gap: 2,
+        maxWidth: '100%',
+      }}
+    >
+      <PdfStatusIcon color={colors.foreground} name={priority.iconName} />
+      <Text
+        style={{
+          color: colors.foreground,
+          flex: 1,
+          fontSize: 8,
+          lineHeight: 1.25,
+        }}
+      >
+        {label}
+      </Text>
+    </View>
+  )
+}
+
 function PdfBadge({
   label,
   color,
@@ -1152,13 +1290,6 @@ function PdfDeviationSummary({
 }) {
   const locale = section.locale
   const labels = getReportLabels(locale)
-  const priorityName = section.priorityLevel
-    ? localizeReportValue(
-        locale,
-        section.priorityLevel.nameSv,
-        section.priorityLevel.nameEn,
-      )
-    : null
   const createdBy = formatActorDisplayNameForLocale(section.createdBy, locale)
   return (
     <View
@@ -1180,7 +1311,7 @@ function PdfDeviationSummary({
       >
         {labels.deviations.title}
       </Text>
-      {priorityName && (
+      {section.priorityLevel && (
         <View
           style={{
             alignItems: 'center',
@@ -1192,11 +1323,11 @@ function PdfDeviationSummary({
           <Text style={{ fontSize: 9, color: '#6b7280' }}>
             {labels.deviations.priorityLevel}
           </Text>
-          <PdfStatusIcon
-            color={section.priorityLevel?.color ?? '#6b7280'}
-            name={section.priorityLevel?.iconName}
+          <PdfPriorityInline
+            backdrop="#fffbeb"
+            locale={locale}
+            priority={section.priorityLevel}
           />
-          <Text style={{ fontSize: 9, color: '#6b7280' }}>{priorityName}</Text>
         </View>
       )}
       <Text

--- a/components/reports/pdf/report-response.tsx
+++ b/components/reports/pdf/report-response.tsx
@@ -1,13 +1,18 @@
 import { createElement } from 'react'
 import PdfReportRenderer from '@/components/reports/pdf/PdfReportRenderer'
+import {
+  collectStatusIconNames,
+  preloadStatusIconNodes,
+} from '@/lib/icons/status-icon-allowlist'
 import { renderPdfResponse } from '@/lib/pdf/server-response'
 import type { ReportModel } from '@/lib/reports/types'
 
-export function renderReportModelPdfResponse(
+export async function renderReportModelPdfResponse(
   model: ReportModel,
   locale: string,
   filename: string,
 ): Promise<Response> {
+  await preloadStatusIconNodes(collectStatusIconNames(model))
   return renderPdfResponse(
     createElement(PdfReportRenderer, { locale, model }),
     filename,

--- a/docs/development/report-generation-developer-workflow.md
+++ b/docs/development/report-generation-developer-workflow.md
@@ -13,6 +13,7 @@ consumes the shared report model.
 ```text
 Shared Layer (engine-agnostic)
   lib/reports/types.ts              Report model types
+  lib/reports/priority.ts           Priority normalization and PDF colors
   lib/reports/text-diff.ts          Word-level diff utility
   lib/reports/data/                 Data fetching helpers
   lib/reports/templates/            Template functions (data -> ReportModel)
@@ -37,11 +38,15 @@ authorized report data and do not call the authorization service themselves.
 1. Route/page authorizes the requested report scope.
 2. Route/page collects report data server-side.
 3. Template function converts raw data into a `ReportModel`, an array of typed
-   sections like header, diff, version-summary, and timeline-entry.
-4. Engine-specific renderer consumes the `ReportModel` and produces output.
+   sections like header, diff, version-summary, and timeline-entry. Priority
+   values become a normalized `ReportPriorityIdentity`; invalid colors and icon
+   names become `null` before reaching React-PDF.
+4. The rendering entrypoint collects allowlisted icon names from the complete
+   model and preloads their static vector nodes.
+5. Engine-specific renderer consumes the `ReportModel` and produces output.
    The large requirements-list route uses the isolated worker; smaller existing
    report routes keep the direct Node renderer.
-5. PDF routes return binary `application/pdf` responses with attachment headers
+6. PDF routes return binary `application/pdf` responses with attachment headers
    and `Cache-Control: no-store`.
 
 ## Route URL Patterns
@@ -85,6 +90,20 @@ the shared report model to binary PDF. It is the path for report delivery,
 sharing, and archival output. The browser never imports React-PDF, which keeps
 production CSP compatible with strict `script-src` values and avoids
 `unsafe-eval`/WebAssembly eval exceptions.
+
+Priority rendering has two PDF-specific variants. `PdfPriorityBadge` is used
+for version summaries and old/new metadata values. `PdfPriorityInline` is used
+for dense report rows and the deviation card. Both consume
+`ReportPriorityIdentity`, format `code – localized name`, share the strict
+`#RRGGBB`/neutral policy, and derive foreground colors with at least 4.5:1
+contrast against their exact opaque PDF background. Keep these calculations in
+`lib/reports/priority.ts`; do not pass raw configured colors to React-PDF or add
+fallback icons.
+
+`renderReportModelPdfResponse()` preloads allowlisted icon vector nodes for the
+direct renderer. `report-worker-entry.ts` performs the same preload inside the
+worker because icon caches are process-local. Icon resolution must remain a
+static allowlist operation without network or file loading.
 
 The shared client helper opens immediately, shows separate indeterminate
 generation and Blob-download phases, supports cancellation, and maps only

--- a/docs/governance/manuella-testfall.md
+++ b/docs/governance/manuella-testfall.md
@@ -1077,11 +1077,13 @@ inte längre i paketets praktiska lista.
 
 **Steg:** Välj svenska och skapa PDF för granskningsrapport, kombinerad
 granskningsrapport och historikrapport. Använd kravversioner som visar
-metadataändringar samt publicerat, arkiverat, redigerat och skapat datum.
+metadataändringar, en ändrad prioritet samt publicerat, arkiverat, redigerat
+och skapat datum.
 
 **Förväntat resultat:** Metadataändringarnas rubrik och kolumner samt
 tidslinjens datumetiketter visas på svenska. Skapat datum visas endast när
 inget publicerat, arkiverat eller redigerat datum finns för tidslinjeposten.
+Tidigare och ny prioritet visas separat som P-kod, tankstreck och svenskt namn.
 
 ### LIFE-15: engelska gransknings- och historikrapporter förblir engelska
 
@@ -1091,7 +1093,8 @@ LIFE-14.
 
 **Förväntat resultat:** Metadataändringarnas rubrik och kolumner samt
 tidslinjens datumetiketter visas på engelska. Datumurvalet är oförändrat från
-det svenska testfallet och inga svenska strukturetiketter visas.
+det svenska testfallet och inga svenska strukturetiketter visas. Prioriteten
+visas med samma P-kod och sitt engelska namn.
 
 ## Samarbete i kravdetalj
 
@@ -1137,8 +1140,10 @@ förslaget kan inte lösas eller avvisas en gång till.
 **Steg:** Öppna rapport för förslagshistorik på ett krav med förslag.
 
 **Förväntat resultat:** Rapporten för förslagshistorik kan hämtas som PDF för
-krav med förslag och servern returnerar PDF-svar. Automatiserad täckning får
-verifiera serverns PDF-svar och rapportens datakälla via befintlig
+krav med förslag och servern returnerar PDF-svar. En prioritet visas med P-kod,
+lokaliserat namn, kontrastsäker färg och enbart en giltig konfigurerad ikon.
+Automatiserad täckning får verifiera serverns PDF-svar och rapportens datakälla
+via befintlig
 rapportmodell eller rapportslutpunkt.
 
 ### COL-07: metadata visar kravområdesägare och taxonomi
@@ -1335,8 +1340,9 @@ exportmenyn.
 
 **Förväntat resultat:** Rapporten genereras för hela kravunderlaget och
 innehåller intern uppföljningsmetadata, kravversion, kravområde, kategori, typ,
-kvalitetsegenskap, risknivå, kravversionsstatus, verifierbarhet,
-behovsreferens, användningsstatus och normreferenser. `Anbuds-CSV` visas inte.
+kvalitetsegenskap, prioritet som P-kod och lokaliserat namn,
+kravversionsstatus, verifierbarhet, behovsreferens, användningsstatus och
+normreferenser. `Anbuds-CSV` visas inte.
 `Full CSV-export` visas. Automatiserad täckning får verifiera fälten via
 befintlig strukturerad rapportslutpunkt.
 
@@ -1348,7 +1354,8 @@ rapportmenyn och välj `Förvaltningsrapport`.
 **Förväntat resultat:** Rapporten återanvänder genomföranderapportens fält och
 visar dessutom avstegssignal och rest från införande. Avvikna krav flaggas via
 avstegssignalen, inte genom att räknas som implementerad rest. Automatiserad
-täckning får verifiera fälten via befintlig strukturerad rapportslutpunkt.
+täckning får verifiera fälten och den strukturerade prioritetsidentiteten via
+befintlig strukturerad rapportslutpunkt.
 
 ### SPEC-10d: kravunderlagsrapporter kräver läsbehörighet
 
@@ -1370,8 +1377,9 @@ Sammanfattningen visar totalt antal kravtillämpningar, bibliotekskrav,
 kravunderlagslokala krav, användningsstatusfördelning, saknade
 behovsreferenser och avsteg per beslutsläge. Detaljraderna visar Krav-ID,
 ursprung, version, kravområde, behovsreferens, användningsstatus,
-statusändringsdatum, avsteg, risk, verifierbarhet/verifieringsmetod och
-anteckning. Rapporten omfattar hela det serverfiltrerade resultatet i samma
+statusändringsdatum, avsteg, prioritet som P-kod och lokaliserat namn,
+verifierbarhet/verifieringsmetod och anteckning. Rapporten omfattar hela det
+serverfiltrerade resultatet i samma
 databasstyrda ordning även när resultatet kräver flera serversidor. Webbläsaren
 skickar filter- och sorteringsläget, inte en lista med kravtillämpningsreferenser.
 Automatiserad täckning får verifiera filtrerat innehåll och resultat över 100

--- a/docs/reference/reports.md
+++ b/docs/reference/reports.md
@@ -11,6 +11,34 @@ Version summaries include requirement package names when present. Blank or
 whitespace-only package names are ignored so report output does not show empty
 package entries.
 
+## Priority Identity in PDF Reports
+
+PDF reports represent a resolved priority as structured data containing its
+code, Swedish and English names, validated color, and optional allowlisted icon
+name. History, review, combined review, improvement suggestion history,
+deviation review, progress, management, and application traceability reports
+render the identity as `code – localized name`. If the localized name is empty,
+only the code is shown. A missing priority produces no badge or replacement
+label.
+
+Version summaries and old/new change values use the PDF badge variant. Dense
+progress, management, and traceability rows use the compact inline variant;
+both retain the complete code and name and allow text to wrap without a fixed
+height. Deviation review uses the inline variant against its amber card
+background.
+
+Only strict `#RRGGBB` configured colors enter the report model. Badge fills are
+opaque tints composited for the white PDF page, and their foreground is clamped
+to at least 4.5:1 contrast against that exact fill. Inline foregrounds use the
+same minimum against their exact white or amber background. Missing or invalid
+colors use the neutral PDF palette and never reach React-PDF as raw color
+values.
+
+Allowlisted static vector icons are preloaded before direct or isolated-worker
+rendering and use the same readable foreground as the priority text. Missing,
+empty, or unknown icon names produce no icon, fallback glyph, bullet, or
+external resource request.
+
 ## Report Types
 
 ### 1. History Report
@@ -31,6 +59,7 @@ latest archived version.
 - Only available when the requirement has Review status
 - Shows word-level diffs for requirement text and acceptance criteria
 - Shows metadata changes (category, type, quality characteristic, etc.)
+- Shows previous and new priorities as separate complete priority identities
 - If no published or archived version exists, displays a notice
 - **Archiving reviews** (Published → Review → Archive) are visually
   distinct: titled "Arkiveringsförfrågan" / "Archive Request" with a
@@ -142,6 +171,7 @@ version, sorted in descending version order.
   specification-item detail views
 - Each version section shows a version summary followed by
   its suggestions (or an empty-state label)
+- Version priorities use the localized PDF priority badge when present
 - Suggestion cards display status badge, content, author,
   date, and resolution details when applicable
 - Status colors: Draft (blue), Review Requested (yellow),

--- a/lib/__tests__/report-priority.test.ts
+++ b/lib/__tests__/report-priority.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { contrastRatio } from '@/lib/color-contrast'
+import {
+  createReportPriorityIdentity,
+  formatReportPriorityLabel,
+  getPdfPriorityColors,
+} from '@/lib/reports/priority'
+
+describe('report priority identity', () => {
+  it('normalizes valid priority data and rejects invalid visual configuration', () => {
+    expect(
+      createReportPriorityIdentity({
+        code: ' P1 ',
+        color: '#FDE047',
+        iconName: 'CircleAlert',
+        nameEn: ' Critical ',
+        nameSv: ' Kritisk ',
+      }),
+    ).toEqual({
+      code: 'P1',
+      color: '#fde047',
+      iconName: 'CircleAlert',
+      nameEn: 'Critical',
+      nameSv: 'Kritisk',
+    })
+
+    expect(
+      createReportPriorityIdentity({
+        code: 'P2',
+        color: 'javascript:red',
+        iconName: 'NotAnAllowedIcon',
+        nameEn: 'High',
+        nameSv: 'Hög',
+      }),
+    ).toEqual({
+      code: 'P2',
+      color: null,
+      iconName: null,
+      nameEn: 'High',
+      nameSv: 'Hög',
+    })
+  })
+
+  it('formats code and localized name without a dangling separator', () => {
+    const priority = createReportPriorityIdentity({
+      code: 'P3',
+      color: null,
+      iconName: null,
+      nameEn: '',
+      nameSv: 'Medel',
+    })
+
+    expect(formatReportPriorityLabel(priority, 'sv')).toBe('P3 – Medel')
+    expect(formatReportPriorityLabel(priority, 'en')).toBe('P3')
+    expect(
+      formatReportPriorityLabel(
+        createReportPriorityIdentity({
+          code: 'P4',
+          color: null,
+          iconName: null,
+          nameEn: '',
+          nameSv: '',
+        }),
+        'en',
+      ),
+    ).toBe('P4')
+    expect(formatReportPriorityLabel(null, 'sv')).toBeNull()
+  })
+
+  it('derives opaque badge and inline colors with printable text contrast', () => {
+    for (const accent of ['#fde047', '#1e3a8a', null, 'invalid']) {
+      const badge = getPdfPriorityColors(accent, '#ffffff', 'badge')
+      const inline = getPdfPriorityColors(accent, '#fffbeb', 'inline')
+
+      expect(badge.background).toMatch(/^#[0-9a-f]{6}$/)
+      expect(inline.background).toBe('#fffbeb')
+      expect(
+        contrastRatio(badge.foreground, badge.background),
+      ).toBeGreaterThanOrEqual(4.5)
+      expect(
+        contrastRatio(inline.foreground, inline.background),
+      ).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+})

--- a/lib/__tests__/report-priority.test.ts
+++ b/lib/__tests__/report-priority.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { contrastRatio } from '@/lib/color-contrast'
 import {
   createReportPriorityIdentity,
+  createReportPriorityIdentityFromItem,
   formatReportPriorityLabel,
   getPdfPriorityColors,
 } from '@/lib/reports/priority'
@@ -39,6 +40,33 @@ describe('report priority identity', () => {
       nameEn: 'High',
       nameSv: 'Hög',
     })
+  })
+
+  it('creates an identity from report item fields when a code exists', () => {
+    expect(
+      createReportPriorityIdentityFromItem({
+        priorityLevelCode: 'P1',
+        priorityLevelColor: '#FDE047',
+        priorityLevelIconName: 'CircleAlert',
+        priorityLevelNameEn: 'Critical',
+        priorityLevelNameSv: 'Kritisk',
+      }),
+    ).toEqual({
+      code: 'P1',
+      color: '#fde047',
+      iconName: 'CircleAlert',
+      nameEn: 'Critical',
+      nameSv: 'Kritisk',
+    })
+    expect(
+      createReportPriorityIdentityFromItem({
+        priorityLevelCode: null,
+        priorityLevelColor: null,
+        priorityLevelIconName: null,
+        priorityLevelNameEn: null,
+        priorityLevelNameSv: null,
+      }),
+    ).toBeNull()
   })
 
   it('formats code and localized name without a dangling separator', () => {

--- a/lib/dal/requirements-specifications.ts
+++ b/lib/dal/requirements-specifications.ts
@@ -53,6 +53,9 @@ export interface TraceabilityReportItem {
   kind: SpecificationItemKind
   needsReference: string | null
   note: string | null
+  priorityLevelCode: string | null
+  priorityLevelColor: string | null
+  priorityLevelIconName: string | null
   priorityLevelNameEn: string | null
   priorityLevelNameSv: string | null
   specificationItemStatusId: number | null
@@ -310,6 +313,9 @@ function mapTraceabilityReportRow(
     needsReference: toStr(row.needsReference),
     note: toStr(row.note),
     verifiable: toBool(row.verifiable),
+    priorityLevelCode: toStr(row.priorityLevelCode),
+    priorityLevelColor: toStr(row.priorityLevelColor),
+    priorityLevelIconName: toStr(row.priorityLevelIconName),
     priorityLevelNameEn: toStr(row.priorityLevelNameEn),
     priorityLevelNameSv: toStr(row.priorityLevelNameSv),
     specificationItemStatusId: toNum(row.specificationItemStatusId),
@@ -355,6 +361,9 @@ export async function listSpecificationTraceabilityItems(
           requirement_version.version_number AS versionNumber,
           requirement_version.is_verifiable AS verifiable,
           requirement_version.verification_method AS verificationMethod,
+          priority_level.code AS priorityLevelCode,
+          priority_level.color AS priorityLevelColor,
+          priority_level.icon_name AS priorityLevelIconName,
           priority_level.name_en AS priorityLevelNameEn,
           priority_level.name_sv AS priorityLevelNameSv,
           needs_reference.text AS needsReference,
@@ -418,6 +427,9 @@ export async function listSpecificationTraceabilityItems(
           CAST(NULL AS nvarchar(450)) AS areaName,
           local_requirement.is_verifiable AS verifiable,
           local_requirement.verification_method AS verificationMethod,
+          priority_level.code AS priorityLevelCode,
+          priority_level.color AS priorityLevelColor,
+          priority_level.icon_name AS priorityLevelIconName,
           priority_level.name_en AS priorityLevelNameEn,
           priority_level.name_sv AS priorityLevelNameSv,
           needs_reference.text AS needsReference,

--- a/lib/pdf/report-worker-entry.ts
+++ b/lib/pdf/report-worker-entry.ts
@@ -5,6 +5,10 @@ import { parentPort, workerData } from 'node:worker_threads'
 import { renderToStream } from '@react-pdf/renderer'
 import { createElement, type ReactElement } from 'react'
 import PdfReportRenderer from '@/components/reports/pdf/PdfReportRenderer'
+import {
+  collectStatusIconNames,
+  preloadStatusIconNodes,
+} from '@/lib/icons/status-icon-allowlist'
 import type { ReportModel } from '@/lib/reports/types'
 
 interface PdfReportWorkerData {
@@ -22,6 +26,7 @@ class PdfByteLimitError extends Error {}
 
 async function renderReport(): Promise<void> {
   const data = workerData as PdfReportWorkerData
+  await preloadStatusIconNodes(collectStatusIconNames(data.model))
   const document = createElement(PdfReportRenderer, {
     locale: data.locale,
     model: data.model,

--- a/lib/reports/data/fetch-deviation.ts
+++ b/lib/reports/data/fetch-deviation.ts
@@ -17,6 +17,7 @@ export interface DeviationReportVersion {
   description: string | null
   normReferences: { name: string; reference: string; uri: string | null }[]
   priorityLevel: {
+    code: string
     color: string | null
     iconName: string | null
     nameEn: string
@@ -79,6 +80,7 @@ export async function fetchDeviationForReport(
       } | null
       verifiable: boolean
       priorityLevel: {
+        code: string
         color: string | null
         iconName: string | null
         id: number
@@ -173,6 +175,7 @@ export async function fetchDeviationForReport(
         : null,
       priorityLevel: version.priorityLevel
         ? {
+            code: version.priorityLevel.code,
             color: version.priorityLevel.color,
             iconName: version.priorityLevel.iconName,
             nameEn: version.priorityLevel.nameEn,

--- a/lib/reports/data/fetch-requirement.ts
+++ b/lib/reports/data/fetch-requirement.ts
@@ -11,6 +11,7 @@ export interface RequirementReportVersion {
   editedAt: string | null
   id: number
   priorityLevel: {
+    code: string
     color?: string | null
     iconName?: string | null
     id: number

--- a/lib/reports/data/server.ts
+++ b/lib/reports/data/server.ts
@@ -192,6 +192,7 @@ function mapDeviationVersion(
     verifiable: version.verifiable,
     priorityLevel: version.priorityLevel
       ? {
+          code: version.priorityLevel.code,
           color: version.priorityLevel.color ?? null,
           iconName: version.priorityLevel.iconName ?? null,
           nameEn: version.priorityLevel.nameEn,

--- a/lib/reports/data/specification-output.ts
+++ b/lib/reports/data/specification-output.ts
@@ -34,6 +34,9 @@ export interface SpecificationOutputItem {
   kind: 'library' | 'specificationLocal'
   needsReference: string | null
   normReferences: SpecificationOutputNormReference[]
+  priorityLevelCode: string | null
+  priorityLevelColor: string | null
+  priorityLevelIconName: string | null
   priorityLevelNameEn: string | null
   priorityLevelNameSv: string | null
   qualityCharacteristicChapterId: string | null
@@ -269,6 +272,9 @@ function mapLibraryItem(row: Row): SpecificationOutputItem {
     qualityCharacteristicNameSv: toStr(row.qualityCharacteristicNameSv),
     requirementPackageNames: [],
     verifiable: toBool(row.verifiable),
+    priorityLevelCode: toStr(row.priorityLevelCode),
+    priorityLevelColor: toStr(row.priorityLevelColor),
+    priorityLevelIconName: toStr(row.priorityLevelIconName),
     priorityLevelNameEn: toStr(row.priorityLevelNameEn),
     priorityLevelNameSv: toStr(row.priorityLevelNameSv),
     specificationItemStatusId: toNum(row.specificationItemStatusId),
@@ -301,6 +307,9 @@ function mapLocalItem(row: Row): SpecificationOutputItem {
     qualityCharacteristicNameSv: toStr(row.qualityCharacteristicNameSv),
     requirementPackageNames: [],
     verifiable: toBool(row.verifiable),
+    priorityLevelCode: toStr(row.priorityLevelCode),
+    priorityLevelColor: toStr(row.priorityLevelColor),
+    priorityLevelIconName: toStr(row.priorityLevelIconName),
     priorityLevelNameEn: toStr(row.priorityLevelNameEn),
     priorityLevelNameSv: toStr(row.priorityLevelNameSv),
     specificationItemStatusId: toNum(row.specificationItemStatusId),
@@ -350,6 +359,9 @@ async function collectSpecificationOutputPage(
           quality_characteristic.name_en AS qualityCharacteristicNameEn,
           quality_characteristic.name_sv AS qualityCharacteristicNameSv,
           quality_characteristic.chapter_id AS qualityCharacteristicChapterId,
+          priority_level.code AS priorityLevelCode,
+          priority_level.color AS priorityLevelColor,
+          priority_level.icon_name AS priorityLevelIconName,
           priority_level.name_en AS priorityLevelNameEn,
           priority_level.name_sv AS priorityLevelNameSv,
           needs_reference.text AS needsReference,
@@ -398,6 +410,9 @@ async function collectSpecificationOutputPage(
           quality_characteristic.name_en AS qualityCharacteristicNameEn,
           quality_characteristic.name_sv AS qualityCharacteristicNameSv,
           quality_characteristic.chapter_id AS qualityCharacteristicChapterId,
+          priority_level.code AS priorityLevelCode,
+          priority_level.color AS priorityLevelColor,
+          priority_level.icon_name AS priorityLevelIconName,
           priority_level.name_en AS priorityLevelNameEn,
           priority_level.name_sv AS priorityLevelNameSv,
           needs_reference.text AS needsReference,

--- a/lib/reports/priority.ts
+++ b/lib/reports/priority.ts
@@ -20,6 +20,14 @@ interface PriorityIdentityInput {
   nameSv?: string | null
 }
 
+interface PriorityIdentityItemInput {
+  priorityLevelCode: string | null
+  priorityLevelColor: string | null
+  priorityLevelIconName: string | null
+  priorityLevelNameEn: string | null
+  priorityLevelNameSv: string | null
+}
+
 export interface PdfPriorityColors {
   background: string
   foreground: string
@@ -36,6 +44,19 @@ export function createReportPriorityIdentity(
     nameEn: input.nameEn?.trim() ?? '',
     nameSv: input.nameSv?.trim() ?? '',
   }
+}
+
+export function createReportPriorityIdentityFromItem(
+  item: PriorityIdentityItemInput,
+): ReportPriorityIdentity | null {
+  if (!item.priorityLevelCode) return null
+  return createReportPriorityIdentity({
+    code: item.priorityLevelCode,
+    color: item.priorityLevelColor,
+    iconName: item.priorityLevelIconName,
+    nameEn: item.priorityLevelNameEn,
+    nameSv: item.priorityLevelNameSv,
+  })
 }
 
 export function formatReportPriorityLabel(

--- a/lib/reports/priority.ts
+++ b/lib/reports/priority.ts
@@ -1,0 +1,82 @@
+import {
+  clampForReadability,
+  compositeHexColors,
+  isStrictHexColor,
+} from '@/lib/color-contrast'
+import { isStatusIconName } from '@/lib/icons/status-icon-allowlist'
+import { localizeReportValue } from '@/lib/reports/report-labels'
+import type { ReportPriorityIdentity } from '@/lib/reports/types'
+
+const PDF_PAGE_BACKGROUND = '#ffffff'
+const PDF_NEUTRAL_BADGE_BACKGROUND = '#f1f5f9'
+const PDF_NEUTRAL_FOREGROUND = '#475569'
+const PDF_BADGE_TINT_OPACITY = 0.125
+
+interface PriorityIdentityInput {
+  code: string
+  color?: string | null
+  iconName?: string | null
+  nameEn?: string | null
+  nameSv?: string | null
+}
+
+export interface PdfPriorityColors {
+  background: string
+  foreground: string
+}
+
+export function createReportPriorityIdentity(
+  input: PriorityIdentityInput,
+): ReportPriorityIdentity {
+  const color = input.color?.trim() ?? ''
+  return {
+    code: input.code.trim(),
+    color: isStrictHexColor(color) ? color.toLowerCase() : null,
+    iconName: isStatusIconName(input.iconName) ? input.iconName : null,
+    nameEn: input.nameEn?.trim() ?? '',
+    nameSv: input.nameSv?.trim() ?? '',
+  }
+}
+
+export function formatReportPriorityLabel(
+  priority: ReportPriorityIdentity | null,
+  locale: string,
+): string | null {
+  if (!priority) return null
+  const name = localizeReportValue(locale, priority.nameSv, priority.nameEn)
+  const parts = [priority.code, name].filter(Boolean)
+  return parts.length > 0 ? parts.join(' – ') : null
+}
+
+export function getPdfPriorityColors(
+  accent: string | null,
+  backdrop: string,
+  variant: 'badge' | 'inline',
+): PdfPriorityColors {
+  const safeBackdrop = isStrictHexColor(backdrop)
+    ? backdrop.toLowerCase()
+    : PDF_PAGE_BACKGROUND
+  const safeAccent = accent && isStrictHexColor(accent) ? accent : null
+
+  if (!safeAccent) {
+    const background =
+      variant === 'badge' && safeBackdrop === PDF_PAGE_BACKGROUND
+        ? PDF_NEUTRAL_BADGE_BACKGROUND
+        : safeBackdrop
+    return {
+      background,
+      foreground: clampForReadability(PDF_NEUTRAL_FOREGROUND, background),
+    }
+  }
+
+  const background =
+    variant === 'badge'
+      ? (compositeHexColors(safeAccent, safeBackdrop, PDF_BADGE_TINT_OPACITY) ??
+        safeBackdrop)
+      : safeBackdrop
+
+  return {
+    background,
+    foreground: clampForReadability(safeAccent, background),
+  }
+}

--- a/lib/reports/templates/deviation-review-template.ts
+++ b/lib/reports/templates/deviation-review-template.ts
@@ -1,4 +1,5 @@
 import type { DeviationReportData } from '../data/fetch-deviation'
+import { createReportPriorityIdentity } from '../priority'
 import { formatReportTemplate, getReportLabels } from '../report-labels'
 import type { ReportModel, ReportSection, VersionSummaryData } from '../types'
 
@@ -31,6 +32,9 @@ export function buildDeviationReviewReport(
 
   // Requirement version connected to the specification — blue border
   const v = data.version
+  const priorityLevel = v.priorityLevel
+    ? createReportPriorityIdentity(v.priorityLevel)
+    : null
   const versionSummary: VersionSummaryData = {
     versionNumber: v.versionNumber,
     description: v.description,
@@ -40,7 +44,7 @@ export function buildDeviationReviewReport(
     category: v.category,
     type: v.type,
     qualityCharacteristic: v.qualityCharacteristic,
-    priorityLevel: v.priorityLevel,
+    priorityLevel,
     status: v.status,
     createdBy: v.createdBy,
     createdAt: '',
@@ -70,7 +74,7 @@ export function buildDeviationReviewReport(
     createdAt: data.deviation.createdAt,
     specificationName: data.specificationName,
     specificationCode: data.specificationCode,
-    priorityLevel: v.priorityLevel,
+    priorityLevel,
     locale,
   })
 

--- a/lib/reports/templates/history-template.ts
+++ b/lib/reports/templates/history-template.ts
@@ -4,6 +4,7 @@ import {
 } from '@/lib/requirements/lifecycle'
 import type { RequirementReportData } from '../data/fetch-requirement'
 import { requirementPackageName } from '../package-name'
+import { createReportPriorityIdentity } from '../priority'
 import {
   formatReportTemplate,
   getReportLabels,
@@ -55,12 +56,7 @@ function toVersionSummary(
         }
       : null,
     priorityLevel: version.priorityLevel
-      ? {
-          nameSv: version.priorityLevel.nameSv,
-          nameEn: version.priorityLevel.nameEn,
-          color: version.priorityLevel.color,
-          iconName: version.priorityLevel.iconName,
-        }
+      ? createReportPriorityIdentity(version.priorityLevel)
       : null,
     status: {
       label: getStatusLabel(version, locale, labels),

--- a/lib/reports/templates/history-template.ts
+++ b/lib/reports/templates/history-template.ts
@@ -3,20 +3,14 @@ import {
   isRequirementPublishedStatus,
 } from '@/lib/requirements/lifecycle'
 import type { RequirementReportData } from '../data/fetch-requirement'
-import { requirementPackageName } from '../package-name'
-import { createReportPriorityIdentity } from '../priority'
 import {
   formatReportTemplate,
   getReportLabels,
   localizeReportValue,
   type ReportLabels,
 } from '../report-labels'
-import type {
-  ReportModel,
-  ReportSection,
-  TimelineEntryData,
-  VersionSummaryData,
-} from '../types'
+import type { ReportModel, ReportSection, TimelineEntryData } from '../types'
+import { createReportVersionSummary } from '../version-summary'
 
 function getStatusLabel(
   version: RequirementReportData['versions'][number],
@@ -27,65 +21,6 @@ function getStatusLabel(
     localizeReportValue(locale, version.statusNameSv, version.statusNameEn) ||
     labels.common.unknown
   )
-}
-
-function toVersionSummary(
-  version: RequirementReportData['versions'][number],
-  locale: string,
-  labels: ReportLabels,
-): VersionSummaryData {
-  return {
-    versionNumber: version.versionNumber,
-    description: version.description,
-    acceptanceCriteria: version.acceptanceCriteria,
-    verifiable: version.verifiable,
-    verificationMethod: version.verificationMethod,
-    category: version.category
-      ? {
-          nameSv: version.category.nameSv,
-          nameEn: version.category.nameEn,
-        }
-      : null,
-    type: version.type
-      ? { nameSv: version.type.nameSv, nameEn: version.type.nameEn }
-      : null,
-    qualityCharacteristic: version.qualityCharacteristic
-      ? {
-          nameSv: version.qualityCharacteristic.nameSv,
-          nameEn: version.qualityCharacteristic.nameEn,
-        }
-      : null,
-    priorityLevel: version.priorityLevel
-      ? createReportPriorityIdentity(version.priorityLevel)
-      : null,
-    status: {
-      label: getStatusLabel(version, locale, labels),
-      color: version.statusColor,
-      iconName: version.statusIconName,
-    },
-    createdBy: version.createdBy,
-    createdAt: version.createdAt,
-    editedAt: version.editedAt,
-    publishedAt: version.publishedAt,
-    archivedAt: version.archivedAt,
-    normReferences: version.versionNormReferences
-      .filter(vnr => vnr.normReference)
-      .map(vnr => ({
-        name: vnr.normReference.name,
-        reference: vnr.normReference.reference,
-        uri: vnr.normReference.uri,
-      })),
-    requirementPackages: version.versionRequirementPackages.flatMap(vs => {
-      const requirementPackage = vs.requirementPackage
-      const name = requirementPackageName(requirementPackage).trim()
-      if (!name) return []
-      return [
-        {
-          name,
-        },
-      ]
-    }),
-  }
 }
 
 function toTimelineEntry(
@@ -141,7 +76,10 @@ export function buildHistoryReport(
   if (publishedVersion) {
     sections.push({
       type: 'version-summary',
-      version: toVersionSummary(publishedVersion, locale, labels),
+      version: createReportVersionSummary(
+        publishedVersion,
+        getStatusLabel(publishedVersion, locale, labels),
+      ),
       label: labels.common.currentPublishedVersion,
     })
   }
@@ -149,7 +87,10 @@ export function buildHistoryReport(
   for (const version of unpublishedVersions) {
     sections.push({
       type: 'version-summary',
-      version: toVersionSummary(version, locale, labels),
+      version: createReportVersionSummary(
+        version,
+        getStatusLabel(version, locale, labels),
+      ),
       label: formatReportTemplate(labels.common.unpublishedVersion, {
         version: version.versionNumber,
       }),

--- a/lib/reports/templates/review-template.ts
+++ b/lib/reports/templates/review-template.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/requirements/lifecycle'
 import type { RequirementReportData } from '../data/fetch-requirement'
 import { requirementPackageName } from '../package-name'
+import { createReportPriorityIdentity } from '../priority'
 import {
   formatReportBoolean,
   formatReportTemplate,
@@ -98,12 +99,7 @@ function toVersionSummary(
         }
       : null,
     priorityLevel: version.priorityLevel
-      ? {
-          nameSv: version.priorityLevel.nameSv,
-          nameEn: version.priorityLevel.nameEn,
-          color: version.priorityLevel.color,
-          iconName: version.priorityLevel.iconName,
-        }
+      ? createReportPriorityIdentity(version.priorityLevel)
       : null,
     status: {
       label: getStatusLabel(version, locale, labels),
@@ -169,13 +165,17 @@ function computeMetadataChanges(
     })
   }
 
-  const oldRl = getName(baseVersion.priorityLevel, locale)
-  const newRl = getName(reviewVersion.priorityLevel, locale)
-  if (oldRl !== newRl) {
+  const oldPriorityId = baseVersion.priorityLevel?.id ?? null
+  const newPriorityId = reviewVersion.priorityLevel?.id ?? null
+  if (oldPriorityId !== newPriorityId) {
     changes.push({
       field: labels.columns.priorityLevel,
-      oldValue: oldRl,
-      newValue: newRl,
+      oldValue: baseVersion.priorityLevel
+        ? createReportPriorityIdentity(baseVersion.priorityLevel)
+        : null,
+      newValue: reviewVersion.priorityLevel
+        ? createReportPriorityIdentity(reviewVersion.priorityLevel)
+        : null,
     })
   }
 

--- a/lib/reports/templates/review-template.ts
+++ b/lib/reports/templates/review-template.ts
@@ -15,12 +15,8 @@ import {
   type ReportLabels,
 } from '../report-labels'
 import { diffText } from '../text-diff'
-import type {
-  MetadataChange,
-  ReportModel,
-  ReportSection,
-  VersionSummaryData,
-} from '../types'
+import type { MetadataChange, ReportModel, ReportSection } from '../types'
+import { createReportVersionSummary } from '../version-summary'
 
 type LocalizedNameItem = {
   nameSv: string | null
@@ -70,61 +66,6 @@ function collectPackageIds(
     .filter((id): id is number => Number.isInteger(id))
     .sort((a, b) => a - b)
     .join(',')
-}
-
-function toVersionSummary(
-  version: RequirementReportData['versions'][number],
-  locale: string,
-  labels: ReportLabels,
-): VersionSummaryData {
-  return {
-    versionNumber: version.versionNumber,
-    description: version.description,
-    acceptanceCriteria: version.acceptanceCriteria,
-    verifiable: version.verifiable,
-    verificationMethod: version.verificationMethod,
-    category: version.category
-      ? {
-          nameSv: version.category.nameSv,
-          nameEn: version.category.nameEn,
-        }
-      : null,
-    type: version.type
-      ? { nameSv: version.type.nameSv, nameEn: version.type.nameEn }
-      : null,
-    qualityCharacteristic: version.qualityCharacteristic
-      ? {
-          nameSv: version.qualityCharacteristic.nameSv,
-          nameEn: version.qualityCharacteristic.nameEn,
-        }
-      : null,
-    priorityLevel: version.priorityLevel
-      ? createReportPriorityIdentity(version.priorityLevel)
-      : null,
-    status: {
-      label: getStatusLabel(version, locale, labels),
-      color: version.statusColor,
-      iconName: version.statusIconName,
-    },
-    createdBy: version.createdBy,
-    createdAt: version.createdAt,
-    editedAt: version.editedAt,
-    publishedAt: version.publishedAt,
-    archivedAt: version.archivedAt,
-    normReferences: version.versionNormReferences
-      .filter(vnr => vnr.normReference)
-      .map(vnr => ({
-        name: vnr.normReference.name,
-        reference: vnr.normReference.reference,
-        uri: vnr.normReference.uri,
-      })),
-    requirementPackages: version.versionRequirementPackages.flatMap(
-      ({ requirementPackage }) => {
-        const name = requirementPackageName(requirementPackage).trim()
-        return name ? [{ name }] : []
-      },
-    ),
-  }
 }
 
 function computeMetadataChanges(
@@ -296,7 +237,10 @@ export function buildReviewReport(
     }
     sections.push({
       type: 'version-summary',
-      version: toVersionSummary(reviewVersion, locale, labels),
+      version: createReportVersionSummary(
+        reviewVersion,
+        getStatusLabel(reviewVersion, locale, labels),
+      ),
       label: formatReportTemplate(labels.common.reviewVersion, {
         version: reviewVersion.versionNumber,
       }),

--- a/lib/reports/templates/specification-profile-template.ts
+++ b/lib/reports/templates/specification-profile-template.ts
@@ -1,4 +1,5 @@
 import type { SpecificationOutputData } from '@/lib/reports/data/specification-output'
+import { createReportPriorityIdentity } from '@/lib/reports/priority'
 import {
   formatReportBoolean,
   formatRequirementCount,
@@ -161,6 +162,15 @@ function buildProgressRow(
 ): RequirementTableRow {
   const labels = getReportLabels(locale)
   return {
+    priorityLevel: item.priorityLevelCode
+      ? createReportPriorityIdentity({
+          code: item.priorityLevelCode,
+          color: item.priorityLevelColor,
+          iconName: item.priorityLevelIconName,
+          nameEn: item.priorityLevelNameEn,
+          nameSv: item.priorityLevelNameSv,
+        })
+      : null,
     cells: {
       area: formatArea(item, labels),
       category: localizeReportValue(
@@ -176,11 +186,6 @@ function buildProgressRow(
         locale,
         item.statusNameSv,
         item.statusNameEn,
-      ),
-      priorityLevel: localizeReportValue(
-        locale,
-        item.priorityLevelNameSv,
-        item.priorityLevelNameEn,
       ),
       type: localizeReportValue(locale, item.typeNameSv, item.typeNameEn),
       uniqueId: item.uniqueId,

--- a/lib/reports/templates/specification-profile-template.ts
+++ b/lib/reports/templates/specification-profile-template.ts
@@ -1,5 +1,5 @@
 import type { SpecificationOutputData } from '@/lib/reports/data/specification-output'
-import { createReportPriorityIdentity } from '@/lib/reports/priority'
+import { createReportPriorityIdentityFromItem } from '@/lib/reports/priority'
 import {
   formatReportBoolean,
   formatRequirementCount,
@@ -162,15 +162,7 @@ function buildProgressRow(
 ): RequirementTableRow {
   const labels = getReportLabels(locale)
   return {
-    priorityLevel: item.priorityLevelCode
-      ? createReportPriorityIdentity({
-          code: item.priorityLevelCode,
-          color: item.priorityLevelColor,
-          iconName: item.priorityLevelIconName,
-          nameEn: item.priorityLevelNameEn,
-          nameSv: item.priorityLevelNameSv,
-        })
-      : null,
+    priorityLevel: createReportPriorityIdentityFromItem(item),
     cells: {
       area: formatArea(item, labels),
       category: localizeReportValue(

--- a/lib/reports/templates/specification-traceability-template.ts
+++ b/lib/reports/templates/specification-traceability-template.ts
@@ -1,5 +1,6 @@
 import type { TraceabilityReportItem } from '@/lib/dal/requirements-specifications'
 import type { SpecificationTraceabilityData } from '@/lib/reports/data/specification-traceability'
+import { createReportPriorityIdentity } from '@/lib/reports/priority'
 import {
   formatReportBoolean,
   formatReportTemplate,
@@ -63,17 +64,6 @@ function formatUsageStatus(
     locale,
     item.specificationItemStatusNameSv,
     item.specificationItemStatusNameEn,
-  )
-}
-
-function formatPriorityLevel(
-  item: TraceabilityReportItem,
-  locale: string,
-): string {
-  return localizeReportValue(
-    locale,
-    item.priorityLevelNameSv,
-    item.priorityLevelNameEn,
   )
 }
 
@@ -225,7 +215,15 @@ function buildTableSection(
       note: item.note ?? '',
       origin: formatOrigin(item, locale),
       requirementId: item.uniqueId,
-      priorityLevel: formatPriorityLevel(item, locale),
+      priorityLevel: item.priorityLevelCode
+        ? createReportPriorityIdentity({
+            code: item.priorityLevelCode,
+            color: item.priorityLevelColor,
+            iconName: item.priorityLevelIconName,
+            nameEn: item.priorityLevelNameEn,
+            nameSv: item.priorityLevelNameSv,
+          })
+        : null,
       statusChangedAt: formatDate(item.statusUpdatedAt, locale),
       usageStatus: formatUsageStatus(item, locale),
       verification: formatVerification(item, locale),

--- a/lib/reports/templates/specification-traceability-template.ts
+++ b/lib/reports/templates/specification-traceability-template.ts
@@ -1,6 +1,6 @@
 import type { TraceabilityReportItem } from '@/lib/dal/requirements-specifications'
 import type { SpecificationTraceabilityData } from '@/lib/reports/data/specification-traceability'
-import { createReportPriorityIdentity } from '@/lib/reports/priority'
+import { createReportPriorityIdentityFromItem } from '@/lib/reports/priority'
 import {
   formatReportBoolean,
   formatReportTemplate,
@@ -215,15 +215,7 @@ function buildTableSection(
       note: item.note ?? '',
       origin: formatOrigin(item, locale),
       requirementId: item.uniqueId,
-      priorityLevel: item.priorityLevelCode
-        ? createReportPriorityIdentity({
-            code: item.priorityLevelCode,
-            color: item.priorityLevelColor,
-            iconName: item.priorityLevelIconName,
-            nameEn: item.priorityLevelNameEn,
-            nameSv: item.priorityLevelNameSv,
-          })
-        : null,
+      priorityLevel: createReportPriorityIdentityFromItem(item),
       statusChangedAt: formatDate(item.statusUpdatedAt, locale),
       usageStatus: formatUsageStatus(item, locale),
       verification: formatVerification(item, locale),

--- a/lib/reports/templates/suggestion-history-template.ts
+++ b/lib/reports/templates/suggestion-history-template.ts
@@ -8,6 +8,7 @@ import type {
   SuggestionReportRow,
 } from '../data/fetch-requirement'
 import { requirementPackageName } from '../package-name'
+import { createReportPriorityIdentity } from '../priority'
 import {
   formatReportTemplate,
   getReportLabels,
@@ -59,12 +60,7 @@ function toVersionSummary(
         }
       : null,
     priorityLevel: version.priorityLevel
-      ? {
-          nameSv: version.priorityLevel.nameSv,
-          nameEn: version.priorityLevel.nameEn,
-          color: version.priorityLevel.color,
-          iconName: version.priorityLevel.iconName,
-        }
+      ? createReportPriorityIdentity(version.priorityLevel)
       : null,
     status: {
       label: getStatusLabel(version, locale, labels),

--- a/lib/reports/templates/suggestion-history-template.ts
+++ b/lib/reports/templates/suggestion-history-template.ts
@@ -7,20 +7,14 @@ import type {
   RequirementReportData,
   SuggestionReportRow,
 } from '../data/fetch-requirement'
-import { requirementPackageName } from '../package-name'
-import { createReportPriorityIdentity } from '../priority'
 import {
   formatReportTemplate,
   getReportLabels,
   localizeReportValue,
   type ReportLabels,
 } from '../report-labels'
-import type {
-  ReportModel,
-  ReportSection,
-  SuggestionReportItem,
-  VersionSummaryData,
-} from '../types'
+import type { ReportModel, ReportSection, SuggestionReportItem } from '../types'
+import { createReportVersionSummary } from '../version-summary'
 
 const SUGGESTION_RESOLVED = 1
 const SUGGESTION_DISMISSED = 2
@@ -34,56 +28,6 @@ function getStatusLabel(
     localizeReportValue(locale, version.statusNameSv, version.statusNameEn) ||
     labels.common.unknown
   )
-}
-
-function toVersionSummary(
-  version: RequirementReportData['versions'][number],
-  locale: string,
-  labels: ReportLabels,
-): VersionSummaryData {
-  return {
-    versionNumber: version.versionNumber,
-    description: version.description,
-    acceptanceCriteria: version.acceptanceCriteria,
-    verifiable: version.verifiable,
-    verificationMethod: version.verificationMethod,
-    category: version.category
-      ? { nameSv: version.category.nameSv, nameEn: version.category.nameEn }
-      : null,
-    type: version.type
-      ? { nameSv: version.type.nameSv, nameEn: version.type.nameEn }
-      : null,
-    qualityCharacteristic: version.qualityCharacteristic
-      ? {
-          nameSv: version.qualityCharacteristic.nameSv,
-          nameEn: version.qualityCharacteristic.nameEn,
-        }
-      : null,
-    priorityLevel: version.priorityLevel
-      ? createReportPriorityIdentity(version.priorityLevel)
-      : null,
-    status: {
-      label: getStatusLabel(version, locale, labels),
-      color: version.statusColor,
-      iconName: version.statusIconName,
-    },
-    createdBy: version.createdBy,
-    createdAt: version.createdAt,
-    editedAt: version.editedAt,
-    publishedAt: version.publishedAt,
-    archivedAt: version.archivedAt,
-    normReferences: version.versionNormReferences
-      .filter(vnr => vnr.normReference)
-      .map(vnr => ({
-        name: vnr.normReference.name,
-        reference: vnr.normReference.reference,
-        uri: vnr.normReference.uri,
-      })),
-    requirementPackages: version.versionRequirementPackages.flatMap(vs => {
-      const name = requirementPackageName(vs.requirementPackage).trim()
-      return name ? [{ name }] : []
-    }),
-  }
 }
 
 function getSuggestionStatus(
@@ -175,7 +119,10 @@ export function buildSuggestionHistoryReport(
 
     sections.push({
       type: 'version-summary',
-      version: toVersionSummary(version, locale, labels),
+      version: createReportVersionSummary(
+        version,
+        getStatusLabel(version, locale, labels),
+      ),
       label: formatReportTemplate(labels.common.version, {
         version: version.versionNumber,
       }),

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -3,6 +3,14 @@ export interface DiffSegment {
   type: 'added' | 'removed' | 'unchanged'
 }
 
+export interface ReportPriorityIdentity {
+  code: string
+  color: string | null
+  iconName: string | null
+  nameEn: string
+  nameSv: string
+}
+
 export interface VersionSummaryData {
   acceptanceCriteria: string | null
   archivedAt: string | null
@@ -12,12 +20,7 @@ export interface VersionSummaryData {
   description: string | null
   editedAt: string | null
   normReferences: { name: string; reference: string; uri: string | null }[]
-  priorityLevel: {
-    color?: string | null
-    iconName?: string | null
-    nameSv: string
-    nameEn: string
-  } | null
+  priorityLevel: ReportPriorityIdentity | null
   publishedAt: string | null
   qualityCharacteristic: { nameSv: string; nameEn: string } | null
   requirementPackages: { name: string }[]
@@ -30,8 +33,8 @@ export interface VersionSummaryData {
 
 export interface MetadataChange {
   field: string
-  newValue: string | null
-  oldValue: string | null
+  newValue: ReportPriorityIdentity | string | null
+  oldValue: ReportPriorityIdentity | string | null
 }
 
 export interface SuggestionReportItem {
@@ -55,7 +58,7 @@ export interface TraceabilityReportRow {
   needsReference: string
   note: string
   origin: string
-  priorityLevel: string
+  priorityLevel: ReportPriorityIdentity | null
   requirementId: string
   statusChangedAt: string
   usageStatus: string
@@ -111,6 +114,7 @@ export type ReportSection =
       columns: { key: string; label: string; width?: string }[]
       rows: {
         cells: Record<string, string>
+        priorityLevel?: ReportPriorityIdentity | null
         statusColor?: string | null
         statusIconName?: string | null
       }[]
@@ -165,12 +169,7 @@ export type ReportSection =
       createdAt: string
       specificationName: string | null
       specificationCode: string | null
-      priorityLevel: {
-        color?: string | null
-        iconName?: string | null
-        nameSv: string
-        nameEn: string
-      } | null
+      priorityLevel: ReportPriorityIdentity | null
       locale: string
     }
   | {

--- a/lib/reports/version-summary.ts
+++ b/lib/reports/version-summary.ts
@@ -1,0 +1,58 @@
+import type { RequirementReportData } from '@/lib/reports/data/fetch-requirement'
+import { requirementPackageName } from '@/lib/reports/package-name'
+import { createReportPriorityIdentity } from '@/lib/reports/priority'
+import type { VersionSummaryData } from '@/lib/reports/types'
+
+export function createReportVersionSummary(
+  version: RequirementReportData['versions'][number],
+  statusLabel: string,
+): VersionSummaryData {
+  return {
+    versionNumber: version.versionNumber,
+    description: version.description,
+    acceptanceCriteria: version.acceptanceCriteria,
+    verifiable: version.verifiable,
+    verificationMethod: version.verificationMethod,
+    category: version.category
+      ? {
+          nameSv: version.category.nameSv,
+          nameEn: version.category.nameEn,
+        }
+      : null,
+    type: version.type
+      ? { nameSv: version.type.nameSv, nameEn: version.type.nameEn }
+      : null,
+    qualityCharacteristic: version.qualityCharacteristic
+      ? {
+          nameSv: version.qualityCharacteristic.nameSv,
+          nameEn: version.qualityCharacteristic.nameEn,
+        }
+      : null,
+    priorityLevel: version.priorityLevel
+      ? createReportPriorityIdentity(version.priorityLevel)
+      : null,
+    status: {
+      label: statusLabel,
+      color: version.statusColor,
+      iconName: version.statusIconName,
+    },
+    createdBy: version.createdBy,
+    createdAt: version.createdAt,
+    editedAt: version.editedAt,
+    publishedAt: version.publishedAt,
+    archivedAt: version.archivedAt,
+    normReferences: version.versionNormReferences
+      .filter(vnr => vnr.normReference)
+      .map(vnr => ({
+        name: vnr.normReference.name,
+        reference: vnr.normReference.reference,
+        uri: vnr.normReference.uri,
+      })),
+    requirementPackages: version.versionRequirementPackages.flatMap(
+      ({ requirementPackage }) => {
+        const name = requirementPackageName(requirementPackage).trim()
+        return name ? [{ name }] : []
+      },
+    ),
+  }
+}

--- a/tests/integration/00-report-pdf/collaboration-report.spec.ts
+++ b/tests/integration/00-report-pdf/collaboration-report.spec.ts
@@ -10,6 +10,7 @@ import {
   type TestInfo,
   test,
 } from '@playwright/test'
+import { extractText } from 'unpdf'
 import { expectApiResponseOk } from '../api-response-assertions'
 import {
   getRequirementRowButton,
@@ -271,6 +272,11 @@ test('COL-06: opens the suggestion-history report for a requirement with suggest
     for await (const chunk of pdfStream) {
       chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
     }
-    expect(Buffer.concat(chunks).subarray(0, 4).toString('utf8')).toBe('%PDF')
+    const pdfBuffer = Buffer.concat(chunks)
+    expect(pdfBuffer.subarray(0, 4).toString('utf8')).toBe('%PDF')
+    const { text } = await extractText(new Uint8Array(pdfBuffer), {
+      mergePages: true,
+    })
+    expect(text.replace(/\s+/gu, ' ')).toContain('P2 – Låg')
   })
 })

--- a/tests/integration/00-report-pdf/collaboration-report.spec.ts
+++ b/tests/integration/00-report-pdf/collaboration-report.spec.ts
@@ -277,6 +277,6 @@ test('COL-06: opens the suggestion-history report for a requirement with suggest
     const { text } = await extractText(new Uint8Array(pdfBuffer), {
       mergePages: true,
     })
-    expect(text.replace(/\s+/gu, ' ')).toContain('P2 – Låg')
+    expect(text).toContain('P2 – Låg')
   })
 })

--- a/tests/integration/requirements/lifecycle.spec.ts
+++ b/tests/integration/requirements/lifecycle.spec.ts
@@ -288,12 +288,11 @@ async function verifyPdfDownload(
   const { text: pdfText } = await extractText(Uint8Array.from(pdfBuffer), {
     mergePages: true,
   })
-  const normalizedPdfText = pdfText.replace(/\s+/gu, ' ')
   for (const text of expectedText) {
-    expect(normalizedPdfText).toContain(text.replace(/\s+/gu, ' '))
+    expect(pdfText).toContain(text)
   }
   for (const text of unexpectedText) {
-    expect(normalizedPdfText).not.toContain(text.replace(/\s+/gu, ' '))
+    expect(pdfText).not.toContain(text)
   }
 }
 

--- a/tests/integration/requirements/lifecycle.spec.ts
+++ b/tests/integration/requirements/lifecycle.spec.ts
@@ -288,11 +288,12 @@ async function verifyPdfDownload(
   const { text: pdfText } = await extractText(Uint8Array.from(pdfBuffer), {
     mergePages: true,
   })
+  const normalizedPdfText = pdfText.replace(/\s+/gu, ' ')
   for (const text of expectedText) {
-    expect(pdfText).toContain(text)
+    expect(normalizedPdfText).toContain(text.replace(/\s+/gu, ' '))
   }
   for (const text of unexpectedText) {
-    expect(pdfText).not.toContain(text)
+    expect(normalizedPdfText).not.toContain(text.replace(/\s+/gu, ' '))
   }
 }
 
@@ -713,6 +714,9 @@ test.describe('Requirement lifecycle manual cases', () => {
           await page
             .getByRole('combobox', { name: 'Kategori' })
             .selectOption({ label: 'IT-krav' })
+          await page
+            .getByRole('combobox', { name: 'Prioritet' })
+            .selectOption('4')
 
           const saveButton = page.getByRole('button', { name: 'Spara' })
           await expect(saveButton).toBeEnabled()
@@ -852,6 +856,7 @@ test.describe('Requirement lifecycle manual cases', () => {
               requirement.uniqueId,
               'Metadata Changes',
               'Category',
+              'P4 – High',
               'Review',
             ],
             history: [
@@ -861,6 +866,7 @@ test.describe('Requirement lifecycle manual cases', () => {
               `Unpublished Version (v${reviewVersionNumber})`,
               'Category',
               'IT requirement',
+              'P4 – High',
               'Published',
               'Review',
             ],
@@ -870,6 +876,7 @@ test.describe('Requirement lifecycle manual cases', () => {
               'Metadata Changes',
               'Category',
               'IT requirement',
+              'P4 – High',
               'Review',
             ],
             unexpected: [],
@@ -898,6 +905,7 @@ test.describe('Requirement lifecycle manual cases', () => {
               requirement.uniqueId,
               'Metadataändringar',
               'Kategori',
+              'P4 – Hög',
               'Granskning',
             ],
             history: [
@@ -907,6 +915,7 @@ test.describe('Requirement lifecycle manual cases', () => {
               `Opublicerad version (v${reviewVersionNumber})`,
               'Kategori',
               'IT-krav',
+              'P4 – Hög',
               'Publicerad',
               'Granskning',
             ],
@@ -916,6 +925,7 @@ test.describe('Requirement lifecycle manual cases', () => {
               'Metadataändringar',
               'Kategori',
               'IT-krav',
+              'P4 – Hög',
               'Granskning',
             ],
             unexpected: [

--- a/tests/integration/specifications/requirement-detail.spec.ts
+++ b/tests/integration/specifications/requirement-detail.spec.ts
@@ -524,7 +524,16 @@ function reportTable(model: StructuredReportModel) {
   expect(table).toBeDefined()
   return table as {
     columns: Array<{ key: string }>
-    rows: Array<{ cells: Record<string, string> }>
+    rows: Array<{
+      cells: Record<string, string>
+      priorityLevel?: {
+        code: string
+        color: string | null
+        iconName: string | null
+        nameEn: string
+        nameSv: string
+      } | null
+    }>
     type: 'requirement-table'
   }
 }
@@ -2995,6 +3004,16 @@ test.describe('Requirements specification deterministic manual cases', () => {
         'usageStatus',
         'normReferences',
       ])
+      expect(progressTable.rows[0]).toMatchObject({
+        priorityLevel: {
+          code: 'P2',
+          color: '#22c55e',
+          iconName: 'ArrowDownLeft',
+          nameEn: 'Low',
+          nameSv: 'Låg',
+        },
+      })
+      expect(progressTable.rows[0]?.cells.priorityLevel).toBeUndefined()
 
       const exportMenu = await openActionMenu(page, 'Exportera')
       await expect(
@@ -3055,6 +3074,13 @@ test.describe('Requirements specification deterministic manual cases', () => {
       'residualFromImplementation',
     )
     expect(managementTable.rows.length).toBeGreaterThan(0)
+    expect(managementTable.rows[0]).toMatchObject({
+      priorityLevel: {
+        code: 'P2',
+        nameEn: 'Low',
+        nameSv: 'Låg',
+      },
+    })
   })
 
   test('SPEC-10e: generates complete server-filtered traceability beyond 100 items', async ({
@@ -3091,6 +3117,10 @@ test.describe('Requirements specification deterministic manual cases', () => {
       items?: Array<{
         itemRef: string
         needsReference: string | null
+        priorityLevelCode: string | null
+        priorityLevelColor: string | null
+        priorityLevelIconName: string | null
+        priorityLevelNameSv: string | null
         uniqueId: string
         verificationMethod: string | null
       }>
@@ -3111,6 +3141,12 @@ test.describe('Requirements specification deterministic manual cases', () => {
     })
     expect(traceabilityData.items?.[0]).toHaveProperty('needsReference')
     expect(traceabilityData.items?.[0]).toHaveProperty('verificationMethod')
+    expect(traceabilityData.items?.[0]).toMatchObject({
+      priorityLevelCode: 'P2',
+      priorityLevelColor: '#22c55e',
+      priorityLevelIconName: 'ArrowDownLeft',
+      priorityLevelNameSv: 'Låg',
+    })
 
     await gotoSpecificationDetail(page, 920006)
     const reportsMenu = await openActionMenu(page, 'Rapporter')

--- a/tests/unit/fetch-deviation-report.test.ts
+++ b/tests/unit/fetch-deviation-report.test.ts
@@ -73,4 +73,72 @@ describe('fetchDeviationForReport', () => {
 
     expect(result.version.requirementPackages).toEqual([{ name: 'Mobile use' }])
   })
+
+  it('keeps the complete priority identity from the requirement API', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: string | URL | Request) => {
+        if (String(input).includes('/api/requirements/42')) {
+          return okJson({
+            uniqueId: 'REQ-42',
+            versions: [
+              {
+                acceptanceCriteria: null,
+                category: null,
+                createdBy: null,
+                description: 'Deviation target',
+                id: 9,
+                priorityLevel: {
+                  code: 'P2',
+                  color: '#fde047',
+                  iconName: 'CircleAlert',
+                  id: 2,
+                  nameEn: 'High',
+                  nameSv: 'Hög',
+                },
+                qualityCharacteristic: null,
+                status: 3,
+                statusColor: null,
+                statusIconName: null,
+                statusNameEn: 'Published',
+                statusNameSv: 'Publicerad',
+                type: null,
+                verifiable: false,
+                verificationMethod: null,
+                versionNormReferences: [],
+                versionNumber: 1,
+                versionRequirementPackages: [],
+              },
+            ],
+          })
+        }
+
+        return okJson({
+          deviations: [
+            {
+              createdAt: '2026-05-02T00:00:00.000Z',
+              createdBy: 'reviewer',
+              decision: null,
+              id: 7,
+              isReviewRequested: 1,
+              motivation: 'Needs review',
+              requirementVersionId: 9,
+              specificationCode: 'SPEC',
+              specificationName: 'Spec',
+            },
+          ],
+        })
+      }),
+    )
+
+    const result = await fetchDeviationForReport(42, 77, 'en')
+
+    expect(result.version.priorityLevel).toEqual({
+      code: 'P2',
+      color: '#fde047',
+      iconName: 'CircleAlert',
+      nameEn: 'High',
+      nameSv: 'Hög',
+    })
+  })
 })

--- a/tests/unit/pdf-priority-layout.test.tsx
+++ b/tests/unit/pdf-priority-layout.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment node
+
+import { renderToBuffer } from '@react-pdf/renderer'
+import { extractText } from 'unpdf'
+import { describe, expect, it } from 'vitest'
+import PdfReportRenderer from '@/components/reports/pdf/PdfReportRenderer'
+import { preloadStatusIconNodes } from '@/lib/icons/status-icon-allowlist'
+import type { ReportModel } from '@/lib/reports/types'
+
+describe('PDF priority layout', () => {
+  it('keeps a short priority identity on one extracted line', async () => {
+    await preloadStatusIconNodes(['ArrowDownLeft'])
+    const model: ReportModel = {
+      sections: [
+        {
+          type: 'version-summary',
+          version: {
+            acceptanceCriteria: null,
+            archivedAt: null,
+            category: null,
+            createdAt: '2026-08-03T00:00:00.000Z',
+            createdBy: 'seed',
+            description: null,
+            editedAt: null,
+            normReferences: [],
+            priorityLevel: {
+              code: 'P2',
+              color: '#22c55e',
+              iconName: 'ArrowDownLeft',
+              nameEn: 'Low',
+              nameSv: 'Låg',
+            },
+            publishedAt: null,
+            qualityCharacteristic: null,
+            requirementPackages: [],
+            status: { color: null, label: 'Publicerad' },
+            type: { nameEn: 'Functional', nameSv: 'Funktionellt' },
+            verifiable: false,
+            verificationMethod: null,
+            versionNumber: 1,
+          },
+        },
+      ],
+    }
+
+    const buffer = await renderToBuffer(
+      <PdfReportRenderer locale="sv" model={model} />,
+    )
+    const { text } = await extractText(new Uint8Array(buffer), {
+      mergePages: true,
+    })
+
+    expect(text).toContain('P2 – Låg')
+  })
+})

--- a/tests/unit/pdf-priority-layout.test.tsx
+++ b/tests/unit/pdf-priority-layout.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { renderToBuffer } from '@react-pdf/renderer'
-import { extractText } from 'unpdf'
+import { extractTextItems } from 'unpdf'
 import { describe, expect, it } from 'vitest'
 import PdfReportRenderer from '@/components/reports/pdf/PdfReportRenderer'
 import { preloadStatusIconNodes } from '@/lib/icons/status-icon-allowlist'
@@ -46,10 +46,33 @@ describe('PDF priority layout', () => {
     const buffer = await renderToBuffer(
       <PdfReportRenderer locale="sv" model={model} />,
     )
-    const { text } = await extractText(new Uint8Array(buffer), {
-      mergePages: true,
-    })
+    const { items } = await extractTextItems(new Uint8Array(buffer))
+    const priorityTokens = ['P2', '–', 'Låg']
+    const priorityPage = items.find(pageItems =>
+      pageItems.some(item =>
+        priorityTokens.some(token => item.str.includes(token)),
+      ),
+    )
+    expect(priorityPage).toBeDefined()
+    const priorityItemIndexes = (priorityPage ?? []).flatMap((item, index) =>
+      priorityTokens.some(token => item.str.includes(token)) ? [index] : [],
+    )
+    const priorityItems = priorityItemIndexes.map(
+      index => (priorityPage ?? [])[index],
+    )
 
-    expect(text).toContain('P2 – Låg')
+    expect(
+      priorityItems.flatMap(item => item?.str.split(/\s+/u).filter(Boolean)),
+    ).toEqual(priorityTokens)
+    expect(new Set(priorityItems.map(item => item?.y)).size).toBe(1)
+    const firstPriorityIndex = priorityItemIndexes.at(0)
+    const lastPriorityIndex = priorityItemIndexes.at(-1)
+    expect(firstPriorityIndex).toBeDefined()
+    expect(lastPriorityIndex).toBeDefined()
+    expect(
+      (priorityPage ?? [])
+        .slice(firstPriorityIndex, lastPriorityIndex)
+        .some(item => item.hasEOL),
+    ).toBe(false)
   })
 })

--- a/tests/unit/pdf-report-renderer-localization.test.tsx
+++ b/tests/unit/pdf-report-renderer-localization.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import PdfReportRenderer, {
   formatTimelineDate,
 } from '@/components/reports/pdf/PdfReportRenderer'
+import { loadStatusIconNodes } from '@/lib/icons/status-icon-allowlist'
 import type { RequirementReportData } from '@/lib/reports/data/fetch-requirement'
 import { buildCombinedReviewReport } from '@/lib/reports/templates/combined-review-template'
 import { buildHistoryReport } from '@/lib/reports/templates/history-template'
@@ -121,6 +122,111 @@ function timelineEntry(
 }
 
 describe('PDF report renderer localization', () => {
+  it('renders complete structured priority identities in badge and dense inline variants', async () => {
+    await loadStatusIconNodes('CircleAlert')
+    const oldPriority = {
+      code: 'P2',
+      color: '#fde047',
+      iconName: 'CircleAlert',
+      nameEn: 'High',
+      nameSv: 'Hög',
+    }
+    const newPriority = {
+      code: 'P1',
+      color: '#1e3a8a',
+      iconName: null,
+      nameEn: 'Critical priority with a representative long name',
+      nameSv: 'Kritisk prioritet med ett representativt långt namn',
+    }
+    const model = {
+      sections: [
+        {
+          type: 'metadata-changes',
+          changes: [
+            {
+              field: 'Prioritet',
+              oldValue: oldPriority,
+              newValue: newPriority,
+            },
+          ],
+        },
+        {
+          type: 'requirement-table',
+          columns: [{ key: 'priorityLevel', label: 'Prioritet', width: '20%' }],
+          rows: [{ cells: {}, priorityLevel: newPriority }],
+        },
+        {
+          type: 'traceability-table',
+          labels: {
+            area: 'Område',
+            deviation: 'Avsteg',
+            needsReference: 'Behov',
+            note: 'Notering',
+            origin: 'Ursprung',
+            priorityLevel: 'Prioritet',
+            statusChangedAt: 'Ändrad',
+            usageStatus: 'Status',
+            verification: 'Verifiering',
+            version: 'Version',
+          },
+          rows: [
+            {
+              area: '',
+              deviation: '',
+              needsReference: '',
+              note: '',
+              origin: 'Bibliotekskrav',
+              priorityLevel: newPriority,
+              requirementId: 'BEH0001',
+              statusChangedAt: '',
+              usageStatus: '',
+              verification: '',
+              version: '1',
+            },
+          ],
+        },
+      ],
+    } as unknown as ReportModel
+
+    const output = renderReport(model, 'sv')
+
+    expect(output).toContain('P2 – Hög')
+    expect(output).toContain(
+      'P1 – Kritisk prioritet med ett representativt långt namn',
+    )
+    expect(output.match(/<svg/g)).toHaveLength(1)
+    expect(output).not.toContain('UnknownIcon')
+  })
+
+  it('renders deviation priority identity against its amber PDF background', async () => {
+    await loadStatusIconNodes('CircleAlert')
+    const model = {
+      sections: [
+        {
+          type: 'deviation-summary',
+          createdAt: '2026-05-01T00:00:00.000Z',
+          createdBy: null,
+          locale: 'en',
+          motivation: 'Needed for the implementation',
+          priorityLevel: {
+            code: 'P2',
+            color: '#fde047',
+            iconName: 'CircleAlert',
+            nameEn: 'High',
+            nameSv: 'Hög',
+          },
+          specificationCode: 'SPEC-1',
+          specificationName: 'Specification',
+        },
+      ],
+    } as ReportModel
+
+    const output = renderReport(model, 'en')
+
+    expect(output).toContain('P2 – High')
+    expect(output.match(/<svg/g)).toHaveLength(1)
+  })
+
   it('renders Swedish review, combined-review, and history structure', () => {
     const requirement = makeRequirement()
     const reports = [

--- a/tests/unit/report-data-server.test.ts
+++ b/tests/unit/report-data-server.test.ts
@@ -135,6 +135,56 @@ describe('report data server helpers', () => {
     } satisfies Partial<ReportDataError>)
   })
 
+  it('keeps the complete priority identity in deviation report data', async () => {
+    dalState.getRequirementById.mockResolvedValue({
+      area: null,
+      createdAt: '2026-05-01T00:00:00.000Z',
+      id: 42,
+      isArchived: false,
+      uniqueId: 'KRAV-42',
+      versions: [
+        {
+          ...reportVersion(10),
+          priorityLevel: {
+            code: 'P2',
+            color: '#fde047',
+            iconName: 'CircleAlert',
+            id: 2,
+            nameEn: 'High',
+            nameSv: 'Hög',
+          },
+        },
+      ],
+    })
+    dalState.listDeviationsForSpecificationItem.mockResolvedValue([
+      {
+        createdAt: '2026-05-02T00:00:00.000Z',
+        createdBy: 'reviewer',
+        decision: null,
+        id: 7,
+        isReviewRequested: 1,
+        motivation: 'Needs review',
+        requirementVersionId: 10,
+        specificationCode: 'SPEC',
+        specificationName: 'Spec',
+      },
+    ])
+
+    await expect(
+      collectDeviationForReport(createReportDb(), 42, '55', 'sv'),
+    ).resolves.toMatchObject({
+      version: {
+        priorityLevel: {
+          code: 'P2',
+          color: '#fde047',
+          iconName: 'CircleAlert',
+          nameEn: 'High',
+          nameSv: 'Hög',
+        },
+      },
+    })
+  })
+
   it('parses library and numeric item refs for deviation reports', () => {
     dalState.parseSpecificationItemRef.mockImplementation((value: string) =>
       value === 'lib:55' ? { id: 55, kind: 'library' } : null,

--- a/tests/unit/report-response.test.tsx
+++ b/tests/unit/report-response.test.tsx
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const responseState = vi.hoisted(() => ({
+  collectStatusIconNames: vi.fn(() => ['CircleAlert']),
+  events: [] as string[],
+  preloadStatusIconNodes: vi.fn(async () => {
+    responseState.events.push('preload')
+  }),
+  renderPdfResponse: vi.fn(async () => {
+    responseState.events.push('render')
+    return new Response('%PDF')
+  }),
+}))
+
+vi.mock('@/components/reports/pdf/PdfReportRenderer', () => ({
+  default: 'mock-pdf-report',
+}))
+
+vi.mock('@/lib/icons/status-icon-allowlist', () => ({
+  collectStatusIconNames: responseState.collectStatusIconNames,
+  preloadStatusIconNodes: responseState.preloadStatusIconNodes,
+}))
+
+vi.mock('@/lib/pdf/server-response', () => ({
+  renderPdfResponse: responseState.renderPdfResponse,
+}))
+
+import { renderReportModelPdfResponse } from '@/components/reports/pdf/report-response'
+
+describe('report PDF response', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    responseState.events.length = 0
+  })
+
+  it('preloads allowlisted model icons before server rendering', async () => {
+    const model = {
+      sections: [
+        {
+          type: 'header' as const,
+          generatedAt: '2026-05-01T00:00:00.000Z',
+          requirementId: 'REQ-1',
+          status: {
+            color: '#22c55e',
+            iconName: 'CircleAlert',
+            label: 'Published',
+          },
+          title: 'Report',
+        },
+      ],
+    }
+
+    await renderReportModelPdfResponse(model, 'en', 'report.pdf')
+
+    expect(responseState.collectStatusIconNames).toHaveBeenCalledWith(model)
+    expect(responseState.preloadStatusIconNodes).toHaveBeenCalledWith([
+      'CircleAlert',
+    ])
+    expect(responseState.events).toEqual(['preload', 'render'])
+  })
+})

--- a/tests/unit/report-templates.test.ts
+++ b/tests/unit/report-templates.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { RequirementReportData } from '@/lib/reports/data/fetch-requirement'
+import { buildDeviationReviewReport } from '@/lib/reports/templates/deviation-review-template'
 import { buildHistoryReport } from '@/lib/reports/templates/history-template'
 import { buildReviewReport } from '@/lib/reports/templates/review-template'
 import { buildSuggestionHistoryReport } from '@/lib/reports/templates/suggestion-history-template'
@@ -48,6 +49,151 @@ function makeRequirement(
 }
 
 describe('report templates', () => {
+  it('keeps structured previous and new priority identities in review reports', () => {
+    const model = buildReviewReport(
+      makeRequirement([
+        makeVersion({
+          id: 1,
+          priorityLevel: {
+            code: 'P2',
+            color: '#FDE047',
+            iconName: 'CircleAlert',
+            id: 2,
+            nameEn: 'High',
+            nameSv: 'Hög',
+          } as never,
+          status: 3,
+          versionNumber: 1,
+        }),
+        makeVersion({
+          id: 2,
+          priorityLevel: {
+            code: 'P1',
+            color: 'invalid',
+            iconName: 'UnknownIcon',
+            id: 1,
+            nameEn: 'Critical',
+            nameSv: 'Kritisk',
+          } as never,
+          status: 2,
+          statusNameEn: 'Review',
+          statusNameSv: 'Granskning',
+          versionNumber: 2,
+        }),
+      ]),
+      'sv',
+    )
+
+    const metadataChanges = model.sections.find(
+      section => section.type === 'metadata-changes',
+    )
+
+    expect(
+      metadataChanges?.type === 'metadata-changes'
+        ? metadataChanges.changes
+        : [],
+    ).toContainEqual({
+      field: 'Prioritet',
+      newValue: {
+        code: 'P1',
+        color: null,
+        iconName: null,
+        nameEn: 'Critical',
+        nameSv: 'Kritisk',
+      },
+      oldValue: {
+        code: 'P2',
+        color: '#fde047',
+        iconName: 'CircleAlert',
+        nameEn: 'High',
+        nameSv: 'Hög',
+      },
+    })
+  })
+
+  it('keeps structured priority identities in history report summaries', () => {
+    const version = makeVersion({
+      priorityLevel: {
+        code: 'P3',
+        color: '#1E3A8A',
+        iconName: null,
+        id: 3,
+        nameEn: 'Medium priority with a representative long name',
+        nameSv: 'Medelprioritet med ett representativt långt namn',
+      },
+    })
+
+    for (const model of [
+      buildHistoryReport(makeRequirement([version]), 'sv'),
+      buildSuggestionHistoryReport(makeRequirement([version]), [], 'en'),
+    ]) {
+      const summary = model.sections.find(
+        section => section.type === 'version-summary',
+      )
+      expect(
+        summary?.type === 'version-summary'
+          ? summary.version.priorityLevel
+          : null,
+      ).toEqual({
+        code: 'P3',
+        color: '#1e3a8a',
+        iconName: null,
+        nameEn: 'Medium priority with a representative long name',
+        nameSv: 'Medelprioritet med ett representativt långt namn',
+      })
+    }
+  })
+
+  it('keeps a structured priority identity in deviation review sections', () => {
+    const model = buildDeviationReviewReport(
+      {
+        deviation: {
+          createdAt: '2026-05-01T00:00:00.000Z',
+          createdBy: 'Reviewer',
+          motivation: 'A deviation is needed',
+        },
+        requirementUniqueId: 'REQ-1',
+        specificationCode: 'SPEC-1',
+        specificationName: 'Specification',
+        version: {
+          acceptanceCriteria: null,
+          category: null,
+          createdBy: null,
+          description: 'Description',
+          normReferences: [],
+          priorityLevel: {
+            code: 'P2',
+            color: '#FDE047',
+            iconName: 'UnknownIcon',
+            nameEn: 'High',
+            nameSv: 'Hög',
+          } as never,
+          qualityCharacteristic: null,
+          requirementPackages: [],
+          status: { color: null, iconName: null, label: 'Published' },
+          type: null,
+          verifiable: false,
+          verificationMethod: null,
+          versionNumber: 1,
+        },
+      },
+      'sv',
+    )
+    const summary = model.sections.find(
+      section => section.type === 'deviation-summary',
+    )
+
+    expect(
+      summary?.type === 'deviation-summary' ? summary.priorityLevel : null,
+    ).toEqual({
+      code: 'P2',
+      color: '#fde047',
+      iconName: null,
+      nameEn: 'High',
+      nameSv: 'Hög',
+    })
+  })
+
   it('skips blank requirement packages in history reports', () => {
     const model = buildHistoryReport(
       makeRequirement([

--- a/tests/unit/report-worker-entry.test.ts
+++ b/tests/unit/report-worker-entry.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const entryState = vi.hoisted(() => ({
+  collectStatusIconNames: vi.fn(() => ['CircleAlert']),
+  events: [] as string[],
+  pipeline: vi.fn(async () => undefined),
+  postMessage: vi.fn(),
+  preloadStatusIconNodes: vi.fn(async () => {
+    entryState.events.push('preload')
+  }),
+  renderToStream: vi.fn(async () => {
+    entryState.events.push('render')
+    return { source: true }
+  }),
+}))
+
+vi.mock('node:fs', () => {
+  const createWriteStream = vi.fn(() => ({ destination: true }))
+  return { createWriteStream, default: { createWriteStream } }
+})
+
+vi.mock('node:stream/promises', () => ({
+  default: { pipeline: entryState.pipeline },
+  pipeline: entryState.pipeline,
+}))
+
+vi.mock('node:worker_threads', () => {
+  const workerThreads = {
+    parentPort: { postMessage: entryState.postMessage },
+    workerData: {
+      locale: 'sv',
+      maxBytes: 2048,
+      model: {
+        sections: [
+          {
+            generatedAt: '2026-05-01T00:00:00.000Z',
+            requirementId: 'REQ-1',
+            status: { iconName: 'CircleAlert' },
+            title: 'Report',
+            type: 'header',
+          },
+        ],
+      },
+      outputPath: '/tmp/report-worker-entry-test.pdf',
+    },
+  }
+  return { ...workerThreads, default: workerThreads }
+})
+
+vi.mock('@react-pdf/renderer', () => ({
+  renderToStream: entryState.renderToStream,
+}))
+
+vi.mock('@/components/reports/pdf/PdfReportRenderer', () => ({
+  default: 'mock-pdf-report',
+}))
+
+vi.mock('@/lib/icons/status-icon-allowlist', () => ({
+  collectStatusIconNames: entryState.collectStatusIconNames,
+  preloadStatusIconNodes: entryState.preloadStatusIconNodes,
+}))
+
+describe('PDF report worker entry', () => {
+  it('preloads allowlisted model icons before isolated rendering', async () => {
+    await import('@/lib/pdf/report-worker-entry')
+    await vi.waitFor(() => expect(entryState.postMessage).toHaveBeenCalled())
+
+    expect(entryState.preloadStatusIconNodes).toHaveBeenCalledWith([
+      'CircleAlert',
+    ])
+    expect(entryState.events).toEqual(['preload', 'render'])
+  })
+})

--- a/tests/unit/requirements-specifications-dal.test.ts
+++ b/tests/unit/requirements-specifications-dal.test.ts
@@ -1528,6 +1528,9 @@ describe('requirements-specifications DAL (SQL Server path)', () => {
           needsReference: 'IAM-42',
           note: 'Library note',
           verifiable: 1,
+          priorityLevelCode: 'P1',
+          priorityLevelColor: '#1e3a8a',
+          priorityLevelIconName: 'CircleAlert',
           priorityLevelNameEn: 'High',
           priorityLevelNameSv: 'Hög',
           specificationItemStatusId: 2,
@@ -1550,6 +1553,9 @@ describe('requirements-specifications DAL (SQL Server path)', () => {
           needsReference: null,
           note: 'Local note',
           verifiable: 0,
+          priorityLevelCode: null,
+          priorityLevelColor: null,
+          priorityLevelIconName: null,
           priorityLevelNameEn: null,
           priorityLevelNameSv: null,
           specificationItemStatusId: 1,
@@ -1602,6 +1608,9 @@ describe('requirements-specifications DAL (SQL Server path)', () => {
         itemRef: 'lib:31',
         kind: 'library',
         needsReference: 'IAM-42',
+        priorityLevelCode: 'P1',
+        priorityLevelColor: '#1e3a8a',
+        priorityLevelIconName: 'CircleAlert',
         verifiable: true,
         statusUpdatedAt: '2026-06-03T10:00:00.000Z',
         uniqueId: 'REQ-001',
@@ -1609,6 +1618,15 @@ describe('requirements-specifications DAL (SQL Server path)', () => {
         versionNumber: 2,
       }),
     ])
+    expect(query.mock.calls[0]?.[0]).toContain(
+      'priority_level.code AS priorityLevelCode',
+    )
+    expect(query.mock.calls[0]?.[0]).toContain(
+      'priority_level.color AS priorityLevelColor',
+    )
+    expect(query.mock.calls[0]?.[0]).toContain(
+      'priority_level.icon_name AS priorityLevelIconName',
+    )
   })
 
   it('updates requirement application fields by item ref on SQL Server', async () => {

--- a/tests/unit/requirements-specifications-dal.test.ts
+++ b/tests/unit/requirements-specifications-dal.test.ts
@@ -1618,15 +1618,6 @@ describe('requirements-specifications DAL (SQL Server path)', () => {
         versionNumber: 2,
       }),
     ])
-    expect(query.mock.calls[0]?.[0]).toContain(
-      'priority_level.code AS priorityLevelCode',
-    )
-    expect(query.mock.calls[0]?.[0]).toContain(
-      'priority_level.color AS priorityLevelColor',
-    )
-    expect(query.mock.calls[0]?.[0]).toContain(
-      'priority_level.icon_name AS priorityLevelIconName',
-    )
   })
 
   it('updates requirement application fields by item ref on SQL Server', async () => {

--- a/tests/unit/specification-output-data.test.ts
+++ b/tests/unit/specification-output-data.test.ts
@@ -97,6 +97,9 @@ function createDb() {
             qualityCharacteristicNameEn: 'Security',
             qualityCharacteristicNameSv: 'Informationssäkerhet',
             verifiable: 1,
+            priorityLevelCode: 'P1',
+            priorityLevelColor: '#1e3a8a',
+            priorityLevelIconName: 'CircleAlert',
             priorityLevelNameEn: 'High',
             priorityLevelNameSv: 'Hög',
             specificationItemStatusId: 2,
@@ -125,6 +128,9 @@ function createDb() {
             qualityCharacteristicNameEn: null,
             qualityCharacteristicNameSv: null,
             verifiable: 0,
+            priorityLevelCode: null,
+            priorityLevelColor: null,
+            priorityLevelIconName: null,
             priorityLevelNameEn: null,
             priorityLevelNameSv: null,
             specificationItemStatusId: 1,
@@ -196,6 +202,9 @@ describe('specification output data', () => {
     })
     expect(result.items[1]).toMatchObject({
       deviationCounts: { approved: 1 },
+      priorityLevelCode: 'P1',
+      priorityLevelColor: '#1e3a8a',
+      priorityLevelIconName: 'CircleAlert',
       requirementPackageNames: ['Base package'],
       suggestionCount: 3,
       versionNumber: 4,
@@ -211,6 +220,14 @@ describe('specification output data', () => {
         query.includes(
           'requirement_version.id = specification_item.requirement_version_id',
         ),
+      ),
+    ).toBe(true)
+    expect(
+      queries.some(
+        query =>
+          query.includes('priority_level.code AS priorityLevelCode') &&
+          query.includes('priority_level.color AS priorityLevelColor') &&
+          query.includes('priority_level.icon_name AS priorityLevelIconName'),
       ),
     ).toBe(true)
     expect(

--- a/tests/unit/specification-output-data.test.ts
+++ b/tests/unit/specification-output-data.test.ts
@@ -223,14 +223,6 @@ describe('specification output data', () => {
       ),
     ).toBe(true)
     expect(
-      queries.some(
-        query =>
-          query.includes('priority_level.code AS priorityLevelCode') &&
-          query.includes('priority_level.color AS priorityLevelColor') &&
-          query.includes('priority_level.icon_name AS priorityLevelIconName'),
-      ),
-    ).toBe(true)
-    expect(
       queries.some(query =>
         query.includes('specification_local_requirement_requirement_packages'),
       ),

--- a/tests/unit/specification-report-profiles.test.ts
+++ b/tests/unit/specification-report-profiles.test.ts
@@ -50,6 +50,9 @@ function outputData(): SpecificationOutputData {
         qualityCharacteristicNameSv: 'Informationssäkerhet',
         requirementPackageNames: ['Base package'],
         verifiable: true,
+        priorityLevelCode: 'P1',
+        priorityLevelColor: '#1e3a8a',
+        priorityLevelIconName: 'CircleAlert',
         priorityLevelNameEn: 'High',
         priorityLevelNameSv: 'Hög',
         specificationItemStatusId: 2,
@@ -89,6 +92,9 @@ function traceabilityData(): SpecificationTraceabilityData {
         needsReference: 'IAM-need',
         note: 'Follow up at gate 2',
         verifiable: true,
+        priorityLevelCode: 'P1',
+        priorityLevelColor: '#1e3a8a',
+        priorityLevelIconName: 'CircleAlert',
         priorityLevelNameEn: 'High',
         priorityLevelNameSv: 'Hög',
         specificationItemStatusId: 2,
@@ -107,6 +113,9 @@ function traceabilityData(): SpecificationTraceabilityData {
         needsReference: null,
         note: null,
         verifiable: false,
+        priorityLevelCode: null,
+        priorityLevelColor: null,
+        priorityLevelIconName: null,
         priorityLevelNameEn: null,
         priorityLevelNameSv: null,
         specificationItemStatusId: 1,
@@ -122,6 +131,55 @@ function traceabilityData(): SpecificationTraceabilityData {
 }
 
 describe('specification report profiles', () => {
+  it('keeps structured priority identities in dense report rows', () => {
+    const profileData = outputData()
+    Object.assign(profileData.items[0] ?? {}, {
+      priorityLevelCode: 'P1',
+      priorityLevelColor: '#1E3A8A',
+      priorityLevelIconName: 'CircleAlert',
+    })
+    const progressTable = requirementTable(
+      buildSpecificationProfileReport(profileData, 'progress', 'sv'),
+    )
+    const managementTable = requirementTable(
+      buildSpecificationProfileReport(profileData, 'management', 'en'),
+    )
+
+    for (const table of [progressTable, managementTable]) {
+      expect(table?.rows[0]?.priorityLevel).toEqual({
+        code: 'P1',
+        color: '#1e3a8a',
+        iconName: 'CircleAlert',
+        nameEn: 'High',
+        nameSv: 'Hög',
+      })
+      expect(table?.rows[0]?.cells.priorityLevel).toBeUndefined()
+    }
+
+    const traceData = traceabilityData()
+    Object.assign(traceData.items[0] ?? {}, {
+      priorityLevelCode: 'P1',
+      priorityLevelColor: '#FDE047',
+      priorityLevelIconName: null,
+    })
+    const traceability = buildSpecificationTraceabilityReport(
+      traceData,
+      'sv',
+    ).sections.find(section => section.type === 'traceability-table')
+
+    expect(
+      traceability?.type === 'traceability-table'
+        ? traceability.rows[0]?.priorityLevel
+        : null,
+    ).toEqual({
+      code: 'P1',
+      color: '#fde047',
+      iconName: null,
+      nameEn: 'High',
+      nameSv: 'Hög',
+    })
+  })
+
   it('maps lifecycle statuses to the available report and export profiles', () => {
     expect(getSpecificationReportProfileForLifecycleStatus(1)).toBe(
       'procurement',
@@ -300,7 +358,13 @@ describe('specification report profiles', () => {
         note: 'Follow up at gate 2',
         origin: 'Bibliotekskrav',
         requirementId: 'BEH0001',
-        priorityLevel: 'Hög',
+        priorityLevel: {
+          code: 'P1',
+          color: '#1e3a8a',
+          iconName: 'CircleAlert',
+          nameEn: 'High',
+          nameSv: 'Hög',
+        },
         usageStatus: 'Pågår',
         verification: 'Ja: Review test evidence',
         version: '4',


### PR DESCRIPTION
## Description

- Carry a structured priority identity through PDF report collectors, models, and templates for all affected report families.
- Render localized `code – name` badge and compact inline variants with strict color validation and WCAG-safe contrast.
- Validate and preload allowlisted vector icons for direct and worker rendering without external resources.
- Keep short priority identities on one line while preserving wrapping for representative long names.
- Add unit, route, worker, and Playwright coverage plus report and developer documentation.

## Related Issues

Fixes #636

## Reviewer Notes

Validation completed:

- `npm run check`
- Focused Vitest coverage for report collectors, templates, renderer, response, and worker paths
- Playwright LIFE-14/LIFE-15 and COL-06 PDF download coverage in Swedish and English
- Independent Standards and Spec reviews; no remaining hard findings

Procurement PDFs, browser UI, CSV formats, database schema, and externally loaded icons remain out of scope.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
No operator upgrade notes are required.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/878)
<!-- Reviewable:end -->
