### PR TITLE
docs: persist operator upgrade notes from #880

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -10,6 +10,33 @@ target version.
 <!-- operator-upgrade:source pr-870 start -->
 Provision AZURE_DEV_WORKSTATION_APPROVER_PUBLIC_KEY_PATH on destination workstations through a trusted channel before generating requests. Request and package schema 3 intentionally has no compatibility path with schema 2; regenerate pending requests and responses after upgrade. Existing approval key rotation requires provisioning the replacement public key before creating a new request.
 <!-- operator-upgrade:source pr-870 end -->
+
+<!-- operator-upgrade:source pr-880 start -->
+### Invalid requirement and usage status colors are reset during upgrade
+Before running `db-job migrate`, identify seeded requirement version statuses and usage statuses whose color is not an exact case-insensitive `#RRGGBB` value. Migration 0053 resets only these invalid rows to their canonical colors; valid custom colors, including their letter case, remain unchanged.
+```sql
+SELECT N'requirement_statuses' AS catalog, id, color
+FROM requirement_statuses
+WHERE id IN (1, 2, 3, 4)
+AND (
+color IS NULL
+OR DATALENGTH(color)  14
+OR color COLLATE Latin1_General_100_BIN2 NOT LIKE
+N'#[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]'
+)
+UNION ALL
+SELECT N'specification_item_statuses' AS catalog, id, color
+FROM specification_item_statuses
+WHERE id IN (1, 2, 3, 4, 5, 6)
+AND (
+color IS NULL
+OR DATALENGTH(color)  14
+OR color COLLATE Latin1_General_100_BIN2 NOT LIKE
+N'#[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]'
+);
+```
+After upgrade, review `/sv/requirement-statuses` and `/sv/specification-item-statuses`. Open every row and confirm the labeled light- and dark-theme previews report `Uppfyller AA` before accepting the upgraded configuration.
+<!-- operator-upgrade:source pr-880 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade

--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -12,15 +12,21 @@ Provision AZURE_DEV_WORKSTATION_APPROVER_PUBLIC_KEY_PATH on destination workstat
 <!-- operator-upgrade:source pr-870 end -->
 
 <!-- operator-upgrade:source pr-880 start -->
-### Invalid requirement and usage status colors are reset during upgrade
-Before running `db-job migrate`, identify seeded requirement version statuses and usage statuses whose color is not an exact case-insensitive `#RRGGBB` value. Migration 0053 resets only these invalid rows to their canonical colors; valid custom colors, including their letter case, remain unchanged.
+### Invalid requirement and specification-item status colors are reset during upgrade
+
+Before running `db-job migrate`, identify seeded requirement statuses and
+specification-item statuses whose color is not an exact case-insensitive
+`#RRGGBB` value. Migration 0053 resets only these invalid rows to their
+canonical colors; valid custom colors, including their letter case, remain
+unchanged.
+
 ```sql
 SELECT N'requirement_statuses' AS catalog, id, color
 FROM requirement_statuses
 WHERE id IN (1, 2, 3, 4)
 AND (
 color IS NULL
-OR DATALENGTH(color)  14
+OR DATALENGTH(color) <> 14
 OR color COLLATE Latin1_General_100_BIN2 NOT LIKE
 N'#[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]'
 )
@@ -30,7 +36,7 @@ FROM specification_item_statuses
 WHERE id IN (1, 2, 3, 4, 5, 6)
 AND (
 color IS NULL
-OR DATALENGTH(color)  14
+OR DATALENGTH(color) <> 14
 OR color COLLATE Latin1_General_100_BIN2 NOT LIKE
 N'#[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]'
 );


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #880
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/30931171933

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/881)
<!-- Reviewable:end -->
