### PR TITLE
docs: persist operator upgrade notes from #962

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -79,7 +79,7 @@ Single-node deployments must set both `NGINX_RESOLVER` for the edge network and 
 <!-- operator-upgrade:source pr-940 end -->
 
 <!-- operator-upgrade:source pr-962 start -->
-Single-node installations now validate and apply explicit SQL Server and Keycloak CPU, memory, PID, and temporary-storage limits. Review the new `SQLSERVER_*` and `KEYCLOAK_*` values in `containers/production/env/release.env.template` before deployment; the documented defaults require at least 14 GiB host memory. Reinstall the rendered Quadlets and run the production smoke after upgrading so containment, persistence, recovery, and application readiness are verified against the existing volumes. See `docs/operations/production-quadlet-containment.md` for supported ranges, capacity rules, image qualifications, and rollback guidance.
+Single-node installations now validate and apply explicit SQL Server and Keycloak CPU, memory, PID, and temporary-storage limits. Review the new `SQLSERVER_*` and `KEYCLOAK_*` values in `containers/production/env/release.env.template` before deployment; the documented defaults require at least 16 GiB host memory. Reinstall the rendered Quadlets and run the production smoke after upgrading so containment, persistence, recovery, and application readiness are verified against the existing volumes. See `docs/operations/production-quadlet-containment.md` for supported ranges, capacity rules, image qualifications, and rollback guidance.
 <!-- operator-upgrade:source pr-962 end -->
 ## v0.4.0 - 2026-08-02
 

--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -77,6 +77,10 @@ selected topology and manage the resulting target with systemctl --user.
 Before upgrading, verify that each production host supports rootless container resource controls, has finite journal retention configured, and has sufficient CPU, memory, and temporary export capacity. Installation now fails closed when these prerequisites are not met. If disk-backed export storage is required, prepare its ownership, permissions, capacity, and security labels before rollout.
 Single-node deployments must set both `NGINX_RESOLVER` for the edge network and `NGINX_IDENTITY_RESOLVER` for the identity network before starting nginx. Existing installations that lack the identity setting must first add the temporary value documented in the single-node upgrade guide so the helper can render the network units. After the edge and identity networks exist, discover each resolver with `kravhantering-quadlet.sh print-resolver`, replace both settings with the discovered values, reinstall the units, and only then start the full target. nginx uses the edge resolver only for `app-runtime` and the identity resolver only for Keycloak.
 <!-- operator-upgrade:source pr-940 end -->
+
+<!-- operator-upgrade:source pr-962 start -->
+Single-node installations now validate and apply explicit SQL Server and Keycloak CPU, memory, PID, and temporary-storage limits. Review the new `SQLSERVER_*` and `KEYCLOAK_*` values in `containers/production/env/release.env.template` before deployment; the documented defaults require at least 14 GiB host memory. Reinstall the rendered Quadlets and run the production smoke after upgrading so containment, persistence, recovery, and application readiness are verified against the existing volumes. See `docs/operations/production-quadlet-containment.md` for supported ranges, capacity rules, image qualifications, and rollback guidance.
+<!-- operator-upgrade:source pr-962 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #962
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/31399345735

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/964)
<!-- Reviewable:end -->
