### PR TITLE
fix: harden single-node Keycloak profiles

### DIFF
--- a/containers/production/bin/kravhantering-images.sh
+++ b/containers/production/bin/kravhantering-images.sh
@@ -72,7 +72,12 @@ service_env_prefix() {
 services_for_topology() {
   case "$1" in
     app-node) printf '%s\n' app-runtime db-job nginx ;;
-    single-node | all) printf '%s\n' app-runtime db-job nginx sqlserver keycloak ;;
+    single-node)
+      printf '%s\n' app-runtime db-job nginx sqlserver
+      [[ "${IDENTITY_PROVIDER_MODE:-bundled}" == external ]] || \
+        printf '%s\n' keycloak
+      ;;
+    all) printf '%s\n' app-runtime db-job nginx sqlserver keycloak ;;
     single-node-demo)
       printf '%s\n' app-runtime db-job nginx sqlserver keycloak kong hsa-person-lookup-adapter hsa-directory-mock
       ;;

--- a/containers/production/bin/kravhantering-quadlet.sh
+++ b/containers/production/bin/kravhantering-quadlet.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 BUNDLE_ROOT="${KRAVHANTERING_BUNDLE_ROOT:-$(cd -- "$SCRIPT_DIR/.." && pwd -P)}"
 RELEASE_ENV_FILE="${KRAVHANTERING_RELEASE_ENV_FILE:-/etc/kravhantering/release.env}"
+KEYCLOAK_ENV_FILE="${KRAVHANTERING_KEYCLOAK_ENV_FILE:-/etc/kravhantering/keycloak.env}"
 TEMPLATE_ROOT="$BUNDLE_ROOT/quadlet/templates"
 QUADLET_DIR="${KRAVHANTERING_QUADLET_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/containers/systemd}"
 SYSTEMD_USER_DIR="${KRAVHANTERING_SYSTEMD_USER_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user}"
@@ -124,6 +125,7 @@ template_values() {
     NGINX_PIDS_LIMIT \
     NGINX_SINGLE_NODE_TEMPLATE \
     NGINX_TASKS_MAX \
+    PUBLIC_ISSUER_HOST_MAPPING \
     SQLSERVER_CPU_QUOTA_PERCENT \
     SQLSERVER_MEMORY_LIMIT_MIB \
     SQLSERVER_PIDS_LIMIT \
@@ -146,6 +148,17 @@ read_release_env() {
   done <"$RELEASE_ENV_FILE"
 }
 
+read_env_value() {
+  local file="$1" requested_key="$2" line value=''
+  [[ -r "$file" ]] || fail "cannot read env file: $file"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    [[ "$line" == "$requested_key="* ]] || continue
+    value="${line#*=}"
+  done <"$file"
+  printf '%s\n' "$value"
+}
+
 configure_identity_provider() {
   default_release_value IDENTITY_PROVIDER_MODE bundled
   case "$IDENTITY_PROVIDER_MODE" in
@@ -158,6 +171,7 @@ configure_identity_provider() {
       KEYCLOAK_MANAGEMENT_MTLS_VOLUMES=''
       NGINX_KEYCLOAK_MANAGEMENT_PUBLISH=''
       NGINX_SINGLE_NODE_TEMPLATE='single-node-tls.conf.template'
+      PUBLIC_ISSUER_HOST_MAPPING="PodmanArgs=--add-host=${PUBLIC_HOSTNAME-}:host-gateway"
       ;;
     external)
       NGINX_IDENTITY_RESOLVER=''
@@ -169,6 +183,7 @@ configure_identity_provider() {
       KEYCLOAK_MANAGEMENT_MTLS_VOLUMES=''
       NGINX_KEYCLOAK_MANAGEMENT_PUBLISH=''
       NGINX_SINGLE_NODE_TEMPLATE='single-node-external-oidc-tls.conf.template'
+      PUBLIC_ISSUER_HOST_MAPPING=''
       ;;
     hardened-bundled)
       KEYCLOAK_APP_DEPENDENCIES='kravhantering-keycloak.service'
@@ -179,6 +194,7 @@ configure_identity_provider() {
       KEYCLOAK_MANAGEMENT_MTLS_VOLUMES=$'Volume=/etc/kravhantering/keycloak-management-tls/client-ca.crt:/etc/nginx/keycloak-management-tls/client-ca.crt:ro\nVolume=/etc/kravhantering/keycloak-management-tls/fullchain.pem:/etc/nginx/keycloak-management-tls/fullchain.pem:ro\nVolume=/etc/kravhantering/keycloak-management-tls/privkey.pem:/etc/nginx/keycloak-management-tls/privkey.pem:ro'
       NGINX_KEYCLOAK_MANAGEMENT_PUBLISH="PublishPort=${KEYCLOAK_MANAGEMENT_HTTPS_BIND-}"
       NGINX_SINGLE_NODE_TEMPLATE='single-node-hardened-keycloak-tls.conf.template'
+      PUBLIC_ISSUER_HOST_MAPPING="PodmanArgs=--add-host=${PUBLIC_HOSTNAME-}:host-gateway"
       ;;
     *)
       fail 'invalid IDENTITY_PROVIDER_MODE: expected bundled, external, or hardened-bundled'
@@ -195,22 +211,31 @@ validate_release_env() {
 }
 
 validate_identity_provider() {
-  local bind_address container_port host_port octet
-  local -a bind_octets=()
+  local bind_address container_port host_port host_port_value octet octet_value
+  local -a bind_octets=() bind_octet_values=()
   [[ "$IDENTITY_PROVIDER_MODE" == hardened-bundled ]] || return 0
+  KC_HOSTNAME_ADMIN="$(read_env_value "$KEYCLOAK_ENV_FILE" KC_HOSTNAME_ADMIN)"
+  [[ -n "$KC_HOSTNAME_ADMIN" ]] || \
+    fail 'keycloak.env is missing required value: KC_HOSTNAME_ADMIN for IDENTITY_PROVIDER_MODE=hardened-bundled'
   [[ -n "${KEYCLOAK_MANAGEMENT_HTTPS_BIND-}" ]] || \
     fail 'release.env is missing required value: KEYCLOAK_MANAGEMENT_HTTPS_BIND'
-  [[ "$KEYCLOAK_MANAGEMENT_HTTPS_BIND" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]+:[0-9]+$ ]] || \
+  [[ "$KEYCLOAK_MANAGEMENT_HTTPS_BIND" =~ ^([0-9]+\.){3}[0-9]+:[0-9]{1,5}:[0-9]{1,5}$ ]] || \
     fail 'invalid KEYCLOAK_MANAGEMENT_HTTPS_BIND: expected an explicit IPv4 bind'
   IFS=: read -r bind_address host_port container_port <<<"$KEYCLOAK_MANAGEMENT_HTTPS_BIND"
   IFS=. read -r -a bind_octets <<<"$bind_address"
   for octet in "${bind_octets[@]}"; do
-    (( octet >= 0 && octet <= 255 )) || \
+    [[ "$octet" =~ ^(0|[1-9][0-9]{0,2})$ ]] || \
+      fail 'invalid KEYCLOAK_MANAGEMENT_HTTPS_BIND: expected canonical decimal IPv4 octets'
+    octet_value=$((10#$octet))
+    (( octet_value <= 255 )) || \
       fail 'invalid KEYCLOAK_MANAGEMENT_HTTPS_BIND: expected an explicit IPv4 bind'
+    bind_octet_values+=("$octet_value")
   done
-  [[ "$bind_address" != 0.0.0.0 ]] || \
+  (( bind_octet_values[0] != 0 || bind_octet_values[1] != 0 || \
+    bind_octet_values[2] != 0 || bind_octet_values[3] != 0 )) || \
     fail 'invalid KEYCLOAK_MANAGEMENT_HTTPS_BIND: must not use a wildcard address'
-  (( host_port >= 1 && host_port <= 65535 )) || \
+  host_port_value=$((10#$host_port))
+  (( host_port_value >= 1 && host_port_value <= 65535 )) || \
     fail 'invalid KEYCLOAK_MANAGEMENT_HTTPS_BIND: expected host port 1-65535'
   [[ "$container_port" == 9443 ]] || \
     fail 'invalid KEYCLOAK_MANAGEMENT_HTTPS_BIND: must target container port 9443'
@@ -464,7 +489,9 @@ verify_rootless_networking() {
     "$podman_bin" network rm "$network_name" >/dev/null 2>&1 || true
     fail 'rootless Podman cannot inspect the required bridge networks'
   }
-  if [[ "$TOPOLOGY" == single-node && "$IDENTITY_PROVIDER_MODE" != external ]]; then
+  if [[ "$TOPOLOGY" == single-node ]] &&
+    [[ "$IDENTITY_PROVIDER_MODE" == bundled || \
+      "$IDENTITY_PROVIDER_MODE" == hardened-bundled ]]; then
     "$podman_bin" create --name "$probe_name" --pull=never \
       --network "$network_name" \
       --add-host "${PUBLIC_HOSTNAME}:host-gateway" \

--- a/containers/production/bin/kravhantering-quadlet.sh
+++ b/containers/production/bin/kravhantering-quadlet.sh
@@ -83,9 +83,14 @@ required_values() {
         NGINX_RESOLVER
       ;;
     single-node)
-      printf '%s\n' APP_RUNTIME_IMAGE_REF KEYCLOAK_IMAGE_REF NGINX_IMAGE_REF \
-        NGINX_HTTPS_BIND NGINX_IDENTITY_RESOLVER NGINX_RESOLVER \
-        PUBLIC_HOSTNAME SQLSERVER_IMAGE_REF
+      printf '%s\n' APP_RUNTIME_IMAGE_REF NGINX_IMAGE_REF NGINX_HTTPS_BIND \
+        NGINX_RESOLVER PUBLIC_HOSTNAME SQLSERVER_IMAGE_REF
+      if [[ "$IDENTITY_PROVIDER_MODE" != external ]]; then
+        printf '%s\n' KEYCLOAK_IMAGE_REF NGINX_IDENTITY_RESOLVER
+      fi
+      if [[ "$IDENTITY_PROVIDER_MODE" == hardened-bundled ]]; then
+        printf '%s\n' KEYCLOAK_MANAGEMENT_HTTPS_BIND
+      fi
       ;;
     *) fail "unsupported topology: $1" ;;
   esac
@@ -105,11 +110,19 @@ template_values() {
     KEYCLOAK_QUARKUS_TMPFS_MIB \
     KEYCLOAK_TASKS_MAX \
     KEYCLOAK_TMPFS_MIB \
+    KEYCLOAK_MANAGEMENT_MTLS_VOLUMES \
+    KEYCLOAK_APP_DEPENDENCIES \
+    KEYCLOAK_NGINX_DEPENDENCIES \
+    KEYCLOAK_NGINX_ENVIRONMENT \
+    KEYCLOAK_NGINX_NETWORK \
+    KEYCLOAK_TARGET_DEPENDENCIES \
     NGINX_CACHE_TMPFS_MIB \
     NGINX_CPU_QUOTA_PERCENT \
     NGINX_HTTPS_PUBLISH \
     NGINX_MEMORY_LIMIT_MIB \
+    NGINX_KEYCLOAK_MANAGEMENT_PUBLISH \
     NGINX_PIDS_LIMIT \
+    NGINX_SINGLE_NODE_TEMPLATE \
     NGINX_TASKS_MAX \
     SQLSERVER_CPU_QUOTA_PERCENT \
     SQLSERVER_MEMORY_LIMIT_MIB \
@@ -133,12 +146,74 @@ read_release_env() {
   done <"$RELEASE_ENV_FILE"
 }
 
+configure_identity_provider() {
+  default_release_value IDENTITY_PROVIDER_MODE bundled
+  case "$IDENTITY_PROVIDER_MODE" in
+    bundled)
+      KEYCLOAK_APP_DEPENDENCIES='kravhantering-keycloak.service'
+      KEYCLOAK_NGINX_DEPENDENCIES='kravhantering-keycloak.service'
+      KEYCLOAK_NGINX_ENVIRONMENT="Environment=NGINX_IDENTITY_RESOLVER=${NGINX_IDENTITY_RESOLVER-}"
+      KEYCLOAK_NGINX_NETWORK='Network=kravhantering-single-node-identity.network'
+      KEYCLOAK_TARGET_DEPENDENCIES='kravhantering-keycloak.service'
+      KEYCLOAK_MANAGEMENT_MTLS_VOLUMES=''
+      NGINX_KEYCLOAK_MANAGEMENT_PUBLISH=''
+      NGINX_SINGLE_NODE_TEMPLATE='single-node-tls.conf.template'
+      ;;
+    external)
+      NGINX_IDENTITY_RESOLVER=''
+      KEYCLOAK_APP_DEPENDENCIES=''
+      KEYCLOAK_NGINX_DEPENDENCIES=''
+      KEYCLOAK_NGINX_ENVIRONMENT=''
+      KEYCLOAK_NGINX_NETWORK=''
+      KEYCLOAK_TARGET_DEPENDENCIES=''
+      KEYCLOAK_MANAGEMENT_MTLS_VOLUMES=''
+      NGINX_KEYCLOAK_MANAGEMENT_PUBLISH=''
+      NGINX_SINGLE_NODE_TEMPLATE='single-node-external-oidc-tls.conf.template'
+      ;;
+    hardened-bundled)
+      KEYCLOAK_APP_DEPENDENCIES='kravhantering-keycloak.service'
+      KEYCLOAK_NGINX_DEPENDENCIES='kravhantering-keycloak.service'
+      KEYCLOAK_NGINX_ENVIRONMENT="Environment=NGINX_IDENTITY_RESOLVER=${NGINX_IDENTITY_RESOLVER-}"
+      KEYCLOAK_NGINX_NETWORK='Network=kravhantering-single-node-identity.network'
+      KEYCLOAK_TARGET_DEPENDENCIES='kravhantering-keycloak.service'
+      KEYCLOAK_MANAGEMENT_MTLS_VOLUMES=$'Volume=/etc/kravhantering/keycloak-management-tls/client-ca.crt:/etc/nginx/keycloak-management-tls/client-ca.crt:ro\nVolume=/etc/kravhantering/keycloak-management-tls/fullchain.pem:/etc/nginx/keycloak-management-tls/fullchain.pem:ro\nVolume=/etc/kravhantering/keycloak-management-tls/privkey.pem:/etc/nginx/keycloak-management-tls/privkey.pem:ro'
+      NGINX_KEYCLOAK_MANAGEMENT_PUBLISH="PublishPort=${KEYCLOAK_MANAGEMENT_HTTPS_BIND-}"
+      NGINX_SINGLE_NODE_TEMPLATE='single-node-hardened-keycloak-tls.conf.template'
+      ;;
+    *)
+      fail 'invalid IDENTITY_PROVIDER_MODE: expected bundled, external, or hardened-bundled'
+      ;;
+  esac
+}
+
 validate_release_env() {
   local key value
   while IFS= read -r key; do
     value="${!key-}"
     [[ -n "$value" ]] || fail "release.env is missing required value: $key"
   done < <(required_values "$1")
+}
+
+validate_identity_provider() {
+  local bind_address container_port host_port octet
+  local -a bind_octets=()
+  [[ "$IDENTITY_PROVIDER_MODE" == hardened-bundled ]] || return 0
+  [[ -n "${KEYCLOAK_MANAGEMENT_HTTPS_BIND-}" ]] || \
+    fail 'release.env is missing required value: KEYCLOAK_MANAGEMENT_HTTPS_BIND'
+  [[ "$KEYCLOAK_MANAGEMENT_HTTPS_BIND" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]+:[0-9]+$ ]] || \
+    fail 'invalid KEYCLOAK_MANAGEMENT_HTTPS_BIND: expected an explicit IPv4 bind'
+  IFS=: read -r bind_address host_port container_port <<<"$KEYCLOAK_MANAGEMENT_HTTPS_BIND"
+  IFS=. read -r -a bind_octets <<<"$bind_address"
+  for octet in "${bind_octets[@]}"; do
+    (( octet >= 0 && octet <= 255 )) || \
+      fail 'invalid KEYCLOAK_MANAGEMENT_HTTPS_BIND: expected an explicit IPv4 bind'
+  done
+  [[ "$bind_address" != 0.0.0.0 ]] || \
+    fail 'invalid KEYCLOAK_MANAGEMENT_HTTPS_BIND: must not use a wildcard address'
+  (( host_port >= 1 && host_port <= 65535 )) || \
+    fail 'invalid KEYCLOAK_MANAGEMENT_HTTPS_BIND: expected host port 1-65535'
+  [[ "$container_port" == 9443 ]] || \
+    fail 'invalid KEYCLOAK_MANAGEMENT_HTTPS_BIND: must target container port 9443'
 }
 
 default_release_value() {
@@ -187,11 +262,13 @@ configure_containment() {
     validate_integer_range SQLSERVER_CPU_QUOTA_PERCENT 50 "$(( $(nproc) * 100 ))"
     validate_integer_range SQLSERVER_PIDS_LIMIT 128 2048
     validate_integer_range SQLSERVER_TMPFS_MIB 128 2048
-    validate_integer_range KEYCLOAK_MEMORY_LIMIT_MIB 512 4096
-    validate_integer_range KEYCLOAK_CPU_QUOTA_PERCENT 25 "$(( $(nproc) * 100 ))"
-    validate_integer_range KEYCLOAK_PIDS_LIMIT 64 1024
-    validate_integer_range KEYCLOAK_QUARKUS_TMPFS_MIB 32 256
-    validate_integer_range KEYCLOAK_TMPFS_MIB 128 2048
+    if [[ "$IDENTITY_PROVIDER_MODE" != external ]]; then
+      validate_integer_range KEYCLOAK_MEMORY_LIMIT_MIB 512 4096
+      validate_integer_range KEYCLOAK_CPU_QUOTA_PERCENT 25 "$(( $(nproc) * 100 ))"
+      validate_integer_range KEYCLOAK_PIDS_LIMIT 64 1024
+      validate_integer_range KEYCLOAK_QUARKUS_TMPFS_MIB 32 256
+      validate_integer_range KEYCLOAK_TMPFS_MIB 128 2048
+    fi
   fi
 
   (( APP_RUNTIME_EXPORT_TMPFS_MIB * 2 <= APP_RUNTIME_MEMORY_LIMIT_MIB )) || \
@@ -201,11 +278,15 @@ configure_containment() {
   if [[ "$TOPOLOGY" == single-node ]]; then
     (( SQLSERVER_TMPFS_MIB * 2 <= SQLSERVER_MEMORY_LIMIT_MIB )) || \
       fail 'invalid SQLSERVER_TMPFS_MIB: must not exceed half SQLSERVER_MEMORY_LIMIT_MIB'
-    (( (KEYCLOAK_TMPFS_MIB + KEYCLOAK_QUARKUS_TMPFS_MIB) * 2 <= KEYCLOAK_MEMORY_LIMIT_MIB )) || \
-      fail 'invalid Keycloak tmpfs combination: must not exceed half KEYCLOAK_MEMORY_LIMIT_MIB'
+    if [[ "$IDENTITY_PROVIDER_MODE" != external ]]; then
+      (( (KEYCLOAK_TMPFS_MIB + KEYCLOAK_QUARKUS_TMPFS_MIB) * 2 <= KEYCLOAK_MEMORY_LIMIT_MIB )) || \
+        fail 'invalid Keycloak tmpfs combination: must not exceed half KEYCLOAK_MEMORY_LIMIT_MIB'
+    fi
     topology_cpu_capacity="$(( $(nproc) * 200 ))"
     (( topology_cpu_capacity <= 800 )) || topology_cpu_capacity=800
-    (( APP_RUNTIME_CPU_QUOTA_PERCENT + NGINX_CPU_QUOTA_PERCENT + SQLSERVER_CPU_QUOTA_PERCENT + KEYCLOAK_CPU_QUOTA_PERCENT <= topology_cpu_capacity )) || \
+    local identity_cpu_quota=0
+    [[ "$IDENTITY_PROVIDER_MODE" == external ]] || identity_cpu_quota="$KEYCLOAK_CPU_QUOTA_PERCENT"
+    (( APP_RUNTIME_CPU_QUOTA_PERCENT + NGINX_CPU_QUOTA_PERCENT + SQLSERVER_CPU_QUOTA_PERCENT + identity_cpu_quota <= topology_cpu_capacity )) || \
       fail 'invalid CPU quota combination: exceeds single-node CPU capacity'
   else
     topology_cpu_capacity="$(( $(nproc) * 100 ))"
@@ -383,7 +464,7 @@ verify_rootless_networking() {
     "$podman_bin" network rm "$network_name" >/dev/null 2>&1 || true
     fail 'rootless Podman cannot inspect the required bridge networks'
   }
-  if [[ "$TOPOLOGY" == single-node ]]; then
+  if [[ "$TOPOLOGY" == single-node && "$IDENTITY_PROVIDER_MODE" != external ]]; then
     "$podman_bin" create --name "$probe_name" --pull=never \
       --network "$network_name" \
       --add-host "${PUBLIC_HOSTNAME}:host-gateway" \
@@ -441,6 +522,9 @@ verify_host_enforcement() {
   if [[ "$TOPOLOGY" == app-node-* ]]; then
     (( (APP_RUNTIME_MEMORY_LIMIT_MIB + NGINX_MEMORY_LIMIT_MIB) * 4 <= total_memory_mib * 3 )) || \
       fail 'stateless service memory limits exceed 75% of app-node host memory'
+  elif [[ "$TOPOLOGY" == single-node && "$IDENTITY_PROVIDER_MODE" == external ]]; then
+    (( (APP_RUNTIME_MEMORY_LIMIT_MIB + NGINX_MEMORY_LIMIT_MIB + SQLSERVER_MEMORY_LIMIT_MIB) * 4 <= total_memory_mib * 3 )) || \
+      fail 'single-node service memory limits exceed 75% of host memory'
   else
     (( (APP_RUNTIME_MEMORY_LIMIT_MIB + NGINX_MEMORY_LIMIT_MIB + SQLSERVER_MEMORY_LIMIT_MIB + KEYCLOAK_MEMORY_LIMIT_MIB) * 4 <= total_memory_mib * 3 )) || \
       fail 'single-node service memory limits exceed 75% of host memory'
@@ -477,13 +561,24 @@ render_units() {
   [[ -d "$template_dir" ]] || fail "template directory is missing: $template_dir"
 
   read_release_env
+  configure_identity_provider
   validate_release_env "$TOPOLOGY"
+  validate_identity_provider
   configure_containment
   mkdir -p -- "$output_dir"
   remove_managed_units "$output_dir"
 
   while IFS= read -r template; do
     template_name="$(basename -- "$template")"
+    if [[ "$TOPOLOGY" == single-node && "$IDENTITY_PROVIDER_MODE" == external ]]; then
+      case "$template_name" in
+        kravhantering-keycloak-data.volume.template | \
+          kravhantering-keycloak.container.template | \
+          kravhantering-single-node-identity.network.template)
+          continue
+          ;;
+      esac
+    fi
     output_name="${template_name%.template}"
     render_template "$template" "$output_dir/$output_name"
   done < <(find "$template_dir" -maxdepth 1 -type f -name '*.template' | sort)

--- a/containers/production/env/keycloak.env.template
+++ b/containers/production/env/keycloak.env.template
@@ -1,5 +1,8 @@
 KC_HEALTH_ENABLED=true
 KC_HOSTNAME=https://kravhantering.example.internal/auth
+# Required with IDENTITY_PROVIDER_MODE=hardened-bundled. Use a management-only
+# hostname that resolves only through the approved management network or VPN.
+# KC_HOSTNAME_ADMIN=https://keycloak-management.example.internal:9443/auth
 KC_HTTP_ENABLED=true
 KC_HTTP_PORT=8080
 KC_PROXY_HEADERS=xforwarded

--- a/containers/production/env/release.env.template
+++ b/containers/production/env/release.env.template
@@ -13,6 +13,17 @@ NGINX_IMAGE_REF=registry.example.internal/nginx:replace-with-release-nginx-tag
 SQLSERVER_IMAGE_REF=registry.example.internal/mssql/server:replace-with-release-sqlserver-tag
 KEYCLOAK_IMAGE_REF=registry.example.internal/keycloak/keycloak:replace-with-release-keycloak-tag
 
+# Single-node identity-provider choice. The default bundled profile preserves
+# the convenient Keycloak setup for QA, demos, automated tests, prod-like
+# validation, and smoke tests. Use external to omit the bundled Keycloak units,
+# or hardened-bundled only after completing the production-hardening appendix.
+IDENTITY_PROVIDER_MODE=bundled
+
+# Required only with IDENTITY_PROVIDER_MODE=hardened-bundled. Bind the separate
+# mTLS-protected management listener to an explicit host IPv4 address. Wildcard
+# binds fail validation; the final container port must remain 9443.
+# KEYCLOAK_MANAGEMENT_HTTPS_BIND=10.20.30.40:9443:9443
+
 # Opt-in only when approved to pull public upstream registries directly.
 # Use image:tag values derived from container-stack.lock.json and verify
 # immediately because public tags can be republished. The image helper also

--- a/containers/production/nginx/nginx.conf
+++ b/containers/production/nginx/nginx.conf
@@ -16,7 +16,8 @@ http {
 
     log_format main '$remote_addr - $remote_user [$time_local] "$request" '
                     '$status $body_bytes_sent "$http_referer" '
-                    '"$http_user_agent" "$http_x_forwarded_for"';
+                    '"$http_user_agent" "$http_x_forwarded_for" '
+                    'upstream="$upstream_addr"';
 
     access_log /dev/stdout main;
 

--- a/containers/production/nginx/templates/keycloak-management-proxy-headers.conf
+++ b/containers/production/nginx/templates/keycloak-management-proxy-headers.conf
@@ -1,0 +1,6 @@
+proxy_http_version 1.1;
+proxy_set_header Host $host;
+proxy_set_header X-Forwarded-Proto https;
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Port 9443;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/containers/production/nginx/templates/keycloak-proxy-headers.conf
+++ b/containers/production/nginx/templates/keycloak-proxy-headers.conf
@@ -3,4 +3,4 @@ proxy_set_header Host $host;
 proxy_set_header X-Forwarded-Proto https;
 proxy_set_header X-Forwarded-Host $host;
 proxy_set_header X-Forwarded-Port 443;
-proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-For $remote_addr;

--- a/containers/production/nginx/templates/keycloak-proxy-headers.conf
+++ b/containers/production/nginx/templates/keycloak-proxy-headers.conf
@@ -1,0 +1,6 @@
+proxy_http_version 1.1;
+proxy_set_header Host $host;
+proxy_set_header X-Forwarded-Proto https;
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header X-Forwarded-Port 443;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/containers/production/nginx/templates/single-node-external-oidc-tls.conf.template
+++ b/containers/production/nginx/templates/single-node-external-oidc-tls.conf.template
@@ -1,0 +1,50 @@
+# cSpell:words fullchain privkey
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+upstream app_runtime_upstream {
+    zone app_runtime_upstream 64k;
+    resolver ${NGINX_RESOLVER} valid=10s ipv6=off;
+    resolver_timeout 5s;
+    server app-runtime:3000 resolve;
+}
+
+server {
+    listen 8443 ssl;
+    http2 on;
+    server_name _;
+
+    ssl_certificate /etc/nginx/tls/fullchain.pem;
+    ssl_certificate_key /etc/nginx/tls/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+
+    location = /api-docs/hsa-person-lookup {
+        include /etc/nginx/snippets/api-docs-security-headers.conf;
+        return 308 /api-docs/hsa-person-lookup/;
+    }
+
+    location /api-docs/ {
+        include /etc/nginx/snippets/api-docs-security-headers.conf;
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ =404;
+    }
+
+    include /etc/nginx/snippets/generated-output-locations.conf;
+
+    location / {
+        proxy_pass http://app_runtime_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port 443;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+}

--- a/containers/production/nginx/templates/single-node-hardened-keycloak-tls.conf.template
+++ b/containers/production/nginx/templates/single-node-hardened-keycloak-tls.conf.template
@@ -1,0 +1,125 @@
+# cSpell:words fullchain privkey
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+upstream keycloak_upstream {
+    zone keycloak_upstream 64k;
+    resolver ${NGINX_IDENTITY_RESOLVER} valid=10s ipv6=off;
+    resolver_timeout 5s;
+    server keycloak:8080 resolve;
+}
+
+upstream app_runtime_upstream {
+    zone app_runtime_upstream 64k;
+    resolver ${NGINX_RESOLVER} valid=10s ipv6=off;
+    resolver_timeout 5s;
+    server app-runtime:3000 resolve;
+}
+
+server {
+    listen 8443 ssl;
+    http2 on;
+    server_name _;
+
+    ssl_certificate /etc/nginx/tls/fullchain.pem;
+    ssl_certificate_key /etc/nginx/tls/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+
+    location = /auth {
+        return 404;
+    }
+
+    location = /auth/error {
+        proxy_pass http://app_runtime_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port 443;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location = /auth/realms/kravhantering-production {
+        proxy_pass http://keycloak_upstream/realms/kravhantering-production;
+        include /etc/nginx/snippets/keycloak-proxy-headers.conf;
+    }
+
+    location = /auth/realms/kravhantering-production/clients-registrations {
+        return 404;
+    }
+
+    location ^~ /auth/realms/kravhantering-production/clients-registrations/ {
+        return 404;
+    }
+
+    location ^~ /auth/realms/kravhantering-production/ {
+        proxy_pass http://keycloak_upstream/realms/kravhantering-production/;
+        include /etc/nginx/snippets/keycloak-proxy-headers.conf;
+    }
+
+    location ^~ /auth/resources/ {
+        proxy_pass http://keycloak_upstream/resources/;
+        include /etc/nginx/snippets/keycloak-proxy-headers.conf;
+    }
+
+    location /auth/ {
+        return 404;
+    }
+
+    location = /api-docs/hsa-person-lookup {
+        include /etc/nginx/snippets/api-docs-security-headers.conf;
+        return 308 /api-docs/hsa-person-lookup/;
+    }
+
+    location /api-docs/ {
+        include /etc/nginx/snippets/api-docs-security-headers.conf;
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ =404;
+    }
+
+    include /etc/nginx/snippets/generated-output-locations.conf;
+
+    location / {
+        proxy_pass http://app_runtime_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port 443;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+}
+
+server {
+    listen 9443 ssl;
+    http2 on;
+    server_name _;
+
+    ssl_certificate /etc/nginx/keycloak-management-tls/fullchain.pem;
+    ssl_certificate_key /etc/nginx/keycloak-management-tls/privkey.pem;
+    ssl_client_certificate /etc/nginx/keycloak-management-tls/client-ca.crt;
+    ssl_verify_client on;
+    ssl_verify_depth 2;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+
+    location = /auth {
+        return 308 /auth/;
+    }
+
+    location /auth/ {
+        proxy_pass http://keycloak_upstream/;
+        include /etc/nginx/snippets/keycloak-management-proxy-headers.conf;
+    }
+
+    location / {
+        return 404;
+    }
+}

--- a/containers/production/quadlet/templates/single-node/kravhantering-app-runtime.container.template
+++ b/containers/production/quadlet/templates/single-node/kravhantering-app-runtime.container.template
@@ -1,8 +1,8 @@
 [Unit]
 Description=Kravhantering application runtime
 PartOf=kravhantering-single-node.target
-Requires=kravhantering-single-node-edge-network.service kravhantering-single-node-database-network.service kravhantering-single-node-egress-network.service kravhantering-sqlserver.service kravhantering-keycloak.service
-After=kravhantering-single-node-edge-network.service kravhantering-single-node-database-network.service kravhantering-single-node-egress-network.service kravhantering-sqlserver.service kravhantering-keycloak.service
+Requires=kravhantering-single-node-edge-network.service kravhantering-single-node-database-network.service kravhantering-single-node-egress-network.service kravhantering-sqlserver.service @@KEYCLOAK_APP_DEPENDENCIES@@
+After=kravhantering-single-node-edge-network.service kravhantering-single-node-database-network.service kravhantering-single-node-egress-network.service kravhantering-sqlserver.service @@KEYCLOAK_APP_DEPENDENCIES@@
 
 [Container]
 ContainerName=kravhantering-app-runtime

--- a/containers/production/quadlet/templates/single-node/kravhantering-app-runtime.container.template
+++ b/containers/production/quadlet/templates/single-node/kravhantering-app-runtime.container.template
@@ -20,7 +20,7 @@ Network=kravhantering-single-node-edge.network
 Network=kravhantering-single-node-database.network
 Network=kravhantering-single-node-egress.network
 PodmanArgs=--network-alias=app-runtime
-PodmanArgs=--add-host=@@PUBLIC_HOSTNAME@@:host-gateway
+@@PUBLIC_ISSUER_HOST_MAPPING@@
 Volume=/etc/kravhantering/tls/ca.crt:/run/kravhantering/tls/ca.crt:ro
 @@APP_RUNTIME_EXPORT_MOUNT@@
 Tmpfs=/tmp:rw,size=64M,mode=1777,nosuid,nodev,noexec

--- a/containers/production/quadlet/templates/single-node/kravhantering-nginx.container.template
+++ b/containers/production/quadlet/templates/single-node/kravhantering-nginx.container.template
@@ -1,8 +1,8 @@
 [Unit]
 Description=Kravhantering nginx TLS edge
 PartOf=kravhantering-single-node.target
-Requires=kravhantering-app-runtime.service kravhantering-keycloak.service
-After=kravhantering-app-runtime.service kravhantering-keycloak.service
+Requires=kravhantering-app-runtime.service @@KEYCLOAK_NGINX_DEPENDENCIES@@
+After=kravhantering-app-runtime.service @@KEYCLOAK_NGINX_DEPENDENCIES@@
 
 [Container]
 ContainerName=kravhantering-nginx
@@ -15,22 +15,26 @@ ReadOnlyTmpfs=false
 PidsLimit=@@NGINX_PIDS_LIMIT@@
 LogDriver=journald
 Environment=NGINX_RESOLVER=@@NGINX_RESOLVER@@
-Environment=NGINX_IDENTITY_RESOLVER=@@NGINX_IDENTITY_RESOLVER@@
+@@KEYCLOAK_NGINX_ENVIRONMENT@@
 PublishPort=@@NGINX_HTTPS_PUBLISH@@
+@@NGINX_KEYCLOAK_MANAGEMENT_PUBLISH@@
 Network=kravhantering-single-node-edge.network
-Network=kravhantering-single-node-identity.network
+@@KEYCLOAK_NGINX_NETWORK@@
 PodmanArgs=--network-alias=nginx
 PodmanArgs=--group-add=keep-groups
 Tmpfs=/etc/nginx/conf.d:rw,size=1M,mode=0755,U,notmpcopyup,nosuid,nodev,noexec
 Tmpfs=/var/cache/nginx:rw,size=@@NGINX_CACHE_TMPFS_MIB@@M,mode=0750,U,notmpcopyup,nosuid,nodev,noexec
 Tmpfs=/run:rw,size=1M,mode=0755,U,notmpcopyup,nosuid,nodev,noexec
 Volume=@@BUNDLE_ROOT@@/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-Volume=@@BUNDLE_ROOT@@/nginx/templates/single-node-tls.conf.template:/etc/nginx/templates/default.conf.template:ro
+Volume=@@BUNDLE_ROOT@@/nginx/templates/@@NGINX_SINGLE_NODE_TEMPLATE@@:/etc/nginx/templates/default.conf.template:ro
 Volume=@@BUNDLE_ROOT@@/nginx/templates/api-docs-security-headers.conf:/etc/nginx/snippets/api-docs-security-headers.conf:ro
 Volume=@@BUNDLE_ROOT@@/nginx/templates/generated-output-locations.conf:/etc/nginx/snippets/generated-output-locations.conf:ro
+Volume=@@BUNDLE_ROOT@@/nginx/templates/keycloak-proxy-headers.conf:/etc/nginx/snippets/keycloak-proxy-headers.conf:ro
+Volume=@@BUNDLE_ROOT@@/nginx/templates/keycloak-management-proxy-headers.conf:/etc/nginx/snippets/keycloak-management-proxy-headers.conf:ro
 Volume=@@BUNDLE_ROOT@@/api-docs:/usr/share/nginx/html/api-docs:ro
 Volume=/etc/kravhantering/tls/fullchain.pem:/etc/nginx/tls/fullchain.pem:ro
 Volume=/etc/kravhantering/tls/privkey.pem:/etc/nginx/tls/privkey.pem:ro
+@@KEYCLOAK_MANAGEMENT_MTLS_VOLUMES@@
 
 [Service]
 Restart=always

--- a/containers/production/quadlet/templates/single-node/kravhantering-single-node.target.template
+++ b/containers/production/quadlet/templates/single-node/kravhantering-single-node.target.template
@@ -1,7 +1,7 @@
 [Unit]
 Description=Kravhantering single-node services
-Requires=kravhantering-sqlserver.service kravhantering-keycloak.service kravhantering-app-runtime.service kravhantering-nginx.service
-After=kravhantering-sqlserver.service kravhantering-keycloak.service kravhantering-app-runtime.service kravhantering-nginx.service
+Requires=kravhantering-sqlserver.service @@KEYCLOAK_TARGET_DEPENDENCIES@@ kravhantering-app-runtime.service kravhantering-nginx.service
+After=kravhantering-sqlserver.service @@KEYCLOAK_TARGET_DEPENDENCIES@@ kravhantering-app-runtime.service kravhantering-nginx.service
 
 [Install]
 WantedBy=default.target

--- a/docs/integrations/oidc-identity-provider-integration.md
+++ b/docs/integrations/oidc-identity-provider-integration.md
@@ -12,6 +12,26 @@ deployment and for the external IdP. Where this document and the current code
 differ, this document should be read as target deployment intent rather than
 current implementation.
 
+## Self-Contained Single-Node Identity Profiles
+
+The self-contained single-node topology requires an explicit identity-provider
+choice through `IDENTITY_PROVIDER_MODE`:
+
+- `bundled` is the default. It keeps the convenient bundled Keycloak service
+  for QA, demos, automated tests, prod-like validation and smoke tests. Its
+  shared user and administration ingress is not sufficiently secure for
+  production.
+- `external` omits the bundled Keycloak service. Configure the application
+  contract below against an OIDC-compatible provider selected and operated by
+  the deployer.
+- `hardened-bundled` is the explicit bundled-Keycloak production option. It
+  separates user-facing application access from fail-closed management-only
+  access and requires the complete
+  [production-hardening appendix](../operations/rhel10-production-single-node-self-contained-deploy.md#appendix-c-production-hardened-bundled-keycloak).
+
+The profile changes how the provider is hosted, not the application roles,
+claims, session behavior or provider-neutral OIDC contract in this guide.
+
 ## Target Production Setup
 
 At a high level, the production-facing connections look like this:

--- a/docs/operations/rhel10-production-deploy.md
+++ b/docs/operations/rhel10-production-deploy.md
@@ -24,6 +24,16 @@ For upgrades and rollback, use
 To uninstall a first install of this topology, use
 [rhel10-production-uninstall.md](./rhel10-production-uninstall.md).
 
+>[!WARNING]
+>The self-contained single-node topology keeps an easy bundled Keycloak
+>profile as its default for QA, demos, automated testing, prod-like validation
+>and smoke tests. That default is not sufficiently secure for production.
+>Production single-node deployments must choose an external OIDC provider or
+>explicitly select and verify the
+>[production-hardened bundled Keycloak appendix](./rhel10-production-single-node-self-contained-deploy.md#appendix-c-production-hardened-bundled-keycloak).
+
+<!-- Separate consecutive GitHub alerts for markdownlint MD028. -->
+
 >[!IMPORTANT]
 >For disconnected deployment, first follow
 >[rhel10-production-disconnected.md](./rhel10-production-disconnected.md). The
@@ -732,6 +742,21 @@ and restarting Keycloak only affects a first import, not a running realm.
 
 Do not import the release-smoke realm into production. The smoke-test realm
 contains public test credentials.
+
+### Production-Hardened Bundled Keycloak Appendix
+
+This app-node guide normally uses a deployer-operated external IdP. If the
+deployment instead chooses bundled Keycloak on the self-contained single-node
+host, the complete and equivalent production-hardening contract is
+[Appendix C in the single-node topology guide](./rhel10-production-single-node-self-contained-deploy.md#appendix-c-production-hardened-bundled-keycloak).
+
+That appendix is mandatory for this choice. It separates **user-facing
+application access** from **management-only access** without assuming either
+surface is exposed to the public Internet. It covers fail-closed ingress,
+individual administrator identities, MFA and recovery, bootstrap-account
+retirement, verification, upgrades, rollback, backup, recovery, uninstall and
+incident response. Do not substitute `KC_HOSTNAME_ADMIN` alone for the reverse
+proxy and network controls in that appendix.
 
 ## App Node Start Alternatives
 

--- a/docs/operations/rhel10-production-single-node-self-contained-deploy.md
+++ b/docs/operations/rhel10-production-single-node-self-contained-deploy.md
@@ -18,6 +18,14 @@ Red Hat Enterprise Linux 10 host from released artifacts only, with nginx,
 `db-job` runs explicitly on the database Quadlet network for release
 operations.
 
+>[!WARNING]
+>The default bundled Keycloak profile is intentionally easy to operate for
+>quality assurance, demos, automated testing, prod-like validation and smoke
+>tests. It is not sufficiently secure for production. Do not use bundled
+>Keycloak in production unless `IDENTITY_PROVIDER_MODE=hardened-bundled` and
+>all controls in [Appendix C](#appendix-c-production-hardened-bundled-keycloak)
+>are implemented and verified.
+
 Apply the shared containment defaults, validated override ranges, network
 ownership, and host preflight in
 [Production Quadlet Containment](production-quadlet-containment.md).
@@ -37,6 +45,24 @@ To uninstall a first install of this topology, use
 >The disconnected guide prepares the transferable bundle, imports the release
 >directory and images on the disconnected host, and tells you where to resume
 >these regular deployment steps.
+
+## Choose the Identity Provider Profile
+
+Record exactly one choice in `/etc/kravhantering/release.env`. Omitting the
+setting preserves `bundled`, the existing default.
+
+<!-- markdownlint-disable MD013 -->
+| `IDENTITY_PROVIDER_MODE` | Intended use | Bundled Keycloak | Required action |
+| --- | --- | --- | --- |
+| `bundled` | QA, demos, automated testing, prod-like validation and smoke tests | Installed with the permissive `/auth/` proxy | Do not use for production. Disposable bootstrap credentials may remain only in these non-production environments. |
+| `external` | Production or pre-production with a deployer-selected OIDC-compatible provider | Not installed or required | Configure the external issuer, client, redirects, logout, claims and trust in `app.env`. The deployer operates and secures the provider. |
+| `hardened-bundled` | Explicitly approved production use of bundled Keycloak | Installed with separated user-facing and mTLS management ingress | Complete and verify Appendix C before serving users. |
+<!-- markdownlint-enable MD013 -->
+
+The mode controls rendered services as well as image verification. In
+`external` mode the single-node host still provides nginx, `app-runtime` and
+SQL Server, but it renders no Keycloak container, Keycloak volume or identity
+network and does not require `KEYCLOAK_IMAGE_REF`.
 
 ![Kravhantering Infographic Single Node Access Flow](../images/infographic-single-node-access-flow.png)
 
@@ -93,6 +119,8 @@ verification.
 | Name | Applies to | Default / derived value | Plan or record when |
 | --- | --- | --- | --- |
 | `VERSION` | Release artifact names | No default | Always record the release version to install, for example `1.2.3`. |
+| `IDENTITY_PROVIDER_MODE` | Single-node rendered services and nginx identity ingress | `bundled` | Always record the approved choice: `bundled`, `external` or `hardened-bundled`. Production may use only `external` or the fully verified `hardened-bundled` option. |
+| `KEYCLOAK_MANAGEMENT_HTTPS_BIND` | Hardened bundled Keycloak management-only listener | No default | Required only for `hardened-bundled`; use an explicit host IPv4 and mapping to container port `9443`, for example `10.20.30.40:9443:9443`. Wildcard and malformed binds fail closed during rendering. |
 | `APP_HOST` | `PUBLIC_HOSTNAME`, app URLs, `KC_HOSTNAME`, realm redirect/logout settings, realm web origins, TLS certificate SANs and smoke checks | No default | Always record the public DNS name without `https://`, for example `kravhantering.example.internal`. |
 | `NEXT_PUBLIC_SITE_URL` | `NEXT_PUBLIC_SITE_URL` in `app.env` | `https://<APP_HOST>` | Verify after choosing `APP_HOST`; plan only if the public URL cannot use the normal scheme and host. |
 | `KRAVHANTERING_EXPORT_TEMP_DIR` | Optional absolute spool root in `app.env` | Unset/blank (OS temporary directory) | Set only when generated CSV/PDF files need a dedicated filesystem. Use an existing private directory that grants only the non-root operating-system account running Node.js read/write/search access (for example, app-owned mode `0700`). Whether set or unset, verify the directory from inside `app-runtime` and size it for configured CSV/PDF concurrency times maximum file sizes plus headroom. When unset or blank, this verification of the container operating-system temporary directory is mandatory. |
@@ -759,6 +787,30 @@ shell, not from the `kravhantering` service-user shell used for image pulls.
 
 ### `/etc/kravhantering/release.env`
 
+Set the identity-provider choice first. The unchanged easy default is:
+
+```env
+IDENTITY_PROVIDER_MODE=bundled
+```
+
+For a deployer-operated external OIDC provider, use:
+
+```env
+IDENTITY_PROVIDER_MODE=external
+```
+
+For explicitly approved production use of bundled Keycloak, complete
+[Appendix C](#appendix-c-production-hardened-bundled-keycloak) and use:
+
+```env
+IDENTITY_PROVIDER_MODE=hardened-bundled
+KEYCLOAK_MANAGEMENT_HTTPS_BIND=10.20.30.40:9443:9443
+```
+
+Replace `10.20.30.40` with the host address reachable only through the
+approved management network or VPN. The hardened listener also requires mTLS;
+the explicit bind and mTLS are independent controls.
+
 Set `PUBLIC_HOSTNAME` to the public DNS name without `https://`. This must be
 the same hostname used by `NEXT_PUBLIC_SITE_URL`, `KC_HOSTNAME`, redirect URIs
 and the TLS certificate SAN:
@@ -776,7 +828,8 @@ process to bind container port 443. Podman 4.9 does not expose Quadlet's newer
 `PodmanArgs=--add-host`; the helper's generator preflight rejects hosts where
 that compatibility form is unavailable.
 
-Set `NGINX_RESOLVER` and `NGINX_IDENTITY_RESOLVER` to the Podman DNS resolvers
+Set `NGINX_RESOLVER` and, when Keycloak is bundled,
+`NGINX_IDENTITY_RESOLVER` to the Podman DNS resolvers
 that nginx should use for dynamic `app-runtime` and Keycloak lookups. Podman
 DNS is scoped to each network, so single-node nginx needs the edge resolver for
 `app-runtime` and the identity resolver for Keycloak. These values might not be
@@ -795,7 +848,8 @@ release requirements. nginx uses them to re-resolve upstream container names aft
 The resolver can change when the internal Quadlet network is recreated or
 assigned another subnet. Before starting nginx, run the resolver
 check below and update both resolver values in
-`/etc/kravhantering/release.env` if either differs.
+`/etc/kravhantering/release.env` if either differs. The `external` profile does
+not render an identity network and ignores `NGINX_IDENTITY_RESOLVER`.
 
 SQL Server is only available internally on the
 `kravhantering-single-node_database` Podman network. Connect to it as
@@ -922,6 +976,31 @@ OPENROUTER_API_KEY=
 OPENROUTER_MGMT_API_KEY=
 ```
 
+For `IDENTITY_PROVIDER_MODE=external`, replace the bundled issuer and client
+values with the registration supplied by the deployer-selected provider. The
+provider must support OIDC Authorization Code with PKCE, discovery, signing
+keys, token exchange, user-info and logout. Register the exact application
+callback and post-logout URLs shown below and configure the canonical `roles`
+and `employeeHsaId` claims described in
+[OIDC Identity Provider Integration](../integrations/oidc-identity-provider-integration.md):
+
+```env
+AUTH_OIDC_ISSUER_URL=https://idp.example.internal/realms/kravhantering
+AUTH_OIDC_CLIENT_ID=kravhantering-app
+AUTH_OIDC_CLIENT_SECRET=<external-provider-client-secret>
+AUTH_OIDC_REDIRECT_URI=https://kravhantering.example.internal/api/auth/callback
+AUTH_OIDC_POST_LOGOUT_REDIRECT_URI=https://kravhantering.example.internal/
+AUTH_OIDC_ROLES_CLAIM=roles
+AUTH_OIDC_SCOPES=openid profile email
+AUTH_OIDC_API_AUDIENCE=kravhantering-app
+```
+
+Install any private issuer CA in the app runtime trust path before startup.
+Use the bilingual
+[External IdP Handoff](../integrations/external-idp-handoff.md) to verify
+issuer, client, redirect, logout, claim and trust ownership. Do not copy or
+configure `keycloak.env` or the realm import for this mode.
+
 Generate `AUTH_SESSION_COOKIE_PASSWORD` as described in
 [Generate Unique Secrets](#generate-unique-secrets). Keep
 `AUTH_OIDC_CLIENT_SECRET` equal to the `kravhantering-app` client `secret`
@@ -986,6 +1065,9 @@ in it.
 
 ### `/etc/kravhantering/keycloak.env`
 
+This file applies only to `bundled` and `hardened-bundled`. Skip it for
+`external`.
+
 Set Keycloak's public hostname and administrator account:
 
 ```env
@@ -1011,9 +1093,13 @@ realm role. Choose any approved admin username and a strong unique password,
 store it in the deployment secret store, and do not leave the template
 placeholder values in place.
 
-After the stack is running, the bundled Keycloak admin console is available
-through nginx at `https://kravhantering.example.internal/auth/admin/`. From the
-application origin, the same console is reachable as `../auth/admin/`.
+In the non-production `bundled` profile, the Keycloak admin console is
+available through nginx at
+`https://kravhantering.example.internal/auth/admin/`. This shared path is one
+reason that profile is not sufficiently secure for production. The
+`hardened-bundled` profile denies the admin console, Admin REST API and master
+realm on user-facing application access and exposes them only through the
+management-only access described in Appendix C.
 The exact application path `/auth/error` remains handled by the app runtime so
 failed OIDC callbacks can show the Kravhantering error page even though the
 rest of `/auth/` is proxied to Keycloak.
@@ -1403,9 +1489,15 @@ cd /opt/kravhantering/current
 bin/kravhantering-quadlet.sh install --topology single-node
 systemctl --user daemon-reload
 systemctl --user start kravhantering-sqlserver.service
-systemctl --user start kravhantering-keycloak.service
 journalctl --user-unit kravhantering-sqlserver.service -n 100 --no-pager
-journalctl --user-unit kravhantering-keycloak.service -n 100 --no-pager
+
+set -a
+. /etc/kravhantering/release.env
+set +a
+if [ "${IDENTITY_PROVIDER_MODE:-bundled}" != external ]; then
+  systemctl --user start kravhantering-keycloak.service
+  journalctl --user-unit kravhantering-keycloak.service -n 100 --no-pager
+fi
 
 exit
 ```
@@ -1425,22 +1517,25 @@ set -a
 set +a
 
 systemctl --user start kravhantering-single-node-edge-network.service
-systemctl --user start kravhantering-single-node-identity-network.service
 EDGE_RESOLVER="$(
   bin/kravhantering-quadlet.sh print-resolver \
     --topology single-node --purpose edge
 )"
-IDENTITY_RESOLVER="$(
-  bin/kravhantering-quadlet.sh print-resolver \
-    --topology single-node --purpose identity
-)"
-printf 'Use NGINX_RESOLVER=%s and NGINX_IDENTITY_RESOLVER=%s\n' \
-  "$EDGE_RESOLVER" "$IDENTITY_RESOLVER"
+printf 'Use NGINX_RESOLVER=%s\n' "$EDGE_RESOLVER"
+if [ "${IDENTITY_PROVIDER_MODE:-bundled}" != external ]; then
+  systemctl --user start kravhantering-single-node-identity-network.service
+  IDENTITY_RESOLVER="$(
+    bin/kravhantering-quadlet.sh print-resolver \
+      --topology single-node --purpose identity
+  )"
+  printf 'Use NGINX_IDENTITY_RESOLVER=%s\n' "$IDENTITY_RESOLVER"
+fi
 
 exit
 ```
 
-Update both values before starting nginx:
+Update the edge value before starting nginx. For a bundled mode, also update
+the identity value:
 
 ```bash
 # Replace these examples with the printed resolver IPs.
@@ -2385,3 +2480,239 @@ WHERE session_id = @@SPID;
 ```
 
 The result must be `TRUE`.
+
+## Appendix C: Production-Hardened Bundled Keycloak
+
+Use this appendix only after an accountable operator explicitly chooses
+bundled Keycloak for production. The ordinary application and both Keycloak
+paths may remain inside an organization-controlled network. The security
+boundary is between **user-facing application access** and
+**management-only access**; it does not depend on exposure to the public
+Internet.
+
+The hardened profile follows Keycloak's current guidance to use a separate
+administration hostname and to enforce Admin REST API restrictions at the
+reverse proxy. `KC_HOSTNAME_ADMIN` changes generated URLs but does not itself
+block the API on the frontend URL. See Keycloak's
+[hostname](https://www.keycloak.org/server/hostname),
+[reverse proxy](https://www.keycloak.org/server/reverseproxy) and
+[production configuration](https://www.keycloak.org/server/configuration-production)
+guides.
+
+### Access Contract
+
+The supplied hardened nginx profile exposes these surfaces:
+
+<!-- markdownlint-disable MD013 -->
+| Access surface | Allowed paths | Enforcement |
+| --- | --- | --- |
+| User-facing application access on port 443 | The application, `/auth/error`, required OIDC paths below `/auth/realms/kravhantering-production/`, and `/auth/resources/` | `/auth/admin/`, `/auth/realms/master/`, the production realm's `/clients-registrations/` surface, `/auth` and every other Keycloak path return `404` in nginx before proxy selection. Required discovery, signing-key, authorization, token, callback, logout, user-info, login-continuation and browser-resource flows remain below the allowed production realm and resource paths. |
+| Management-only access on port 9443 | `/auth/`, including the console, Admin REST API and master-realm authentication | An explicit non-wildcard host bind plus mandatory client-certificate verification. Requests without a certificate signed by the configured management client CA fail before Keycloak. |
+| Direct Keycloak container access | None from user-facing or application networks | Keycloak remains only on the internal identity network. nginx is the only attached proxy. |
+<!-- markdownlint-enable MD013 -->
+
+Do not add a broader `/auth/` proxy to the user-facing server. Do not publish
+Keycloak port 8080 or management port 9000. Do not treat
+`KC_HOSTNAME_ADMIN` as an access control.
+
+### Configure the Management Boundary
+
+Choose a management hostname and an explicit host IPv4 address reachable only
+through an approved internal management network or VPN. The supplied profile
+also requires mTLS, including when network access is already restricted.
+
+Set `/etc/kravhantering/release.env`:
+
+```env
+IDENTITY_PROVIDER_MODE=hardened-bundled
+KEYCLOAK_MANAGEMENT_HTTPS_BIND=10.20.30.40:9443:9443
+```
+
+Set `/etc/kravhantering/keycloak.env`:
+
+```env
+KC_HOSTNAME=https://kravhantering.example.internal/auth
+KC_HOSTNAME_ADMIN=https://keycloak-management.example.internal:9443/auth
+KC_PROXY_HEADERS=xforwarded
+```
+
+The management DNS name must resolve to the selected management address only
+for approved operator clients. Issue a separate server certificate for that
+name and a client certificate from the approved management client CA. Install:
+
+```text
+/etc/kravhantering/keycloak-management-tls/fullchain.pem
+/etc/kravhantering/keycloak-management-tls/privkey.pem
+/etc/kravhantering/keycloak-management-tls/client-ca.crt
+```
+
+Use owner `root`, group `kravhantering`, mode `0644` for certificates and
+`0640` for the private key. Apply `container_file_t` to the directory. Keep
+operator client certificates and keys in the organization's endpoint identity
+or secret-management system; do not store client private keys on the server.
+
+Allow inbound TCP 9443 only from the approved management network or VPN. A
+firewall rule is still required even though mTLS is enabled. Missing files,
+an empty or malformed bind, a wildcard bind, or a container target other than
+9443 makes Quadlet rendering fail closed.
+
+Reinstall and restart the topology after setting the profile:
+
+```bash
+sudo chcon -R -t container_file_t \
+  /etc/kravhantering/keycloak-management-tls
+
+sudo -iu kravhantering
+cd /opt/kravhantering/current
+bin/kravhantering-quadlet.sh install --topology single-node
+systemctl --user daemon-reload
+systemctl --user restart kravhantering-single-node.target
+exit
+```
+
+### Provision Attributable Administrators
+
+Treat `KEYCLOAK_ADMIN` and `KEYCLOAK_ADMIN_PASSWORD` as temporary first-start
+provisioning inputs. They are not acceptable steady-state credentials.
+
+1. Start Keycloak only through the hardened profile and connect through
+   management-only access with the bootstrap identity.
+2. Create at least two individual named administrator accounts in the master
+   realm. Do not share accounts. Grant the minimum realm-management roles each
+   operator needs.
+3. Require MFA for every administrator. Enroll and verify each administrator's
+   MFA before removing bootstrap access. Apply the site's phishing-resistant
+   method where available; otherwise require Keycloak OTP under the approved
+   authentication policy.
+4. Register recovery factors or sealed recovery material under dual control.
+   Test the recovery runbook with a named account without disabling MFA for
+   the administrator population.
+5. Sign in separately as each named administrator through management-only
+   access and verify the required console and Admin REST API operations.
+6. Delete or disable the temporary bootstrap administrator. Remove
+   `KEYCLOAK_ADMIN` and `KEYCLOAK_ADMIN_PASSWORD` from `keycloak.env` and from
+   every secret, automation and configuration source used at steady state.
+7. Restart Keycloak. Attempt master-realm authentication with the retired
+   identity and record the failed result. Search the configuration and secret
+   inventory for reusable bootstrap credentials; the result must be empty.
+
+Keycloak documents startup and recovery administrators as temporary accounts
+that must be removed after permanent access exists. Follow
+[Bootstrapping and recovering an admin account](https://www.keycloak.org/server/bootstrap-admin-recovery)
+for the installed Keycloak version.
+
+Disposable QA, demo and test environments may keep their documented test
+administrator because the `bundled` profile is deliberately test-oriented.
+Never promote those credentials, realm data or recovery artifacts into the
+hardened production profile.
+
+### Verify Before User Traffic
+
+Run all checks from both an ordinary application client and an approved
+management client. Save status codes and sanitized nginx access-log lines.
+
+From user-facing application access, all of these must return `404`:
+
+```bash
+curl --fail-with-body \
+  https://kravhantering.example.internal/auth/admin/
+curl --fail-with-body \
+  https://kravhantering.example.internal/auth/admin/realms
+curl --fail-with-body \
+  https://kravhantering.example.internal/auth/realms/master/
+curl --fail-with-body \
+  https://kravhantering.example.internal/auth/realms/kravhantering-production/clients-registrations/default
+```
+
+Because `curl --fail-with-body` exits nonzero for `404`, a nonzero result with
+that exact status is expected. In nginx access logs, each denial must show
+`upstream="-"`, proving rejection before Keycloak. Confirm that the Keycloak
+admin console, Admin REST API, master-realm token surface and dynamic client
+registration surface cannot be reached through user-facing application access.
+
+From management-only access, first prove a request without a client
+certificate fails. Then use an approved operator certificate:
+
+```bash
+MGMT=https://keycloak-management.example.internal:9443
+CLIENT_CERT=/secure/operator/keycloak-management.crt
+CLIENT_KEY=/secure/operator/keycloak-management.key
+CLIENT_CA=/secure/operator/keycloak-management-ca.crt
+
+curl --fail --cacert "$CLIENT_CA" "$MGMT/auth/admin/"
+
+curl --fail --cacert "$CLIENT_CA" \
+  --cert "$CLIENT_CERT" --key "$CLIENT_KEY" \
+  "$MGMT/auth/admin/master/console/"
+```
+
+Use a named administrator token to make a read-only Admin REST API request and
+record success. Do not place tokens in evidence. Missing, malformed, expired
+or untrusted client certificates must fail closed and must never fall back to
+the user-facing listener.
+
+Finally verify all intended client flows through user-facing application
+access: discovery, JWKS/signing keys, authorization and PKCE callback, login
+continuations and resources, token exchange, user-info, logout, authentication
+error handling, application sign-in and application sign-out. `/api/ready`
+must remain ready. The production smoke performs the public denial, upstream
+selection, mTLS management console/API and browser login/logout checks.
+
+### Upgrade, Rollback, Backup and Recovery
+
+Classify every maintenance record as `bundled` test-oriented, `external`, or
+`hardened-bundled` before acting.
+
+- **Upgrade:** back up Keycloak data and realm configuration, preserve the
+  previous Keycloak image, nginx template, `keycloak.env`, management
+  certificates and firewall policy, then review the Keycloak upgrading guide.
+  Keep user-facing administration denial active throughout the maintenance
+  window. After upgrade, repeat every access and OIDC verification above
+  before reopening user traffic.
+- **Rollback:** stop the target before restoring a compatible Keycloak image
+  and data backup. Keycloak schema changes can make an old image incompatible
+  with upgraded data; never point the old image at upgraded state unless the
+  release-specific rollback procedure permits it. Restore the previous nginx
+  and management certificate configuration as one set, then re-verify both
+  access surfaces.
+- **Backup:** stop Keycloak or use a site-approved application-consistent
+  database/volume snapshot method. Back up the Keycloak data volume, realm and
+  client configuration, management server certificate chain, firewall and DNS
+  configuration, and a reference to client-CA custody. Store private keys and
+  credentials only in the approved secret backup. Test restoration on an
+  isolated identity network.
+- **Recovery:** restore data and configuration with user-facing traffic
+  closed. If all named administrators are unavailable, stop every Keycloak
+  node and use Keycloak's dedicated `bootstrap-admin` command to create one
+  temporary recovery account. Recover named MFA-protected administration,
+  delete the temporary account and its secret, then repeat the retirement and
+  access verification. Do not expose a temporary recovery route on port 443.
+- **Uninstall:** distinguish application removal from identity-data
+  destruction. The standard helper removes units but retains the Keycloak
+  volume. Revoke management client certificates, remove management DNS and
+  firewall rules, and delete the Keycloak volume or backups only with explicit
+  approval under the retention policy. External mode has no bundled Keycloak
+  volume or management certificate set to remove.
+
+### Incident Response
+
+For suspected administrator, token, signing-key, management-client or
+bootstrap credential compromise:
+
+1. Block management port 9443 at the firewall and stop user-facing identity
+   routing when active exploitation or signing-key compromise is possible.
+2. Preserve redacted nginx, Keycloak and system journals plus certificate
+   serials, administrator events and relevant timestamps. Do not copy tokens,
+   passwords or private keys into general evidence.
+3. Revoke affected management client certificates and administrator sessions.
+   Disable compromised identities and rotate their credentials through a
+   verified recovery administrator.
+4. Rotate OIDC client secrets or realm signing keys when the incident scope
+   requires it. Plan signing-key rotation so intended clients receive the new
+   JWKS and old tokens are handled according to the incident decision.
+5. Verify the bootstrap identity remains retired, named administrators use
+   MFA, user-facing denials occur before Keycloak, management mTLS fails closed,
+   and browser login/logout still work before restoring access.
+
+Escalate database or volume integrity concerns to the backup/recovery process;
+do not attempt an in-place repair without preserving recoverable evidence.

--- a/docs/operations/rhel10-production-single-node-self-contained-deploy.md
+++ b/docs/operations/rhel10-production-single-node-self-contained-deploy.md
@@ -85,7 +85,7 @@ The site must provide approved runtime image refs for:
 - `db-job`
 - nginx
 - SQL Server
-- Keycloak
+- Keycloak (`bundled` and `hardened-bundled` profiles only)
 
 The optional `single-node-demo` test support overlay adds Kong, the HSA person
 lookup adapter and the HSA directory mock from
@@ -115,12 +115,18 @@ Before editing templates, record these site values. The table separates values
 that must be planned from defaults or derived values that usually only need
 verification.
 
+Rows that reference `keycloak.env`, the Keycloak realm JSON, Keycloak
+administrators or the identity-network resolver apply only to `bundled` and
+`hardened-bundled`. In `external` mode, record the equivalent client and claim
+contract with the external provider owner instead.
+
 <!-- markdownlint-disable MD013 -->
 | Name | Applies to | Default / derived value | Plan or record when |
 | --- | --- | --- | --- |
 | `VERSION` | Release artifact names | No default | Always record the release version to install, for example `1.2.3`. |
 | `IDENTITY_PROVIDER_MODE` | Single-node rendered services and nginx identity ingress | `bundled` | Always record the approved choice: `bundled`, `external` or `hardened-bundled`. Production may use only `external` or the fully verified `hardened-bundled` option. |
 | `KEYCLOAK_MANAGEMENT_HTTPS_BIND` | Hardened bundled Keycloak management-only listener | No default | Required only for `hardened-bundled`; use an explicit host IPv4 and mapping to container port `9443`, for example `10.20.30.40:9443:9443`. Wildcard and malformed binds fail closed during rendering. |
+| `KC_HOSTNAME_ADMIN` | `KC_HOSTNAME_ADMIN` in `keycloak.env`; hardened bundled only | No default | Required for `hardened-bundled`; use the management-only HTTPS origin and `/auth` path. Missing values fail closed during rendering. |
 | `APP_HOST` | `PUBLIC_HOSTNAME`, app URLs, `KC_HOSTNAME`, realm redirect/logout settings, realm web origins, TLS certificate SANs and smoke checks | No default | Always record the public DNS name without `https://`, for example `kravhantering.example.internal`. |
 | `NEXT_PUBLIC_SITE_URL` | `NEXT_PUBLIC_SITE_URL` in `app.env` | `https://<APP_HOST>` | Verify after choosing `APP_HOST`; plan only if the public URL cannot use the normal scheme and host. |
 | `KRAVHANTERING_EXPORT_TEMP_DIR` | Optional absolute spool root in `app.env` | Unset/blank (OS temporary directory) | Set only when generated CSV/PDF files need a dedicated filesystem. Use an existing private directory that grants only the non-root operating-system account running Node.js read/write/search access (for example, app-owned mode `0700`). Whether set or unset, verify the directory from inside `app-runtime` and size it for configured CSV/PDF concurrency times maximum file sizes plus headroom. When unset or blank, this verification of the container operating-system temporary directory is mandatory. |
@@ -133,9 +139,9 @@ verification.
 | `HSA_PERSON_LOOKUP_ADAPTER_IMAGE_REF` | `HSA_PERSON_LOOKUP_ADAPTER_IMAGE_REF` in `release.env` | No production default | Test-only for `single-node-demo`; choose the release tag for the project-owned HSA lookup adapter image when using the demo overlay. |
 | `HSA_DIRECTORY_MOCK_IMAGE_REF` | `HSA_DIRECTORY_MOCK_IMAGE_REF` in `release.env` | No production default | Test-only for `single-node-demo`; choose the release tag for the project-owned HSA mock image when using the demo overlay. |
 | `DEMO_SEED_IMAGE_REF` | One-shot shell variable, not `release.env` | No production default | Test and development only; choose the optional `kravhantering-demo-seed` release tag or internal mirror only when running destructive demo seed in a disposable database. |
-| `KC_HOSTNAME` | `KC_HOSTNAME` in `keycloak.env` | `https://<APP_HOST>/auth` | Verify after choosing `APP_HOST`; plan only if Keycloak is deliberately exposed at another public URL. |
+| `KC_HOSTNAME` | `KC_HOSTNAME` in `keycloak.env`; bundled profiles only | `https://<APP_HOST>/auth` | Verify after choosing `APP_HOST`; plan only if Keycloak is deliberately exposed at another public URL. |
 | `NGINX_RESOLVER` | `NGINX_RESOLVER` in `release.env` | `10.89.0.1` | Verify from the actual Quadlet network. It can change when the internal network is recreated or assigned another subnet. |
-| `NGINX_IDENTITY_RESOLVER` | `NGINX_IDENTITY_RESOLVER` in `release.env` | `10.89.1.1` | Verify from the actual identity Quadlet network. Single-node nginx needs both network-scoped resolvers. |
+| `NGINX_IDENTITY_RESOLVER` | `NGINX_IDENTITY_RESOLVER` in `release.env`; bundled profiles only | `10.89.1.1` | Verify from the actual identity Quadlet network. Bundled-profile nginx needs both network-scoped resolvers. |
 | `MSSQL_SA_PASSWORD` | `MSSQL_SA_PASSWORD` in `sqlserver.env` and `DB_BOOTSTRAP_ADMIN_PASSWORD` in `db-job.env` | No default | Always generate a unique SQL Server `sa` password. Use the same value in both places and follow [Generate Unique Secrets](#generate-unique-secrets). |
 | `DB_JOB_PASSWORD` | `DB_PASSWORD` in `db-job.env` | No default | Always generate a unique SQL Server password for the `kravhantering_job` migration/seed login. Follow [Generate Unique Secrets](#generate-unique-secrets). |
 | `APP_DB_PASSWORD` | `DB_BOOTSTRAP_APP_PASSWORD` in `db-job.env` and `DB_PASSWORD` in `app.env` | No default | Always generate a unique SQL Server password for the `kravhantering_app` runtime login. Use the same value in both places and follow [Generate Unique Secrets](#generate-unique-secrets). |
@@ -157,8 +163,8 @@ verification.
 | `AUTH_SESSION_COOKIE_NAME` | `AUTH_SESSION_COOKIE_NAME` in `app.env` | `kravhantering_session` | Plan only if this host serves another deployment on the same browser cookie scope. |
 | `SESSION_COOKIE_PASSWORD` | `AUTH_SESSION_COOKIE_PASSWORD` in `app.env` | No default | Always generate with the opaque-secret fallback in [Generate Unique Secrets](#generate-unique-secrets). |
 | `AUTH_SESSION_TTL_SECONDS` | `AUTH_SESSION_TTL_SECONDS` in `app.env` | `28800` | Plan only if another absolute browser-session lifetime is approved. |
-| `KEYCLOAK_ADMIN_USER` | `KEYCLOAK_ADMIN` in `keycloak.env` | No default | Always choose an approved Keycloak bootstrap administrator username. |
-| `KEYCLOAK_ADMIN_PASSWORD` | `KEYCLOAK_ADMIN_PASSWORD` in `keycloak.env` | No default | Always generate a strong unique Keycloak bootstrap administrator password. Follow [Generate Unique Secrets](#generate-unique-secrets). |
+| `KEYCLOAK_ADMIN_USER` | `KEYCLOAK_ADMIN` in `keycloak.env`; bundled profiles only | No default | Choose an approved Keycloak bootstrap administrator username when using bundled Keycloak. |
+| `KEYCLOAK_ADMIN_PASSWORD` | `KEYCLOAK_ADMIN_PASSWORD` in `keycloak.env`; bundled profiles only | No default | Generate a strong unique Keycloak bootstrap administrator password when using bundled Keycloak. Follow [Generate Unique Secrets](#generate-unique-secrets). |
 | `MCP_CLIENT_ID` | `MCP_CLIENT_ID` in `app.env` and realm JSON service client id | `kravhantering-mcp` | Plan only if MCP service tokens use a different service-account client id. |
 | `MCP_CLIENT_SECRET` | Realm JSON `kravhantering-mcp` client `secret` | No default | Plan only when MCP service tokens are used; generate a secret separate from `OIDC_APP_CLIENT_SECRET`. |
 | `MCP_SERVICE_EMPLOYEE_HSA_ID` | Realm JSON MCP service-account user attribute | No default | Plan only when MCP service tokens are used; record the approved service-account `hsaId`. |
@@ -1002,18 +1008,21 @@ issuer, client, redirect, logout, claim and trust ownership. Do not copy or
 configure `keycloak.env` or the realm import for this mode.
 
 Generate `AUTH_SESSION_COOKIE_PASSWORD` as described in
-[Generate Unique Secrets](#generate-unique-secrets). Keep
-`AUTH_OIDC_CLIENT_SECRET` equal to the `kravhantering-app` client `secret`
-field in `/etc/kravhantering/keycloak/realm-kravhantering-production.json`.
+[Generate Unique Secrets](#generate-unique-secrets) for every profile.
 
-The app only requires `AUTH_OIDC_CLIENT_SECRET` to be non-empty and to match
-the realm client secret. For production, use a high-entropy generated secret,
-as described in [Generate Unique Secrets](#generate-unique-secrets), and paste
-the exact same value into `app.env` and the realm JSON. Use the same strength
-for the optional `kravhantering-mcp` client secret, but generate a separate
-value for that client.
+For `bundled` and `hardened-bundled` only, keep `AUTH_OIDC_CLIENT_SECRET`
+equal to the `kravhantering-app` client `secret` field in
+`/etc/kravhantering/keycloak/realm-kravhantering-production.json`.
 
-Keep `AUTH_OIDC_SCOPES=openid profile email` unless the Keycloak realm needs
+The app requires `AUTH_OIDC_CLIENT_SECRET` to be non-empty. For production,
+use a high-entropy generated secret as described in
+[Generate Unique Secrets](#generate-unique-secrets). In bundled profiles,
+paste the exact same value into `app.env` and the realm JSON. In `external`
+mode, use the secret from the provider-owned client registration. Use the same
+strength for the optional `kravhantering-mcp` client secret, but generate a
+separate value for that client.
+
+Keep `AUTH_OIDC_SCOPES=openid profile email` unless the selected provider needs
 additional scopes to release required claims. `openid` must always be present.
 Keep `AUTH_SESSION_COOKIE_NAME=kravhantering_session` unless this host must
 serve another deployment on the same browser cookie scope. Changing the cookie
@@ -1026,9 +1035,9 @@ lifetime and the access-token lifetime controls when the user must
 re-authenticate.
 
 `MCP_CLIENT_ID=kravhantering-mcp` is used when issuing service-account tokens
-for MCP clients. Keep it aligned with the `kravhantering-mcp` client id in the
-realm JSON, or leave the default when MCP service tokens are not used. It is not
-a secret.
+for MCP clients. Keep it aligned with the service client in the bundled realm
+JSON or external provider registration, or leave the default when MCP service
+tokens are not used. It is not a secret.
 
 Set `HSA_PERSON_LOOKUP_URL` to the environment-specific server-side HSA
 lookup endpoint. The browser must not call the HSA integration directly; the
@@ -1113,6 +1122,9 @@ KEYCLOAK_ADMIN_PASSWORD=<keycloak-admin-password>
 ```
 
 ### `/etc/kravhantering/keycloak/realm-kravhantering-production.json`
+
+This section applies only to `bundled` and `hardened-bundled`. The external
+provider owner implements the equivalent client, redirect and claim contract.
 
 Update the imported realm before first Keycloak startup:
 
@@ -1209,6 +1221,10 @@ These are the realm JSON values that normally need site-specific changes:
 ```
 
 ### Optional Test and Development Demo Users
+
+The Keycloak instructions in this section apply only to the test-oriented
+`bundled` profile. External mode uses provider-owned test identities instead;
+`hardened-bundled` must not import these disposable demo users.
 
 Use this only for disposable test or development environments. The release
 bundle includes `keycloak/demo-users.not-for-production.json`, generated from
@@ -2552,9 +2568,9 @@ operator client certificates and keys in the organization's endpoint identity
 or secret-management system; do not store client private keys on the server.
 
 Allow inbound TCP 9443 only from the approved management network or VPN. A
-firewall rule is still required even though mTLS is enabled. Missing files,
-an empty or malformed bind, a wildcard bind, or a container target other than
-9443 makes Quadlet rendering fail closed.
+firewall rule is still required even though mTLS is enabled. A missing
+`KC_HOSTNAME_ADMIN`, missing certificate files, an empty or malformed bind, a
+wildcard bind, or a container target other than 9443 makes setup fail closed.
 
 Reinstall and restart the topology after setting the profile:
 

--- a/docs/operations/rhel10-production-single-node-self-contained-uninstall.md
+++ b/docs/operations/rhel10-production-single-node-self-contained-uninstall.md
@@ -8,6 +8,15 @@ Keycloak and explicit `db-job` operations in one rootless Quadlet network. It
 is not an upgrade rollback guide. For release rollback after migration, use
 [rhel10-production-single-node-self-contained-upgrade.md](./rhel10-production-single-node-self-contained-upgrade.md).
 
+Record `IDENTITY_PROVIDER_MODE` before removal. The `external` profile has no
+bundled Keycloak container, volume, identity network or management TLS files;
+coordinate client-registration and secret revocation with the external
+provider owner. For `hardened-bundled`, revoke management client certificates,
+remove the management-only DNS and firewall route, and record whether Keycloak
+data and backups are retained or destroyed. The test-oriented `bundled`
+profile may contain disposable identities, but deletion still requires the
+recorded retention decision.
+
 The default flow copies host-side material to an administrator-controlled
 staging area, performs culling from that staging copy into a smaller long-term
 evidence archive, and then removes the install from the host.

--- a/docs/operations/rhel10-production-single-node-self-contained-uninstall.md
+++ b/docs/operations/rhel10-production-single-node-self-contained-uninstall.md
@@ -33,7 +33,9 @@ Confirm these site decisions before removing anything:
 - the uninstall window is approved
 - browser traffic is drained or blocked
 - the SQL Server backup, volume snapshot or data-retention decision is recorded
-- the Keycloak user, realm and data-retention decision is recorded
+- for bundled profiles, the Keycloak user, realm and data-retention decision
+  is recorded; for `external`, provider-side client and secret revocation is
+  recorded instead
 - enough administrator-controlled storage exists for the raw staging copy
 - the approved long-term evidence location is ready
 - the operator has root access on the RHEL host
@@ -45,8 +47,9 @@ hostnames and operational identifiers.
 ## Optional Demo Cleanup
 
 Run this section only for disposable test or development deployments where demo
-data was intentionally added. Keep SQL Server and Keycloak running until these
-commands finish.
+data was intentionally added. Keep SQL Server running until these commands
+finish. For the test-oriented `bundled` profile, also keep Keycloak running
+until its demo-user cleanup finishes.
 
 Clear SQL Server demo data with the optional `kravhantering-demo-seed` image
 from the release notes or your internal mirror. This deletes all non-required
@@ -81,7 +84,9 @@ podman run --rm --network "$STACK_NETWORK" \
 exit
 ```
 
-Delete marked Keycloak demo users from the running Keycloak realm:
+For the test-oriented `bundled` profile only, delete marked Keycloak demo users
+from the running Keycloak realm. Skip this entire block for `external` and
+`hardened-bundled`:
 
 ```bash
 sudo -iu kravhantering
@@ -136,9 +141,9 @@ done
 exit
 ```
 
-The helper never deletes `kravhantering-sqlserver-data` or
-`kravhantering-keycloak-data`. The rootless volume files are copied from the
-service user's home in the staging step below.
+The helper never deletes `kravhantering-sqlserver-data` or, for bundled
+profiles, `kravhantering-keycloak-data`. The rootless volume files are copied
+from the service user's home in the staging step below.
 
 ## Stage Raw Material
 
@@ -155,8 +160,8 @@ sudo install -d -o root -g root -m 0700 "$STAGING/evidence"
 ```
 
 Copy the host-side install material before removing it from the host. The
-service user's home can be large because it normally contains the rootless
-Podman storage for SQL Server and Keycloak volumes:
+service user's home can be large because it contains rootless Podman storage
+for SQL Server and, in bundled profiles, Keycloak volumes:
 
 ```bash
 sudo cp -a /etc/kravhantering "$STAGING/raw/etc-kravhantering"
@@ -175,8 +180,10 @@ service status:
 sudo -iu kravhantering bash -lc '
   podman volume inspect kravhantering-sqlserver-data \
     --format "{{ .Mountpoint }}"
-  podman volume inspect kravhantering-keycloak-data \
-    --format "{{ .Mountpoint }}"
+  if podman volume exists kravhantering-keycloak-data; then
+    podman volume inspect kravhantering-keycloak-data \
+      --format "{{ .Mountpoint }}"
+  fi
 ' | sudo tee "$STAGING/raw/podman-volume-mountpoints.txt" >/dev/null
 
 sudo cp /var/tmp/kravhantering-systemd-status.txt "$STAGING/raw/"
@@ -197,9 +204,14 @@ sudo cp "$CURRENT_RELEASE/release-metadata.json" "$STAGING/evidence/"
 grep -E '^(APP_RUNTIME_IMAGE_REF|DB_JOB_IMAGE_REF|NGINX_IMAGE_REF)=' \
   /etc/kravhantering/release.env \
   | sudo tee "$STAGING/evidence/image-refs.env" >/dev/null
-grep -E '^(SQLSERVER_IMAGE_REF|KEYCLOAK_IMAGE_REF)=' \
+grep -E '^SQLSERVER_IMAGE_REF=' \
   /etc/kravhantering/release.env \
   | sudo tee -a "$STAGING/evidence/image-refs.env" >/dev/null
+if ! grep -q '^IDENTITY_PROVIDER_MODE=external$' \
+  /etc/kravhantering/release.env; then
+  grep -E '^KEYCLOAK_IMAGE_REF=' /etc/kravhantering/release.env \
+    | sudo tee -a "$STAGING/evidence/image-refs.env" >/dev/null
+fi
 
 grep -E '^(NEXT_PUBLIC_SITE_URL|AUTH_OIDC_ISSUER_URL|AUTH_OIDC_CLIENT_ID)=' \
   /etc/kravhantering/app.env \
@@ -276,5 +288,6 @@ Close remaining records through the site-owned procedures:
 
 - remove load-balancer, DNS and monitoring entries
 - record the SQL Server backup, volume snapshot or purge decision
-- record the Keycloak realm, user and client retention decision
+- for bundled profiles, record the Keycloak realm, user and client retention
+  decision; for `external`, record provider-side client and secret revocation
 - record where the long-term uninstall evidence archive was stored

--- a/docs/operations/rhel10-production-single-node-self-contained-upgrade.md
+++ b/docs/operations/rhel10-production-single-node-self-contained-upgrade.md
@@ -7,6 +7,26 @@ single-node RHEL 10 production topology from released artifacts, with nginx,
 `app-runtime`, SQL Server and Keycloak as rootless Podman Quadlet services.
 `db-job` remains an explicit release operation on the same network.
 
+Before the change, read `IDENTITY_PROVIDER_MODE` from
+`/etc/kravhantering/release.env` and record it in the change ticket:
+
+- `bundled` is the test-oriented default; do not relabel it as production
+  hardened during an upgrade.
+- `external` has no bundled Keycloak unit, image, identity network or volume.
+  Skip Keycloak image, realm-sync, backup and recovery steps and coordinate
+  provider changes with its deployer.
+- `hardened-bundled` must preserve the management bind, mTLS certificates,
+  `KC_HOSTNAME_ADMIN`, user-facing deny rules, named MFA administrators and
+  retired bootstrap identity. Follow the
+  [production-hardening appendix](./rhel10-production-single-node-self-contained-deploy.md#appendix-c-production-hardened-bundled-keycloak)
+  before and after upgrade or rollback.
+
+For `hardened-bundled`, back up Keycloak data and configuration before the
+upgrade and verify public denial before upstream selection, management-only
+mTLS console/API access and browser login/logout after the change. A rollback
+must restore the previous Keycloak image, compatible data, nginx profile and
+management certificate configuration as one tested set.
+
 For a first install, use
 [rhel10-production-single-node-self-contained-deploy.md](./rhel10-production-single-node-self-contained-deploy.md).
 For the enterprise topology with external SQL Server and external IdP, use

--- a/docs/operations/rhel10-production-single-node-self-contained-upgrade.md
+++ b/docs/operations/rhel10-production-single-node-self-contained-upgrade.md
@@ -163,8 +163,9 @@ configuration change.
      release lock.
    - For an internal registry mirror that preserves repository paths, rewrite
      only the registry host while keeping the locked tags.
-   - For an internal mirror with a custom repository layout, set the five
-     `*_IMAGE_REF` values manually to site-approved tag refs.
+   - For an internal mirror with a custom repository layout, set the four
+     always-required `*_IMAGE_REF` values manually to site-approved tag refs;
+     bundled profiles also require the Keycloak ref.
 
    For disconnected upgrades, use the manifest that
    [Upgrade Import](./rhel10-production-single-node-self-contained-disconnected.md#upgrade-import)
@@ -176,6 +177,11 @@ configuration change.
    OFFLINE_ROOT="/tmp/kravhantering-offline-${VERSION}-${TOPOLOGY}"
    TARGET_IMAGE_REGISTRY="${TARGET_IMAGE_REGISTRY:-}"
    MANIFEST="$OFFLINE_ROOT/offline-manifest.json"
+   IDENTITY_PROVIDER_MODE="$(
+     sudo sed -n 's/^IDENTITY_PROVIDER_MODE=//p' \
+       /etc/kravhantering/release.env
+   )"
+   IDENTITY_PROVIDER_MODE="${IDENTITY_PROVIDER_MODE:-bundled}"
 
    update_ref() {
      sudo sed -i "s#^${1}=.*#${1}=${2}#" /etc/kravhantering/release.env
@@ -199,7 +205,9 @@ configuration change.
    update_ref DB_JOB_IMAGE_REF "$(target_ref db-job)"
    update_ref NGINX_IMAGE_REF "$(target_ref nginx)"
    update_ref SQLSERVER_IMAGE_REF "$(target_ref sqlserver)"
-   update_ref KEYCLOAK_IMAGE_REF "$(target_ref keycloak)"
+   if [ "$IDENTITY_PROVIDER_MODE" != "external" ]; then
+     update_ref KEYCLOAK_IMAGE_REF "$(target_ref keycloak)"
+   fi
    if [ "$TOPOLOGY" = "single-node-demo" ]; then
      update_ref KONG_IMAGE_REF "$(target_ref kong)"
      update_ref HSA_PERSON_LOOKUP_ADAPTER_IMAGE_REF \
@@ -213,6 +221,11 @@ configuration change.
    release lock and verify them immediately:
 
    ```bash
+   IDENTITY_PROVIDER_MODE="$(
+     sudo sed -n 's/^IDENTITY_PROVIDER_MODE=//p' \
+       /etc/kravhantering/release.env
+   )"
+   IDENTITY_PROVIDER_MODE="${IDENTITY_PROVIDER_MODE:-bundled}"
    update_ref() {
      sudo sed -i "s#^${1}=.*#${1}=${2}#" /etc/kravhantering/release.env
    }
@@ -238,8 +251,10 @@ configuration change.
      "$(service_ref nginx)"
    update_ref SQLSERVER_IMAGE_REF \
      "$(service_ref sqlserver)"
-   update_ref KEYCLOAK_IMAGE_REF \
-     "$(service_ref keycloak)"
+   if [ "$IDENTITY_PROVIDER_MODE" != "external" ]; then
+     update_ref KEYCLOAK_IMAGE_REF \
+       "$(service_ref keycloak)"
+   fi
    ```
 
    If the site pulls from an internal registry mirror that preserves repository
@@ -247,6 +262,11 @@ configuration change.
 
    ```bash
    TARGET_IMAGE_REGISTRY=registry.example.internal
+   IDENTITY_PROVIDER_MODE="$(
+     sudo sed -n 's/^IDENTITY_PROVIDER_MODE=//p' \
+       /etc/kravhantering/release.env
+   )"
+   IDENTITY_PROVIDER_MODE="${IDENTITY_PROVIDER_MODE:-bundled}"
    LOCK_FILE=/opt/kravhantering/current/container-stack.lock.json
    service_image() {
      jq -r --arg name "$1" \
@@ -271,13 +291,17 @@ configuration change.
      "$(mirror_ref nginx)"
    update_ref SQLSERVER_IMAGE_REF \
      "$(mirror_ref sqlserver)"
-   update_ref KEYCLOAK_IMAGE_REF \
-     "$(mirror_ref keycloak)"
+   if [ "$IDENTITY_PROVIDER_MODE" != "external" ]; then
+     update_ref KEYCLOAK_IMAGE_REF \
+       "$(mirror_ref keycloak)"
+   fi
    ```
 
-   If the internal mirror uses a custom repository layout, set the five
-   `*_IMAGE_REF` values manually to site-approved tag refs, then run the
-   verification below. Each ref must resolve to the locked `imageId`.
+   If the internal mirror uses a custom repository layout, set the four
+   always-required `*_IMAGE_REF` values manually to site-approved tag refs and
+   add `KEYCLOAK_IMAGE_REF` only for a bundled profile. Then run the
+   verification below. Each configured ref must resolve to the locked
+   `imageId`.
 
    Connected upgrades pull and verify the target images as the service user:
 
@@ -292,7 +316,9 @@ configuration change.
    podman pull "$DB_JOB_IMAGE_REF"
    podman pull "$NGINX_IMAGE_REF"
    podman pull "$SQLSERVER_IMAGE_REF"
-   podman pull "$KEYCLOAK_IMAGE_REF"
+   if [ "$IDENTITY_PROVIDER_MODE" != "external" ]; then
+     podman pull "$KEYCLOAK_IMAGE_REF"
+   fi
 
    bin/kravhantering-images.sh --topology single-node \
      --lock-file container-stack.lock.json \
@@ -329,8 +355,9 @@ configuration change.
    ```
 
 8. Run the database jobs once from the new release.
-   First ensure SQL Server, Keycloak and their Quadlet networks exist for the new
-   release, then run the job sequence with the new `DB_JOB_IMAGE_REF`. Use the
+   First ensure SQL Server and its Quadlet network exist for the new release.
+   Bundled profiles must also start Keycloak and its identity network. Then run
+   the job sequence with the new `DB_JOB_IMAGE_REF`. Use the
    DBA-pre-provisioned production sequence by default, matching
    [rhel10-production-upgrade.md](./rhel10-production-upgrade.md), and skip
    `bootstrap`.
@@ -386,8 +413,10 @@ configuration change.
    starts:
 
    ```bash
-   if ! sudo grep -q '^NGINX_IDENTITY_RESOLVER=' \
-     /etc/kravhantering/release.env; then
+   if ! sudo grep -q '^IDENTITY_PROVIDER_MODE=external$' \
+     /etc/kravhantering/release.env && \
+     ! sudo grep -q '^NGINX_IDENTITY_RESOLVER=' \
+       /etc/kravhantering/release.env; then
      printf '%s\n' 'NGINX_IDENTITY_RESOLVER=10.89.1.1' |
        sudo tee -a /etc/kravhantering/release.env >/dev/null
    fi
@@ -402,13 +431,15 @@ configuration change.
    bin/kravhantering-quadlet.sh install --topology single-node
    systemctl --user daemon-reload
    systemctl --user start kravhantering-sqlserver.service
-   systemctl --user start kravhantering-keycloak.service
+   if [ "$IDENTITY_PROVIDER_MODE" != "external" ]; then
+     systemctl --user start kravhantering-keycloak.service
+   fi
 
    exit
    ```
 
-   Start the edge network, then discover the edge and identity resolvers that
-   nginx needs for `app-runtime` and Keycloak through the Quadlet helper.
+   Start the edge network and discover its resolver. Bundled profiles also
+   discover the identity resolver that nginx uses for Keycloak.
 
    ```bash
    sudo -iu kravhantering
@@ -422,18 +453,21 @@ configuration change.
      bin/kravhantering-quadlet.sh print-resolver \
        --topology single-node --purpose edge
    )"
-   IDENTITY_RESOLVER="$(
-     bin/kravhantering-quadlet.sh print-resolver \
-       --topology single-node --purpose identity
-   )"
-   printf 'Use NGINX_RESOLVER=%s and NGINX_IDENTITY_RESOLVER=%s\n' \
-     "$EDGE_RESOLVER" "$IDENTITY_RESOLVER"
+   printf 'Use NGINX_RESOLVER=%s\n' "$EDGE_RESOLVER"
+   if [ "$IDENTITY_PROVIDER_MODE" != "external" ]; then
+     IDENTITY_RESOLVER="$(
+       bin/kravhantering-quadlet.sh print-resolver \
+         --topology single-node --purpose identity
+     )"
+     printf 'Use NGINX_IDENTITY_RESOLVER=%s\n' "$IDENTITY_RESOLVER"
+   fi
 
    exit
    ```
 
-   Add or update both values before starting nginx. The add path is required
-   when upgrading from a release that predates `NGINX_IDENTITY_RESOLVER`:
+   Add or update the edge resolver before starting nginx. For bundled profiles,
+   also update the identity resolver. The add path is required when upgrading
+   from a release that predates `NGINX_IDENTITY_RESOLVER`:
 
    ```bash
    # Replace these examples with the printed resolver IPs.
@@ -450,7 +484,10 @@ configuration change.
      fi
    }
    set_release_value NGINX_RESOLVER "$EDGE_RESOLVER"
-   set_release_value NGINX_IDENTITY_RESOLVER "$ID_DNS"
+   if ! sudo grep -q '^IDENTITY_PROVIDER_MODE=external$' \
+     /etc/kravhantering/release.env; then
+     set_release_value NGINX_IDENTITY_RESOLVER "$ID_DNS"
+   fi
    ```
 
    The resolver can change when the internal Quadlet network is recreated or
@@ -567,6 +604,12 @@ configuration change.
    . /etc/kravhantering/release.env
    set +a
 
+   if [ "$IDENTITY_PROVIDER_MODE" = "external" ]; then
+     printf '%s\n' \
+       'Skip bundled Keycloak demo-user synchronization for external OIDC.'
+     exit
+   fi
+
    STACK_NETWORK="$(
      bin/kravhantering-quadlet.sh print-network \
        --topology single-node --purpose identity
@@ -621,8 +664,8 @@ configuration change.
    ```
 
 9. Start the stack from the new release. Reinstall the units after correcting
-   `NGINX_RESOLVER` and `NGINX_IDENTITY_RESOLVER`, then enable and start the
-   target:
+   `NGINX_RESOLVER` and, for bundled profiles, `NGINX_IDENTITY_RESOLVER`. Then
+   enable and start the target:
 
    ```bash
    sudo -iu kravhantering
@@ -662,9 +705,10 @@ configuration change.
       https://kravhantering.example.internal/api/health
     ```
 
-    The Quadlet networks retain the established edge, identity, database, and
-    egress names documented in the deployment guide. The SQL Server and
-    Keycloak volumes retain their established names.
+    The Quadlet networks retain the established edge, database, and egress
+    names documented in the deployment guide. Bundled profiles also retain the
+    identity network. The SQL Server volume retains its established name, and
+    bundled profiles retain the Keycloak volume name.
 
 11. Re-enable traffic.
     Put the host back into the load balancer, reverse proxy or firewall

--- a/scripts/__tests__/kravhantering-quadlet.test.mjs
+++ b/scripts/__tests__/kravhantering-quadlet.test.mjs
@@ -12,6 +12,10 @@ const PRODUCTION_SMOKE_PATH = path.resolve(
   process.cwd(),
   'scripts/containers/production-smoke.sh',
 )
+const KEYCLOAK_PROXY_HEADERS_PATH = path.resolve(
+  process.cwd(),
+  'containers/production/nginx/templates/keycloak-proxy-headers.conf',
+)
 const PODMAN_USER_GENERATOR =
   '/usr/lib/systemd/user-generators/podman-user-generator'
 const PODMAN_GENERATOR_VERSION = fs.existsSync(PODMAN_USER_GENERATOR)
@@ -42,7 +46,10 @@ function writePodmanProbe(filePath, runtime = 'crun') {
   )
 }
 
-function createFixture(releaseEnv) {
+function createFixture(
+  releaseEnv,
+  keycloakEnv = 'KC_HOSTNAME_ADMIN=https://keycloak-management.example.internal:9443/auth\n',
+) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kh-quadlet-'))
   temporaryDirectories.push(root)
   const controllersPath = path.join(root, 'cgroup.controllers')
@@ -52,6 +59,7 @@ function createFixture(releaseEnv) {
   const podmanPath = path.join(root, 'podman')
   const systemctlPath = path.join(root, 'systemctl')
   const releaseEnvPath = path.join(root, 'release.env')
+  const keycloakEnvPath = path.join(root, 'keycloak.env')
   const outputDir = path.join(root, 'rendered')
   fs.mkdirSync(journalConfigDir)
   fs.writeFileSync(controllersPath, 'cpu memory pids\n')
@@ -68,6 +76,7 @@ function createFixture(releaseEnv) {
     mode: 0o755,
   })
   fs.writeFileSync(releaseEnvPath, releaseEnv)
+  fs.writeFileSync(keycloakEnvPath, keycloakEnv)
   return {
     outputDir,
     podmanPath,
@@ -80,6 +89,7 @@ function createFixture(releaseEnv) {
       KRAVHANTERING_SYSTEMCTL_BIN: systemctlPath,
     },
     releaseEnvPath,
+    keycloakEnvPath,
     root,
   }
 }
@@ -109,6 +119,7 @@ function runHelper(args, fixture, envOverrides = {}) {
     env: {
       ...process.env,
       KRAVHANTERING_RELEASE_ENV_FILE: fixture.releaseEnvPath,
+      KRAVHANTERING_KEYCLOAK_ENV_FILE: fixture.keycloakEnvPath,
       ...fixture.preflightEnv,
       ...envOverrides,
     },
@@ -357,8 +368,10 @@ describe('kravhantering Quadlet helper', () => {
     expect(nginx).not.toContain('NGINX_IDENTITY_RESOLVER')
     expect(nginx).not.toContain('kravhantering-single-node-identity.network')
     expect(target).not.toContain('kravhantering-keycloak.service')
-    expect(units.map(unit => unit.content).join('\n')).not.toContain(
-      'kravhantering-keycloak.service',
+    const renderedContent = units.map(unit => unit.content).join('\n')
+    expect(renderedContent).not.toContain('kravhantering-keycloak.service')
+    expect(renderedContent).not.toContain(
+      'PodmanArgs=--add-host=kravhantering.example.internal:host-gateway',
     )
   })
 
@@ -387,9 +400,22 @@ describe('kravhantering Quadlet helper', () => {
     )
   })
 
+  it('replaces untrusted forwarded chains at the public Keycloak edge', () => {
+    const proxyHeaders = fs.readFileSync(KEYCLOAK_PROXY_HEADERS_PATH, 'utf8')
+
+    expect(proxyHeaders).toContain(
+      'proxy_set_header X-Forwarded-For $remote_addr;',
+    )
+    expect(proxyHeaders).not.toContain('$proxy_add_x_forwarded_for')
+  })
+
   it.each([
     ['', 'missing required value'],
     ['0.0.0.0:9443:9443', 'must not use a wildcard address'],
+    ['00.00.00.00:9443:9443', 'expected canonical decimal IPv4 octets'],
+    ['00.20.30.40:9443:9443', 'expected canonical decimal IPv4 octets'],
+    ['0177.20.30.40:9443:9443', 'expected canonical decimal IPv4 octets'],
+    ['08.20.30.40:9443:9443', 'expected canonical decimal IPv4 octets'],
     ['10.20.30.40:9443:8443', 'must target container port 9443'],
     ['management.internal:9443:9443', 'expected an explicit IPv4 bind'],
   ])(
@@ -417,6 +443,32 @@ describe('kravhantering Quadlet helper', () => {
       expect(fs.existsSync(fixture.outputDir)).toBe(false)
     },
   )
+
+  it('requires a management hostname for hardened bundled Keycloak', () => {
+    const fixture = createFixture(
+      releaseEnv({
+        IDENTITY_PROVIDER_MODE: 'hardened-bundled',
+        KEYCLOAK_MANAGEMENT_HTTPS_BIND: '10.20.30.40:9443:9443',
+      }),
+      'KC_HOSTNAME=https://kravhantering.example.internal/auth\n',
+    )
+    const result = runHelper(
+      [
+        'render',
+        '--topology',
+        'single-node',
+        '--output-dir',
+        fixture.outputDir,
+      ],
+      fixture,
+    )
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain(
+      'keycloak.env is missing required value: KC_HOSTNAME_ADMIN for IDENTITY_PROVIDER_MODE=hardened-bundled',
+    )
+    expect(fs.existsSync(fixture.outputDir)).toBe(false)
+  })
 
   it('rejects an unknown identity-provider profile before rendering', () => {
     const fixture = createFixture(

--- a/scripts/__tests__/kravhantering-quadlet.test.mjs
+++ b/scripts/__tests__/kravhantering-quadlet.test.mjs
@@ -318,6 +318,128 @@ describe('kravhantering Quadlet helper', () => {
     )
   })
 
+  it('renders the default bundled identity provider when no profile is configured', () => {
+    const fixture = createFixture(releaseEnv())
+    const units = render('single-node', fixture)
+
+    expect(units.map(unit => unit.file)).toContain(
+      'kravhantering-keycloak.container',
+    )
+    expect(
+      units.find(unit => unit.file === 'kravhantering-nginx.container')
+        ?.content,
+    ).toContain('single-node-tls.conf.template')
+  })
+
+  it('renders the external OIDC profile without bundled Keycloak resources', () => {
+    const fixture = createFixture(
+      releaseEnv({
+        IDENTITY_PROVIDER_MODE: 'external',
+        KEYCLOAK_IMAGE_REF: '',
+        NGINX_IDENTITY_RESOLVER: '',
+      }),
+    )
+    const units = render('single-node', fixture)
+    const unitNames = units.map(unit => unit.file)
+    const nginx = units.find(
+      unit => unit.file === 'kravhantering-nginx.container',
+    )?.content
+    const target = units.find(
+      unit => unit.file === 'kravhantering-single-node.target',
+    )?.content
+
+    expect(unitNames).not.toContain('kravhantering-keycloak.container')
+    expect(unitNames).not.toContain('kravhantering-keycloak-data.volume')
+    expect(unitNames).not.toContain(
+      'kravhantering-single-node-identity.network',
+    )
+    expect(nginx).toContain('single-node-external-oidc-tls.conf.template')
+    expect(nginx).not.toContain('NGINX_IDENTITY_RESOLVER')
+    expect(nginx).not.toContain('kravhantering-single-node-identity.network')
+    expect(target).not.toContain('kravhantering-keycloak.service')
+    expect(units.map(unit => unit.content).join('\n')).not.toContain(
+      'kravhantering-keycloak.service',
+    )
+  })
+
+  it('renders fail-closed user-facing and management ingress for hardened Keycloak', () => {
+    const fixture = createFixture(
+      releaseEnv({
+        IDENTITY_PROVIDER_MODE: 'hardened-bundled',
+        KEYCLOAK_MANAGEMENT_HTTPS_BIND: '10.20.30.40:9443:9443',
+      }),
+    )
+    const units = render('single-node', fixture)
+    const nginx = units.find(
+      unit => unit.file === 'kravhantering-nginx.container',
+    )?.content
+
+    expect(nginx).toContain('single-node-hardened-keycloak-tls.conf.template')
+    expect(nginx).toContain('PublishPort=10.20.30.40:9443:9443')
+    expect(nginx).toContain(
+      'Volume=/etc/kravhantering/keycloak-management-tls/client-ca.crt:/etc/nginx/keycloak-management-tls/client-ca.crt:ro',
+    )
+    expect(nginx).toContain(
+      'Volume=/etc/kravhantering/keycloak-management-tls/fullchain.pem:/etc/nginx/keycloak-management-tls/fullchain.pem:ro',
+    )
+    expect(nginx).toContain(
+      'Volume=/etc/kravhantering/keycloak-management-tls/privkey.pem:/etc/nginx/keycloak-management-tls/privkey.pem:ro',
+    )
+  })
+
+  it.each([
+    ['', 'missing required value'],
+    ['0.0.0.0:9443:9443', 'must not use a wildcard address'],
+    ['10.20.30.40:9443:8443', 'must target container port 9443'],
+    ['management.internal:9443:9443', 'expected an explicit IPv4 bind'],
+  ])(
+    'rejects unsafe hardened management bind %s',
+    (managementBind, expectedMessage) => {
+      const fixture = createFixture(
+        releaseEnv({
+          IDENTITY_PROVIDER_MODE: 'hardened-bundled',
+          KEYCLOAK_MANAGEMENT_HTTPS_BIND: managementBind,
+        }),
+      )
+      const result = runHelper(
+        [
+          'render',
+          '--topology',
+          'single-node',
+          '--output-dir',
+          fixture.outputDir,
+        ],
+        fixture,
+      )
+
+      expect(result.status).not.toBe(0)
+      expect(result.stderr).toContain(expectedMessage)
+      expect(fs.existsSync(fixture.outputDir)).toBe(false)
+    },
+  )
+
+  it('rejects an unknown identity-provider profile before rendering', () => {
+    const fixture = createFixture(
+      releaseEnv({ IDENTITY_PROVIDER_MODE: 'shared-admin-console' }),
+    )
+    const result = runHelper(
+      [
+        'render',
+        '--topology',
+        'single-node',
+        '--output-dir',
+        fixture.outputDir,
+      ],
+      fixture,
+    )
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain(
+      'invalid IDENTITY_PROVIDER_MODE: expected bundled, external, or hardened-bundled',
+    )
+    expect(fs.existsSync(fixture.outputDir)).toBe(false)
+  })
+
   it.runIf(
     fs.existsSync(PODMAN_USER_GENERATOR) &&
       PODMAN_GENERATOR_VERSION.includes('4.9.3'),
@@ -976,7 +1098,7 @@ rotate_sqlserver_certificate
   it('rejects host memory that cannot enforce the topology envelope', () => {
     const fixture = createFixture(releaseEnv())
     const lowMemory = path.join(fixture.root, 'low-memory')
-    fs.writeFileSync(lowMemory, 'MemTotal:       8388608 kB\n')
+    fs.writeFileSync(lowMemory, 'MemTotal:       12582912 kB\n')
 
     const result = runHelper(
       ['verify-host', '--topology', 'single-node'],
@@ -988,6 +1110,22 @@ rotate_sqlserver_certificate
     expect(result.stderr).toContain(
       'single-node service memory limits exceed 75% of host memory',
     )
+  })
+
+  it('sizes external OIDC single-node without bundled Keycloak memory', () => {
+    const fixture = createFixture(
+      releaseEnv({ IDENTITY_PROVIDER_MODE: 'external' }),
+    )
+    const availableMemory = path.join(fixture.root, 'available-memory')
+    fs.writeFileSync(availableMemory, 'MemTotal:       12582912 kB\n')
+
+    const result = runHelper(
+      ['verify-host', '--topology', 'single-node'],
+      fixture,
+      { KRAVHANTERING_MEMINFO_FILE: availableMemory },
+    )
+
+    expect(result.status).toBe(0)
   })
 
   it('rejects aggregate stateful CPU quotas above single-node capacity', () => {

--- a/scripts/__tests__/production-image-helper.test.mjs
+++ b/scripts/__tests__/production-image-helper.test.mjs
@@ -280,6 +280,30 @@ describe('production image helper', () => {
     expect(result.log).not.toContain('registry.example/sqlserver')
   })
 
+  it('does not require a bundled Keycloak image for external OIDC single-node', () => {
+    const dir = makeTempDir()
+    const lockFile = writeLockFile(dir)
+    const envFile = writeEnvFile(dir, {
+      IDENTITY_PROVIDER_MODE: 'external',
+      KEYCLOAK_IMAGE_REF: '',
+    })
+
+    const result = runHelper(dir, [
+      '--topology',
+      'single-node',
+      '--lock-file',
+      lockFile,
+      '--env-file',
+      envFile,
+      'verify',
+    ])
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain('Verified sqlserver')
+    expect(result.stdout).not.toContain('Verified keycloak')
+    expect(result.log).not.toContain('registry.example/keycloak')
+  })
+
   it('verifies production and test support locks for single-node-demo', () => {
     const dir = makeTempDir()
     const lockFile = writeLockFile(dir)

--- a/scripts/containers/production-smoke.sh
+++ b/scripts/containers/production-smoke.sh
@@ -204,6 +204,7 @@ render_runtime_configuration() {
     printf 'APP_RUNTIME_IMAGE_REF=%s\n' "$APP_RUNTIME_IMAGE_REF"
     printf 'DB_JOB_IMAGE_REF=%s\n' "$DB_JOB_IMAGE_REF"
     printf 'KEYCLOAK_IMAGE_REF=%s\n' "$KEYCLOAK_IMAGE_REF"
+    printf 'IDENTITY_PROVIDER_MODE=bundled\n'
     printf 'NGINX_IMAGE_REF=%s\n' "$NGINX_IMAGE_REF"
     printf 'SQLSERVER_IMAGE_REF=%s\n' "$SQLSERVER_IMAGE_REF"
     printf 'PUBLIC_HOSTNAME=kravhantering.test\n'
@@ -234,7 +235,7 @@ render_runtime_configuration() {
 
   sudo install -d -o root -g "$SERVICE_USER" -m 0750 \
     "$CONFIG_ROOT" "$CONFIG_ROOT/keycloak" "$CONFIG_ROOT/sqlserver-tls" \
-    "$CONFIG_ROOT/tls"
+    "$CONFIG_ROOT/tls" "$CONFIG_ROOT/keycloak-management-tls"
   for file in app.env db-job.env keycloak.env release.env sqlserver.env; do
     sudo install -o root -g "$SERVICE_USER" -m 0640 \
       "$CONFIG_TEMP_DIR/$file" "$CONFIG_ROOT/$file"
@@ -484,6 +485,186 @@ verify_sqlserver_identity_upgrade() {
   printf '%s\n' \
     'sqlserver-legacy-to-verified-tls-upgrade=passed' \
     >"$EVIDENCE_DIR/sqlserver-identity-upgrade.txt"
+}
+
+enable_hardened_keycloak_profile() {
+  local client_ext client_serial management_tls_dir
+  local management_work_dir
+  management_tls_dir="$CONFIG_ROOT/keycloak-management-tls"
+  management_work_dir="$(mktemp -d)"
+  client_ext="$management_work_dir/client.ext"
+  client_serial="$management_work_dir/client-ca.srl"
+
+  node scripts/containers/generate-tls.mjs \
+    --hostname keycloak-management.test \
+    --output-dir "$management_work_dir" \
+    --ca-cert tmp/container-tls/ca.crt \
+    --ca-key tmp/container-tls/ca.key \
+    --file-stem management
+  openssl req -newkey rsa:2048 -nodes \
+    -subj '/CN=production-smoke-keycloak-operator' \
+    -keyout "$management_work_dir/client.key" \
+    -out "$management_work_dir/client.csr"
+  printf '%s\n' \
+    'keyUsage=critical,digitalSignature,keyEncipherment' \
+    'extendedKeyUsage=clientAuth' >"$client_ext"
+  openssl x509 -req \
+    -in "$management_work_dir/client.csr" \
+    -CA tmp/container-tls/ca.crt \
+    -CAkey tmp/container-tls/ca.key \
+    -CAserial "$client_serial" \
+    -CAcreateserial \
+    -out "$management_work_dir/client.crt" \
+    -days 7 -sha256 -extfile "$client_ext"
+
+  sudo install -o root -g "$SERVICE_USER" -m 0644 \
+    tmp/container-tls/ca.crt "$management_tls_dir/client-ca.crt"
+  sudo install -o root -g "$SERVICE_USER" -m 0644 \
+    "$management_work_dir/management.crt" \
+    "$management_tls_dir/fullchain.pem"
+  sudo install -o root -g "$SERVICE_USER" -m 0640 \
+    "$management_work_dir/management.key" \
+    "$management_tls_dir/privkey.pem"
+  sudo install -o root -g "$SERVICE_USER" -m 0644 \
+    "$management_work_dir/client.crt" \
+    "$management_tls_dir/client.crt"
+  sudo install -o root -g "$SERVICE_USER" -m 0640 \
+    "$management_work_dir/client.key" \
+    "$management_tls_dir/client.key"
+  rm -rf -- "$management_work_dir"
+
+  sudo sed -i \
+    -e 's#^IDENTITY_PROVIDER_MODE=.*#IDENTITY_PROVIDER_MODE=hardened-bundled#' \
+    -e '/^KEYCLOAK_MANAGEMENT_HTTPS_BIND=/d' \
+    "$CONFIG_ROOT/release.env"
+  printf '%s\n' \
+    'KEYCLOAK_MANAGEMENT_HTTPS_BIND=127.0.0.1:9443:9443' | \
+    sudo tee -a "$CONFIG_ROOT/release.env" >/dev/null
+  sudo sed -i '/^KC_HOSTNAME_ADMIN=/d' "$CONFIG_ROOT/keycloak.env"
+  printf '%s\n' \
+    'KC_HOSTNAME_ADMIN=https://keycloak-management.test:9443/auth' | \
+    sudo tee -a "$CONFIG_ROOT/keycloak.env" >/dev/null
+
+  as_service "$INSTALL_ROOT/current/bin/kravhantering-quadlet.sh" \
+    install --topology "$TOPOLOGY"
+  service_systemctl daemon-reload
+  service_systemctl restart kravhantering-single-node.target
+  wait_for_url \
+    https://kravhantering.test/auth/realms/kravhantering-production/.well-known/openid-configuration
+}
+
+verify_hardened_keycloak_ingress() {
+  local access_token admin_password admin_user code journal_cursor journal_output
+  local marker marker_count management_url path token_response
+  local -a denied_paths=(
+    /auth
+    /auth/admin/
+    /auth/admin/realms
+    /auth/realms/master/protocol/openid-connect/token
+    /auth/realms/kravhantering-production/clients-registrations/default
+  )
+  management_url='https://keycloak-management.test:9443'
+  marker="hardened-keycloak-$RANDOM-$$"
+  journal_cursor="$(
+    as_service journalctl --user -u kravhantering-nginx.service \
+      -n 0 --show-cursor 2>/dev/null |
+      sed -n 's/^-- cursor: //p'
+  )"
+
+  for path in "${denied_paths[@]}"; do
+    code="$(curl --silent --show-error --output /dev/null \
+      --write-out '%{http_code}' --cacert tmp/container-tls/ca.crt \
+      --user-agent "$marker" "https://kravhantering.test$path")"
+    [[ "$code" == 404 ]] || \
+      fail "hardened user-facing Keycloak path was not denied: $path ($code)"
+  done
+
+  journal_output=''
+  for _ in {1..10}; do
+    if [[ -n "$journal_cursor" ]]; then
+      journal_output="$(
+        as_service journalctl --user -u kravhantering-nginx.service \
+          --after-cursor "$journal_cursor" \
+          --output=cat --no-pager 2>/dev/null || true
+      )"
+    else
+      journal_output="$(
+        as_service journalctl --user -u kravhantering-nginx.service \
+          --since=-1min --output=cat --no-pager 2>/dev/null || true
+      )"
+    fi
+    marker_count="$(grep -Fc "$marker" <<<"$journal_output" || true)"
+    if [[ "$marker_count" == "${#denied_paths[@]}" ]]; then
+      break
+    fi
+    sleep 1
+  done
+  marker_count="$(grep -Fc "$marker" <<<"$journal_output" || true)"
+  [[ "$marker_count" == "${#denied_paths[@]}" ]] || \
+    fail 'hardened public denial requests are missing from nginx evidence'
+  if grep -F "$marker" <<<"$journal_output" | \
+    grep -Fv 'upstream="-"' >/dev/null; then
+    fail 'a denied user-facing Keycloak request selected an upstream'
+  fi
+
+  if sudo curl --fail --silent --show-error \
+    --resolve keycloak-management.test:9443:127.0.0.1 \
+    --cacert tmp/container-tls/ca.crt \
+    "$management_url/auth/admin/" >/dev/null 2>&1; then
+    fail 'Keycloak management ingress accepted a client without mTLS'
+  fi
+
+  admin_user="$(sudo sed -n 's/^KEYCLOAK_ADMIN=//p' \
+    "$CONFIG_ROOT/keycloak.env")"
+  admin_password="$(sudo sed -n 's/^KEYCLOAK_ADMIN_PASSWORD=//p' \
+    "$CONFIG_ROOT/keycloak.env")"
+  [[ -n "$admin_user" && -n "$admin_password" ]] || \
+    fail 'Keycloak smoke administrator credentials are unavailable'
+  token_response="$(sudo curl --fail --silent --show-error \
+    --resolve keycloak-management.test:9443:127.0.0.1 \
+    --cacert tmp/container-tls/ca.crt \
+    --cert "$CONFIG_ROOT/keycloak-management-tls/client.crt" \
+    --key "$CONFIG_ROOT/keycloak-management-tls/client.key" \
+    --data-urlencode grant_type=password \
+    --data-urlencode client_id=admin-cli \
+    --data-urlencode "username=$admin_user" \
+    --data-urlencode "password=$admin_password" \
+    "$management_url/auth/realms/master/protocol/openid-connect/token")"
+  access_token="$(jq -er '.access_token' <<<"$token_response")" || \
+    fail 'authorized management client could not obtain an admin token'
+
+  sudo curl --fail --silent --show-error --location \
+    --resolve keycloak-management.test:9443:127.0.0.1 \
+    --cacert tmp/container-tls/ca.crt \
+    --cert "$CONFIG_ROOT/keycloak-management-tls/client.crt" \
+    --key "$CONFIG_ROOT/keycloak-management-tls/client.key" \
+    "$management_url/auth/admin/master/console/" >/dev/null || \
+    fail 'authorized management client could not reach the admin console'
+  sudo curl --fail --silent --show-error \
+    --resolve keycloak-management.test:9443:127.0.0.1 \
+    --cacert tmp/container-tls/ca.crt \
+    --cert "$CONFIG_ROOT/keycloak-management-tls/client.crt" \
+    --key "$CONFIG_ROOT/keycloak-management-tls/client.key" \
+    --header "Authorization: Bearer $access_token" \
+    "$management_url/auth/admin/realms" >/dev/null || \
+    fail 'authorized management client could not use the Admin REST API'
+
+  printf '%s\n' \
+    'user-facing-admin-denial-before-upstream=passed' \
+    'user-facing-master-realm-denial-before-upstream=passed' \
+    'user-facing-client-registration-denial-before-upstream=passed' \
+    'management-mtls-fail-closed=passed' \
+    'management-console-access=passed' \
+    'management-admin-api-access=passed' \
+    >"$EVIDENCE_DIR/keycloak-hardened-ingress.txt"
+}
+
+verify_default_bundled_keycloak_login() {
+  bash .devcontainer/trust-container-ca.sh
+  CI=true npm run test:release-smoke -- \
+    --grep 'proves HTTPS, auth, SQL Server reads and writes'
+  printf '%s\n' 'default-bundled-browser-login=passed' \
+    >"$EVIDENCE_DIR/keycloak-default-login.txt"
 }
 
 stack_services_are_progressing() {
@@ -969,6 +1150,9 @@ up() {
   verify_sqlserver_certificate_recovery
   wait_for_url https://kravhantering.test/api/ready
   verify_backup_recovery
+  verify_default_bundled_keycloak_login
+  enable_hardened_keycloak_profile
+  verify_hardened_keycloak_ingress
   printf '%s\n' \
     'app-runtime-restart=passed' \
     'sqlserver-restart-and-persistence=passed' \
@@ -979,7 +1163,9 @@ up() {
     'sqlserver-certificate-recovery=passed' \
     'sqlserver-legacy-to-verified-tls-upgrade=passed' \
     'post-reinstall-migration=passed' \
-    'target-stop-start=passed' >"$EVIDENCE_DIR/lifecycle.txt"
+    'target-stop-start=passed' \
+    'keycloak-hardened-profile-transition=passed' \
+    >"$EVIDENCE_DIR/lifecycle.txt"
 }
 
 evidence() {

--- a/tests/release-smoke/release-smoke.md
+++ b/tests/release-smoke/release-smoke.md
@@ -8,6 +8,12 @@ topology and its CI-only HSA overlay are started, signs in through Keycloak via
 nginx, and verifies the release-critical path, including nginx-served API
 documentation, without duplicating the full integration suite.
 
+The production smoke runs the first authenticated test once with the default
+`bundled` profile to prove its unchanged browser login. It then switches the
+installed topology to `hardened-bundled`, verifies the ingress boundary, and
+runs the complete suite so login and logout also traverse the hardened
+user-facing allow-list.
+
 ## Data Model
 
 <!-- markdownlint-disable MD013 -->
@@ -53,7 +59,8 @@ flowchart TD
     N --> O[GET /api/requirements/:id]
     O --> P[Verify nginx API docs headers, assets, rendering and 404]
     P --> Q[Admin verifies HSA person through Kong and adapter]
-    Q --> R[Run 5 CSV exports and 3 PDF reports concurrently]
+    Q --> R[Log out through hardened Keycloak ingress]
+    R --> S[Run 5 CSV exports and 3 PDF reports concurrently]
 ```
 
 ## Test Setup
@@ -173,6 +180,17 @@ sequenceDiagram
     PW->>N: Open Swagger UI in Chromium
     Note over PW,N: Specification renders without CSP violations
 ```
+
+## preserves browser logout through the hardened Keycloak ingress
+
+This test starts with the authenticated reviewer storage state, opens the
+requirements library, and signs out through the account menu. It verifies that
+the Keycloak end-session and browser authorization continuation paths remain
+available through the hardened user-facing allow-list while administrative
+paths remain denied by the production smoke shell checks.
+
+The test confirms the browser returns to the production realm authorization
+endpoint and `/api/auth/me` reports an unauthenticated session.
 
 ## verifies HSA person lookup through Kong, adapter and the HSA mock
 

--- a/tests/release-smoke/release-smoke.spec.ts
+++ b/tests/release-smoke/release-smoke.spec.ts
@@ -298,6 +298,32 @@ test.describe('Release smoke container flow', () => {
     })
   })
 
+  test('preserves browser logout through the hardened Keycloak ingress', async ({
+    page,
+  }) => {
+    await page.goto('/sv/requirements')
+
+    const userMenuButton = page.getByRole('button', {
+      name: /^Inloggad som /,
+    })
+    await userMenuButton.hover()
+    const userInfoDialog = page.getByRole('dialog', {
+      name: 'Kontouppgifter',
+    })
+    await expect(userInfoDialog).toBeVisible()
+    await userInfoDialog.getByRole('button', { name: 'Logga ut' }).click()
+
+    await expect(page).toHaveURL(
+      /\/realms\/kravhantering-production\/protocol\/openid-connect\/auth/,
+    )
+    await expect
+      .poll(async () => {
+        const response = await page.request.get('/api/auth/me')
+        return response.json()
+      })
+      .toEqual({ authenticated: false })
+  })
+
   test('verifies HSA person lookup through Kong and the HSA mock', async ({
     baseURL: configuredBaseUrl,
   }) => {

--- a/tests/unit/requirements-specification-detail-generated-output.suite.tsx
+++ b/tests/unit/requirements-specification-detail-generated-output.suite.tsx
@@ -270,7 +270,14 @@ export function registerGeneratedOutputTests(
       await context.waitForInitialAvailableRequirementsRefresh()
       context.triggerRequirementLoadMore('items')
       expect(await screen.findByRole('row', { name: /BEH0200/ })).toBeVisible()
-      context.triggerRequirementLoadMore('items')
+      await waitFor(() => {
+        context.triggerRequirementLoadMore('items')
+        expect(
+          context.fetchMock.mock.calls.some(([input]) =>
+            String(input).includes('cursor=items-page-3'),
+          ),
+        ).toBe(true)
+      })
       expect(await screen.findByRole('row', { name: /BEH0201/ })).toBeVisible()
 
       expect(


### PR DESCRIPTION
## Description

Add explicit identity-provider profiles for the self-contained single-node
deployment while preserving bundled Keycloak as the default QA, demo,
prod-like, and smoke-test experience.

The external OIDC profile omits bundled Keycloak resources. The hardened
bundled profile separates user-facing OIDC traffic from an mTLS-protected
management path, rejects administrative surfaces before they reach Keycloak,
and adds production-shaped verification for the default and hardened flows.
The deployment, upgrade, uninstall, and OIDC integration guides now describe
the security and lifecycle contract for all three profiles.

## Related Issues

Closes #483

## Reviewer Notes

- `npm run check` passed: 6,514 tests passed and 75 skipped, plus 31 HSA
  support tests.
- Focused production helper tests passed: 69 tests.
- Both generated nginx profile configurations passed `nginx -t`.
- The final staged diff passed independent Standards and Spec reviews with no
  findings.
- The privileged production Quadlet smoke remains CI-executed.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
Existing self-contained single-node deployments retain the bundled identity
provider as their default and require no action unless changing identity
profiles. Operators moving to an external provider must complete the provider
registration, trust, redirect, logout, claim, and connectivity preparation
before rollout.

Before choosing bundled Keycloak for production, provision a separately
controlled management route with server and client certificate trust, restrict
its network reachability, establish named administrators with MFA and tested
recovery, and retire reusable bootstrap access. Validate both the user-facing
denials and authorized management access, and use the profile-specific backup,
rollback, recovery, uninstall, and incident procedures during its lifecycle.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/967)
<!-- Reviewable:end -->
