### PR TITLE
docs: persist operator upgrade notes from #924

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -43,6 +43,28 @@ N'#[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f]'
 ```
 After upgrade, review `/sv/requirement-statuses` and `/sv/specification-item-statuses`. Open every row and confirm the labeled light- and dark-theme previews report `Uppfyller AA` before accepting the upgraded configuration.
 <!-- operator-upgrade:source pr-880 end -->
+
+<!-- operator-upgrade:source pr-924 start -->
+Before the first production rollout, configure a privileged database-job
+identity separately from the application runtime identity. Set
+`DB_RUNTIME_USER` to the application runtime database user, and provision that
+user with only the release-managed `kravhantering_runtime` role. Ensure all
+required application settings exist; privileged database maintenance owns any
+repair because the runtime identity cannot create missing settings.
+Permission reconciliation fails closed when the user is missing, managed
+grants drift, unexpected role nesting exists, or the user has effective
+schema-migration, protected-audit mutation, or database-user impersonation
+capabilities. If a development, test, or rollout database gives the runtime
+user broad read/write memberships, reconciliation removes those memberships
+only after the custom role contract verifies. Other site-managed roles and
+direct grants remain in place, but operators must remove or narrow any that
+cause verification to fail rather than broadening runtime access.
+Retain the permission verification output as deployment evidence and validate
+representative application read/write workflows. For rollback, use a complete
+database restore point so schema, data, permissions, and role memberships
+return as one database state; do not reverse only the role change against the
+restricted runtime identity.
+<!-- operator-upgrade:source pr-924 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #924
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/31272194258

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/926)
<!-- Reviewable:end -->
