### PR TITLE
Make import-receipt CSV formula-safe

### DIFF
--- a/components/RequirementsImportDialog.tsx
+++ b/components/RequirementsImportDialog.tsx
@@ -39,6 +39,7 @@ import RequirementPackagePurposeTooltip from '@/components/RequirementPackagePur
 import StatusBadge from '@/components/StatusBadge'
 import { downloadBlob } from '@/lib/browser-download'
 import { devMarker } from '@/lib/developer-mode-markers'
+import { escapeCsvField } from '@/lib/export-csv'
 import { apiFetch } from '@/lib/http/api-fetch'
 import { readResponseMessage } from '@/lib/http/response-message'
 import {
@@ -508,7 +509,7 @@ function toNormReferencePayload(form: NormReferenceFormData) {
 function csvCell(value: unknown): string {
   if (value == null) return ''
   const text = Array.isArray(value) ? value.join('; ') : String(value)
-  return `"${text.replaceAll('"', '""')}"`
+  return escapeCsvField(text, { delimiter: ',', quoteAll: true })
 }
 
 function receiptCsv(rows: ImportReceiptRow[]): string {

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -39,6 +39,7 @@
     "kravliste",
     "kravpkg",
     "kravpaketsfilterraden",
+    "kravtextens",
     "kravunderlagssidan",
     "mellanlagringsfil",
     "MesloLGS",

--- a/docs/governance/manuella-testfall.md
+++ b/docs/governance/manuella-testfall.md
@@ -851,7 +851,8 @@ om reglaget inte ändras separat.
 
 **Steg:** Logga in som `olle.areaowner`, öppna `/sv/requirements`, välj
 importknappen i den flytande åtgärdsytan och ladda ner schema och
-importinstruktion. Klistra in `requirement-import.v3`-JSON med ett krav,
+importinstruktion. Klistra in `requirement-import.v3`-JSON med ett krav vars
+kravtext börjar med `=`,
 föreslagen normreferens, behovsreferensfält som ska ignoreras och ett först
 otillåtet destinationsfält. Välj kravområde, korrigera JSON, förhandsgranska,
 expandera raden, granska den föreslagna normreferensen, importera vald rad och
@@ -865,7 +866,9 @@ verifieringsmetod visas när `Verifierbar` är aktiv, löst förslag till
 normreferens visas som löst och behovsreferensfält anger att de inte används
 för kravbiblioteksimport. En vald prioritet visas med P-kod, tankstreck och
 lokaliserat namn. Importen skickar vald rad
-och skapar CSV-kvitto med importerad kravrad. Skärmläsare meddelar dynamiska
+och skapar CSV-kvitto med importerad kravrad. CSV-kvittot har kvar sina
+kolumner och sin ordning, och kravtextens inledande formelmarkör neutraliseras
+med en apostrof. Skärmläsare meddelar dynamiska
 importfel som felmeddelanden
 och icke-brådskande varningar samt CSV-kvittot som status utan att användaren
 flyttar fokus; en senare förhandsgranskning eller import meddelar bara det

--- a/docs/reference/reports.md
+++ b/docs/reference/reports.md
@@ -334,16 +334,22 @@ Excluded fields:
 The shared `escapeCsvField()` contract in `lib/export-csv.ts` and the
 row-wise exporters produce CSV with the following conventions:
 
-- **Separator:** semicolon (`;`) — European locale
-  compatibility.
+- **Separator:** semicolon (`;`) by default for European locale
+  compatibility. Callers with another established delimiter pass that
+  delimiter to the shared encoder so quoting follows the active format.
 - **Line endings:** CRLF (`\r\n`).
-- **Escaping:** fields containing `;`, `"`, `\n`, or `\r`
+- **Escaping:** fields containing the active delimiter, `"`, `\n`, or `\r`
   are wrapped in double-quotes with internal `"` doubled.
-- **Formula hardening:** fields beginning with `=`, `+`, `-`, `@`,
-  tab, or carriage return are prefixed with `'` and wrapped in
-  double-quotes.
+- **Formula hardening:** fields beginning with `=`, `+`, `-`, `@`, tab, or
+  carriage return are prefixed with `'` and wrapped in double-quotes. Formula
+  markers after a leading run of spaces, tabs, or carriage returns receive the
+  same treatment without changing the original whitespace.
 - **Download encoding:** UTF-8 with BOM at the HTTP/download boundary so
   Windows spreadsheet tools detect Swedish characters correctly.
+- Browser-generated requirement-import receipts retain their comma delimiter,
+  LF line endings, columns, filename, media type, and UTF-8 BOM while using the
+  same shared escaping and formula-hardening contract. They keep every
+  non-null field double-quoted for compatibility with existing receipts.
 - Requirements specification CSV exports are generated server-side from the
   whole specification, stay row-oriented, do not include metadata rows, and
   write the BOM, header, and each enriched page directly to the bounded spool.

--- a/lib/__tests__/export-csv.test.ts
+++ b/lib/__tests__/export-csv.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { exportToCsv } from '@/lib/export-csv'
+import { escapeCsvField, exportToCsv } from '@/lib/export-csv'
 
 describe('exportToCsv', () => {
   const headers = ['Namn', 'Beskrivning', 'Antal']
@@ -18,6 +18,20 @@ describe('exportToCsv', () => {
     const csv = exportToCsv(headers, data)
 
     expect(csv).toContain('"Namn;med;semikolon"')
+  })
+
+  it('quotes the active delimiter while retaining the semicolon default', () => {
+    expect(escapeCsvField('comma,value', { delimiter: ',' })).toBe(
+      '"comma,value"',
+    )
+    expect(escapeCsvField('comma,value')).toBe('comma,value')
+  })
+
+  it('force-quotes fields when the caller contract requires it', () => {
+    const options = { delimiter: ',', quoteAll: true }
+
+    expect(escapeCsvField('ordinary', options)).toBe('"ordinary"')
+    expect(escapeCsvField('', options)).toBe('""')
   })
 
   it('escapes fields with quotes by doubling them', () => {
@@ -59,6 +73,30 @@ describe('exportToCsv', () => {
 
     expect(csv).toContain(`"'=PlainFormula";Ok;1`)
   })
+
+  it.each([
+    [' =space', `"' =space"`],
+    [' +space', `"' +space"`],
+    [' -space', `"' -space"`],
+    [' @space', `"' @space"`],
+    ['\t=tab', `"'\t=tab"`],
+    ['\t+tab', `"'\t+tab"`],
+    ['\t-tab', `"'\t-tab"`],
+    ['\t@tab', `"'\t@tab"`],
+    ['\r=carriage', `"'\r=carriage"`],
+    ['\r+carriage', `"'\r+carriage"`],
+    ['\r-carriage', `"'\r-carriage"`],
+    ['\r@carriage', `"'\r@carriage"`],
+    [' \t\r=combined', `"' \t\r=combined"`],
+    [' \t\r+combined', `"' \t\r+combined"`],
+    [' \t\r-combined', `"' \t\r-combined"`],
+    [' \t\r@combined', `"' \t\r@combined"`],
+  ])(
+    'neutralizes a formula marker after supported leading whitespace: %j',
+    (field, expected) => {
+      expect(escapeCsvField(field)).toBe(expected)
+    },
+  )
 
   it('returns only header when data is empty', () => {
     const csv = exportToCsv(headers, [])

--- a/lib/export-csv.ts
+++ b/lib/export-csv.ts
@@ -2,22 +2,32 @@ export function exportToCsv(
   headers: string[],
   rows: Record<string, string>[],
 ): string {
-  const headerLine = headers.map(escapeCsvField).join(';')
+  const headerLine = headers.map(header => escapeCsvField(header)).join(';')
   const dataLines = rows.map(row =>
     headers.map(h => escapeCsvField(row[h] ?? '')).join(';'),
   )
   return [headerLine, ...dataLines].join('\r\n')
 }
 
-const FORMULA_LEADING_CHARACTERS = ['=', '+', '-', '@', '\t', '\r'] as const
+const FORMULA_LEADING_PATTERN = /^(?:[\t\r]|[ \t\r]*[-=+@])/
 
-export function escapeCsvField(field: string): string {
+export interface CsvFieldEncodingOptions {
+  delimiter?: string
+  quoteAll?: boolean
+}
+
+export function escapeCsvField(
+  field: string,
+  options: CsvFieldEncodingOptions = {},
+): string {
+  const { delimiter = ';', quoteAll = false } = options
   const isFormulaLeading = startsWithFormulaLeadingCharacter(field)
   const safeField = isFormulaLeading ? `'${field}` : field
 
   if (
+    quoteAll ||
     isFormulaLeading ||
-    safeField.includes(';') ||
+    safeField.includes(delimiter) ||
     safeField.includes('"') ||
     safeField.includes('\t') ||
     safeField.includes('\n') ||
@@ -29,7 +39,5 @@ export function escapeCsvField(field: string): string {
 }
 
 function startsWithFormulaLeadingCharacter(field: string): boolean {
-  return FORMULA_LEADING_CHARACTERS.some(character =>
-    field.startsWith(character),
-  )
+  return FORMULA_LEADING_PATTERN.test(field)
 }

--- a/tests/integration/requirements/import.spec.ts
+++ b/tests/integration/requirements/import.spec.ts
@@ -3,7 +3,7 @@ import { expect, type Route, test } from '@playwright/test'
 import { escapeRegExp } from '@/tests/helpers/common'
 
 const importedDescription =
-  'Playwright importerat krav ska kunna granskas och importeras.'
+  '=Playwright importerat krav ska kunna granskas och importeras.'
 
 // cSpell:ignore SOSFS
 const validImportPayload = {
@@ -325,13 +325,8 @@ test.describe('Requirements import', () => {
         throw new Error('CSV receipt download did not expose a local path.')
       }
       const receiptCsv = await readFile(receiptPath, 'utf8')
-      expect(receiptCsv).toContain(
-        'importMode,sourceIndex,createdVisibleId,createdDatabaseId,description',
-      )
-      expect(receiptCsv).toContain('"library","0","PWI9001","9001"')
-      expect(receiptCsv).toContain(`"${importedDescription}"`)
-      expect(receiptCsv).toContain(
-        '"SOSFS-IMPORT-1 - Importreferens","true","Demonstration","1"',
+      expect(receiptCsv).toBe(
+        `\uFEFFimportMode,sourceIndex,createdVisibleId,createdDatabaseId,description,acceptanceCriteria,category,type,qualityCharacteristic,priorityLevel,requirementPackages,normReferences,verifiable,verificationMethod,targetAreaId,targetSpecificationId,needsReferenceId\n"library","0","PWI9001","9001","'${importedDescription}",,,"Funktionellt",,"P2 – Låg","","SOSFS-IMPORT-1 - Importreferens","true","Demonstration","1",,\n`,
       )
 
       const refreshedRequirements = page.waitForRequest(request => {

--- a/tests/unit/requirements-import-dialog.test.tsx
+++ b/tests/unit/requirements-import-dialog.test.tsx
@@ -1184,7 +1184,43 @@ describe('RequirementsImportDialog', () => {
     await waitFor(() => expect(onClose).toHaveBeenCalledWith(false))
   })
 
-  it('executes selected rows, cleans review state, and downloads a CSV receipt', async () => {
+  it('downloads complete formula-safe CSV receipt content without changing its contract', async () => {
+    const formulaCases = [
+      { description: '=SUM("a,b")', encodedDescription: `"'=SUM(""a,b"")"` },
+      { description: '+direct', encodedDescription: `"'+direct"` },
+      { description: '-direct', encodedDescription: `"'-direct"` },
+      { description: '@direct', encodedDescription: `"'@direct"` },
+      { description: '\tTabbed', encodedDescription: `"'\tTabbed"` },
+      { description: '\rCarriage', encodedDescription: `"'\rCarriage"` },
+      { description: ' =space', encodedDescription: `"' =space"` },
+      { description: ' +space', encodedDescription: `"' +space"` },
+      { description: ' -space', encodedDescription: `"' -space"` },
+      { description: ' @space', encodedDescription: `"' @space"` },
+      { description: '\t=tab', encodedDescription: `"'\t=tab"` },
+      { description: '\t+tab', encodedDescription: `"'\t+tab"` },
+      { description: '\t-tab', encodedDescription: `"'\t-tab"` },
+      { description: '\t@tab', encodedDescription: `"'\t@tab"` },
+      { description: '\r=carriage', encodedDescription: `"'\r=carriage"` },
+      { description: '\r+carriage', encodedDescription: `"'\r+carriage"` },
+      { description: '\r-carriage', encodedDescription: `"'\r-carriage"` },
+      { description: '\r@carriage', encodedDescription: `"'\r@carriage"` },
+      {
+        description: ' \t\r=combined',
+        encodedDescription: `"' \t\r=combined"`,
+      },
+      {
+        description: ' \t\r+combined',
+        encodedDescription: `"' \t\r+combined"`,
+      },
+      {
+        description: ' \t\r-combined',
+        encodedDescription: `"' \t\r-combined"`,
+      },
+      {
+        description: ' \t\r@combined',
+        encodedDescription: `"' \t\r@combined"`,
+      },
+    ]
     const createObjectUrl = vi
       .spyOn(URL, 'createObjectURL')
       .mockReturnValue('blob:receipt')
@@ -1198,28 +1234,27 @@ describe('RequirementsImportDialog', () => {
     second.values.description = 'Keep for later'
     vi.mocked(apiFetch).mockResolvedValueOnce({
       json: async () => ({
-        createdRows: [
-          {
-            acceptanceCriteria: 'Contains "quotes"',
-            categoryName: 'Category',
-            createdDatabaseId: 9001,
-            createdVisibleId: 'KRAV9001',
-            description: 'Imported requirement',
-            importMode: 'library',
-            needsReferenceId: null,
-            normReferences: ['ISO-A', 'ISO-B'],
-            priorityLevelName: 'P4 – High',
-            qualityCharacteristicName: 'Completeness',
-            requirementPackageNames: ['Package A', 'Package B'],
-            sourceIndex: 0,
-            targetAreaId: 7,
-            targetSpecificationId: null,
-            typeName: 'Functional',
-            verifiable: true,
-            verificationMethod: 'Inspection',
-          },
-        ],
-        summary: { createdCount: 1 },
+        createdRows: formulaCases.map(({ description }, index) => ({
+          acceptanceCriteria: 'Contains "quotes", comma',
+          categoryName: 'Line 1\nLine 2',
+          createdDatabaseId: 9001 + index,
+          createdVisibleId: `KRAV${index + 1}`,
+          description,
+          importMode: 'library',
+          needsReferenceId: null,
+          normReferences: index === 0 ? [] : ['Norm "A"', 'Norm,B'],
+          priorityLevelName: index === 0 ? '' : null,
+          qualityCharacteristicName: 'Safe ordinary',
+          requirementPackageNames:
+            index === 0 ? [] : ['Package A', 'Package B'],
+          sourceIndex: index,
+          targetAreaId: 7,
+          targetSpecificationId: null,
+          typeName: 'Carriage\rreturn',
+          verifiable: true,
+          verificationMethod: 'Inspection',
+        })),
+        summary: { createdCount: formulaCases.length },
       }),
       ok: true,
     } as Response)
@@ -1276,7 +1311,9 @@ describe('RequirementsImportDialog', () => {
         expect.objectContaining({ method: 'POST' }),
       ),
     )
-    expect(await screen.findByText('Importerade rader: 1')).toBeVisible()
+    expect(
+      await screen.findByText(`Importerade rader: ${formulaCases.length}`),
+    ).toBeVisible()
     expect(screen.getByText('Keep for later')).toBeVisible()
 
     fireEvent.click(
@@ -1284,6 +1321,24 @@ describe('RequirementsImportDialog', () => {
     )
     expect(createObjectUrl).toHaveBeenCalledWith(expect.any(Blob))
     expect(revokeObjectUrl).toHaveBeenCalledWith('blob:receipt')
+    const receiptBlob = createObjectUrl.mock.calls[0]?.[0] as Blob
+    const receiptBytes = new Uint8Array(await receiptBlob.arrayBuffer())
+    const receiptText = new TextDecoder('utf-8', { ignoreBOM: true }).decode(
+      receiptBytes,
+    )
+    const expectedRows = formulaCases.map(({ encodedDescription }, index) => {
+      const expectedOptionalFields =
+        index === 0
+          ? '"","",""'
+          : ',"Package A; Package B","Norm ""A""; Norm,B"'
+      return `"library","${index}","KRAV${index + 1}","${9001 + index}",${encodedDescription},"Contains ""quotes"", comma","Line 1\nLine 2","Carriage\rreturn","Safe ordinary",${expectedOptionalFields},"true","Inspection","7",,`
+    })
+
+    expect(receiptBlob.type).toBe('text/csv;charset=utf-8')
+    expect(Array.from(receiptBytes.slice(0, 3))).toEqual([0xef, 0xbb, 0xbf])
+    expect(receiptText).toBe(
+      `\uFEFFimportMode,sourceIndex,createdVisibleId,createdDatabaseId,description,acceptanceCriteria,category,type,qualityCharacteristic,priorityLevel,requirementPackages,normReferences,verifiable,verificationMethod,targetAreaId,targetSpecificationId,needsReferenceId\n${expectedRows.join('\n')}\n`,
+    )
 
     fireEvent.click(screen.getByRole('button', { name: 'Ta bort från import' }))
     fireEvent.click(screen.getByRole('button', { name: 'Stäng' }))


### PR DESCRIPTION
## Description

- Route browser-generated import receipt fields through the shared CSV encoder.
- Neutralize direct and supported leading-whitespace spreadsheet formula prefixes.
- Preserve receipt quoting, columns, ordering, delimiter, line endings, filename,
  media type, UTF-8 BOM, and existing semicolon-export behavior.
- Add complete downloaded-Blob coverage and synchronize the REQ-17 manual and
  Playwright scenario.

## Related Issues

Closes #481

## Reviewer Notes

- `npm run check` passes: 6,538 tests passed and 75 were intentionally skipped.
- `npx playwright test tests/integration/requirements/import.spec.ts` passes.
- Final two-axis Standards and Spec review reported no findings.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
No operator notes needed.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/976)
<!-- Reviewable:end -->
