### PR TITLE
fix: resolve production smoke boundary image from runtime

### DIFF
--- a/scripts/containers/production-smoke-debug.mjs
+++ b/scripts/containers/production-smoke-debug.mjs
@@ -376,7 +376,7 @@ function runDebug(values) {
       { environment: inputs.environment },
     )
     dockerExec(['scripts/containers/production-smoke.sh', 'verify'], {
-      environment: inputs.environment,
+      environment: existingEnvironment(),
     })
     collectEvidence(inputs.environment)
   } catch (error) {

--- a/scripts/containers/production-smoke.sh
+++ b/scripts/containers/production-smoke.sh
@@ -648,7 +648,7 @@ verify_normal_service_state() {
 }
 
 boundaries() {
-  local app_runtime_image_ref
+  local app_runtime_image_id
   : >"$EVIDENCE_DIR/normal-load-cgroup-state.txt"
   verify_normal_service_state kravhantering-app-runtime.service
   verify_normal_service_state kravhantering-nginx.service
@@ -661,19 +661,21 @@ boundaries() {
   as_service podman exec kravhantering-app-runtime \
     rm -f /run/kravhantering/export/must-not-fit
 
-  app_runtime_image_ref="$(as_service podman container inspect \
-    --format '{{.ImageName}}' kravhantering-app-runtime)" || \
-    fail 'could not resolve the running application image reference'
-  [[ -n "$app_runtime_image_ref" ]] || \
-    fail 'running application image reference is empty'
+  app_runtime_image_id="$(as_service podman container inspect \
+    --format '{{.Image}}' kravhantering-app-runtime)" || \
+    fail 'could not resolve the running application image ID'
+  [[ -n "$app_runtime_image_id" ]] || \
+    fail 'running application image ID is empty'
+  as_service podman image exists "$app_runtime_image_id" || \
+    fail 'running application image is not available in local storage'
 
-  if as_service podman run --rm --network none --memory 48m \
-    --memory-swap 48m "$app_runtime_image_ref" \
+  if as_service podman run --pull=never --rm --network none --memory 48m \
+    --memory-swap 48m "$app_runtime_image_id" \
     node -e 'Buffer.alloc(256 * 1024 * 1024).fill(1)'; then
     fail 'disposable memory boundary did not terminate an over-limit process'
   fi
-  if as_service podman run --rm --network none --pids-limit 8 \
-    "$app_runtime_image_ref" node -e '
+  if as_service podman run --pull=never --rm --network none --pids-limit 8 \
+    "$app_runtime_image_id" node -e '
       const { spawn } = require("node:child_process")
       const children = []
       let denied = false

--- a/scripts/containers/production-smoke.sh
+++ b/scripts/containers/production-smoke.sh
@@ -648,6 +648,7 @@ verify_normal_service_state() {
 }
 
 boundaries() {
+  local app_runtime_image_ref
   : >"$EVIDENCE_DIR/normal-load-cgroup-state.txt"
   verify_normal_service_state kravhantering-app-runtime.service
   verify_normal_service_state kravhantering-nginx.service
@@ -660,13 +661,19 @@ boundaries() {
   as_service podman exec kravhantering-app-runtime \
     rm -f /run/kravhantering/export/must-not-fit
 
+  app_runtime_image_ref="$(as_service podman container inspect \
+    --format '{{.ImageName}}' kravhantering-app-runtime)" || \
+    fail 'could not resolve the running application image reference'
+  [[ -n "$app_runtime_image_ref" ]] || \
+    fail 'running application image reference is empty'
+
   if as_service podman run --rm --network none --memory 48m \
-    --memory-swap 48m "$APP_RUNTIME_IMAGE_REF" \
+    --memory-swap 48m "$app_runtime_image_ref" \
     node -e 'Buffer.alloc(256 * 1024 * 1024).fill(1)'; then
     fail 'disposable memory boundary did not terminate an over-limit process'
   fi
   if as_service podman run --rm --network none --pids-limit 8 \
-    "$APP_RUNTIME_IMAGE_REF" node -e '
+    "$app_runtime_image_ref" node -e '
       const { spawn } = require("node:child_process")
       const children = []
       let denied = false


### PR DESCRIPTION
## Description

Fix the release-only production smoke failure by deriving the disposable
boundary probe image from the running app container. This removes the hidden
`APP_RUNTIME_IMAGE_REF` requirement from `production-smoke.sh verify`.

The local debug adapter now supplies the same minimal verification environment
as the release workflow.

## Related Issues

Relates to #486.

## Reviewer Notes

Failure addressed:
https://github.com/viscalyx/Kravhantering/actions/runs/31366087079/job/93384650324

Validation:

- Complete local Ubuntu production smoke passed without
  `APP_RUNTIME_IMAGE_REF` in the verification environment.
- All four release-smoke Playwright tests passed.
- Disposable tmpfs, memory, and PID boundary probes passed.
- `npm run check` passed with 6,482 tests plus the HSA mock and adapter suites.
- The debug host was removed and `docker ps` was empty.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/961)
<!-- Reviewable:end -->