### PR TITLE
fix: return stable redacted diagnostics from sensitive request paths

### DIFF
--- a/app/[locale]/specifications/page.tsx
+++ b/app/[locale]/specifications/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { getTranslations } from 'next-intl/server'
+import { routing } from '@/i18n/routing'
 import { loadRequirementsSpecificationsInitialData } from '@/lib/specifications/preload'
 import RequirementsSpecificationsClient from './specifications-client'
 
@@ -8,7 +9,22 @@ export async function generateMetadata(): Promise<Metadata> {
   return { title: t('specifications') }
 }
 
-export default async function RequirementsSpecificationsPage() {
-  const initialData = await loadRequirementsSpecificationsInitialData()
+type Params = Promise<{ locale: string }>
+
+function resolveLocale(requestedLocale: string): 'sv' | 'en' {
+  return routing.locales.includes(requestedLocale as 'sv' | 'en')
+    ? (requestedLocale as 'sv' | 'en')
+    : routing.defaultLocale
+}
+
+export default async function RequirementsSpecificationsPage({
+  params,
+}: {
+  params: Params
+}) {
+  const { locale: requestedLocale } = await params
+  const initialData = await loadRequirementsSpecificationsInitialData(
+    resolveLocale(requestedLocale),
+  )
   return <RequirementsSpecificationsClient initialData={initialData} />
 }

--- a/docs/integrations/mcp-server-contributor-guide.md
+++ b/docs/integrations/mcp-server-contributor-guide.md
@@ -532,7 +532,14 @@ Current behavior:
   trusting any request header. Tests can use the same seam to inject
   verified actors.
 - Missing or invalid Bearer tokens return `401` with `WWW-Authenticate:
-  Bearer` and a JSON-RPC error body before service or tool handling runs.
+  Bearer` and a stable JSON-RPC error body before service or tool handling
+  runs. Authentication configuration failures return `500`; discovery and
+  remote JWKS availability failures return `503`. All authentication failures
+  retain the Bearer challenge and generic public messages.
+- `McpAuthError` derives its public message and status from an allowlisted
+  internal reason. Rejection audit events contain only that reason, never raw
+  verifier text, runtime error names, tokens, claims, client IDs, issuer
+  details, or network endpoints.
 - The default REST and MCP service wiring uses
   `AssignmentBasedAuthorizationService` via
   `createDefaultAuthorizationService(db)`. It resolves the target resource in

--- a/docs/integrations/mcp-server-user-guide.md
+++ b/docs/integrations/mcp-server-user-guide.md
@@ -337,9 +337,13 @@ MCP transport or tool handler runs. Accepted tokens must contain a real-format
 local Keycloak realm instead of compensating in application code.
 
 Invalid or missing tokens return `401` with `WWW-Authenticate: Bearer` and a
-JSON-RPC error body. MCP does not use browser cookies and is intentionally
-excluded from browser CSRF checks. Tool handlers build their actor context only
-from the verified token attached at the HTTP edge.
+stable JSON-RPC error body. Authentication configuration failures return `500`,
+and discovery or JWKS availability failures return `503`; these responses also
+use stable generic messages and the Bearer challenge. They never include token
+verification, issuer, network, JWKS, or configuration details. MCP does not use
+browser cookies and is intentionally excluded from browser CSRF checks. Tool
+handlers build their actor context only from the verified token attached at the
+HTTP edge.
 
 Authorization denials remain fail-closed. If the server cannot record the
 required denial evidence, it keeps the requested work blocked and returns a

--- a/docs/security-privacy/auth-how-it-works.md
+++ b/docs/security-privacy/auth-how-it-works.md
@@ -198,6 +198,12 @@ sequenceDiagram
         Proxy-->>Client: JSON-RPC 401 if Authorization header is missing
         Verify->>Audit: auth.token.rejected
         Route-->>Client: JSON-RPC 401 + WWW-Authenticate: Bearer
+    else Authentication configuration failure
+        Verify->>Audit: auth.token.rejected with allowlisted reason
+        Route-->>Client: Generic JSON-RPC 500 + WWW-Authenticate: Bearer
+    else Discovery or remote JWKS unavailable
+        Verify->>Audit: auth.token.rejected with allowlisted reason
+        Route-->>Client: Generic JSON-RPC 503 + WWW-Authenticate: Bearer
     end
 ```
 <!-- markdownlint-enable MD013 -->
@@ -207,6 +213,11 @@ sequenceDiagram
   [`lib/auth/mcp-token.ts`](../../lib/auth/mcp-token.ts).
 - Missing-header and invalid-token failures use a JSON-RPC error body so MCP
   clients receive the same response shape at both auth gates.
+- The MCP authentication boundary maps invalid credentials to `401`, local
+  authentication configuration failures to `500`, and unavailable discovery
+  or remote JWKS dependencies to `503`. Every response uses a stable generic
+  message and retains `WWW-Authenticate: Bearer`; underlying verifier, issuer,
+  network, JWKS, and configuration messages remain server-side.
 - `verifyMcpBearerToken()` uses OIDC discovery metadata to read the issuer's
   `jwks_uri` and caches the resulting `RemoteJWKSet`.
 - JWT verification checks signature, issuer, audience, and a 30-second clock
@@ -280,6 +291,9 @@ sequenceDiagram
   detail key is redacted, the audit writer also emits a structured
   `detail-key-redacted` breadcrumb with the source event, actor source, and
   redacted key name.
+- Rejected MCP authentication events contain an allowlisted reason code only.
+  They exclude token and claim values, issuer details, dependency text, and
+  runtime error names.
 - Privacy erasure and data subject access export security events are emitted to
   the platform security-log stream. Privacy erasure execution also writes a
   database action-log row for Admin review. Both include the handler

--- a/lib/__tests__/safe-errors.test.ts
+++ b/lib/__tests__/safe-errors.test.ts
@@ -10,11 +10,12 @@ import {
 } from '@/lib/http/safe-errors'
 
 describe('safe error helpers', () => {
-  it('redacts provider keys, bearer tokens, JWTs, HSA-id values, secrets, and SQL fragments', () => {
+  it('redacts provider keys, bearer tokens, JWTs, international HSA-id values, secrets, and SQL fragments', () => {
     const text = [
       'OpenRouter sk-or-v1-secret123 failed',
       'Authorization: Bearer eyJhbGciOi.demo.payload',
       'employeeHsaId=SE5560000001-12345',
+      'reviewerHsaId=NO5560000001-reviewer1',
       'client_secret=supersecret',
       'SELECT token FROM sessions',
     ].join(' ')
@@ -27,7 +28,7 @@ describe('safe error helpers', () => {
     expect(redacted).toContain('client_secret=[REDACTED]')
     expect(redacted).toContain('[SQL_REDACTED]')
     expect(redacted).not.toMatch(
-      /sk-or-v1-|eyJhbGciOi|SE5560000001-12345|supersecret|SELECT/,
+      /sk-or-v1-|eyJhbGciOi|SE5560000001-12345|NO5560000001-reviewer1|supersecret|SELECT/,
     )
   })
 

--- a/lib/auth/hsa-id.ts
+++ b/lib/auth/hsa-id.ts
@@ -20,9 +20,10 @@
 /** Maximum length of an HSA-id (inclusive). */
 export const HSA_ID_MAX_LENGTH = 31
 export const HSA_ID_PREFIX_LENGTH = 12
+export const HSA_ID_PATTERN_SOURCE = String.raw`[A-Z]{2}\d{10}-[A-Za-z0-9]{1,18}`
 
 // Anchored regex with the unicode flag so `[A-Za-z]` cannot match `å/ä/ö`.
-const HSA_ID_PATTERN = /^[A-Z]{2}\d{10}-[A-Za-z0-9]+$/u
+const HSA_ID_PATTERN = new RegExp(`^${HSA_ID_PATTERN_SOURCE}$`, 'u')
 const HSA_ID_PREFIX_PATTERN = /^[A-Z]{2}\d{10}$/u
 const HSA_ID_SUFFIX_PATTERN = /^[A-Za-z0-9]+$/u
 

--- a/lib/auth/mcp-token.ts
+++ b/lib/auth/mcp-token.ts
@@ -82,9 +82,6 @@ function parseJwksUrl(jwksUri: string): URL {
   }
   if (url.protocol === 'https:') return url
   if (url.protocol === 'http:' && ALLOW_INSECURE_OIDC_ISSUER) return url
-  if (url.protocol === 'http:') {
-    throw new McpAuthDependencyError('jwks_configuration_invalid')
-  }
   throw new McpAuthDependencyError('jwks_configuration_invalid')
 }
 
@@ -164,7 +161,7 @@ function classifyVerificationFailure(error: unknown): McpAuthFailureReason {
   if (code === 'ERR_JWT_CLAIM_VALIDATION_FAILED' && claim === 'aud') {
     return 'token_audience_invalid'
   }
-  if (code === 'ERR_JWKS_TIMEOUT' || error instanceof TypeError) {
+  if (code === 'ERR_JWKS_TIMEOUT') {
     return 'jwks_unavailable'
   }
   return 'token_verification_failed'
@@ -196,11 +193,20 @@ export async function verifyMcpBearerToken(
     const issuer = cfg.issuerUrl
     const audience = cfg.apiAudience
     const jwks = await getOrCreateJwks(issuer)
-    const { payload } = await jwtVerify(token, jwks, {
-      issuer,
-      audience,
-      clockTolerance: 30,
-    })
+    let verificationResult: Awaited<ReturnType<typeof jwtVerify>>
+    try {
+      verificationResult = await jwtVerify(token, jwks, {
+        issuer,
+        audience,
+        clockTolerance: 30,
+      })
+    } catch (error) {
+      if (error instanceof TypeError) {
+        throw new McpAuthDependencyError('jwks_unavailable')
+      }
+      throw error
+    }
+    const { payload } = verificationResult
     const sub = typeof payload.sub === 'string' ? payload.sub : null
     const roles = parseRolesClaim(payload.roles)
     const payloadRecord = payload as Record<string, unknown>

--- a/lib/auth/mcp-token.ts
+++ b/lib/auth/mcp-token.ts
@@ -19,32 +19,86 @@ type JwksCacheEntry = {
 
 let jwksCache: JwksCacheEntry | null = null
 
+export type McpAuthFailureReason =
+  | 'auth_boundary_failed'
+  | 'auth_configuration_invalid'
+  | 'bearer_missing'
+  | 'hsa_id_invalid'
+  | 'hsa_id_missing'
+  | 'jwks_configuration_invalid'
+  | 'jwks_unavailable'
+  | 'oidc_discovery_failed'
+  | 'token_audience_invalid'
+  | 'token_issuer_invalid'
+  | 'token_verification_failed'
+
+interface McpAuthFailureContract {
+  message: string
+  status: number
+}
+
+const MCP_AUTH_FAILURE_CONTRACTS: Record<
+  McpAuthFailureReason,
+  McpAuthFailureContract
+> = {
+  auth_boundary_failed: { message: 'Authentication failed.', status: 500 },
+  auth_configuration_invalid: {
+    message: 'Authentication failed.',
+    status: 500,
+  },
+  bearer_missing: { message: 'Missing Bearer token.', status: 401 },
+  hsa_id_invalid: { message: 'Invalid Bearer token.', status: 401 },
+  hsa_id_missing: { message: 'Invalid Bearer token.', status: 401 },
+  jwks_configuration_invalid: {
+    message: 'Authentication failed.',
+    status: 500,
+  },
+  jwks_unavailable: {
+    message: 'Authentication service unavailable.',
+    status: 503,
+  },
+  oidc_discovery_failed: {
+    message: 'Authentication service unavailable.',
+    status: 503,
+  },
+  token_audience_invalid: { message: 'Invalid Bearer token.', status: 401 },
+  token_issuer_invalid: { message: 'Invalid Bearer token.', status: 401 },
+  token_verification_failed: { message: 'Invalid Bearer token.', status: 401 },
+}
+
+class McpAuthDependencyError extends Error {
+  constructor(public readonly reason: McpAuthFailureReason) {
+    super(reason)
+    this.name = 'McpAuthDependencyError'
+  }
+}
+
 function parseJwksUrl(jwksUri: string): URL {
   let url: URL
   try {
     url = new URL(jwksUri)
   } catch {
-    throw new Error('OIDC discovery metadata included an invalid `jwks_uri`.')
+    throw new McpAuthDependencyError('jwks_configuration_invalid')
   }
   if (url.protocol === 'https:') return url
   if (url.protocol === 'http:' && ALLOW_INSECURE_OIDC_ISSUER) return url
   if (url.protocol === 'http:') {
-    throw new Error(
-      'Refusing to use insecure http:// JWKS URI in this build. ' +
-        'Production builds require an https:// JWKS URI.',
-    )
+    throw new McpAuthDependencyError('jwks_configuration_invalid')
   }
-  throw new Error(
-    `Refusing to use unsupported JWKS URI protocol: ${url.protocol}`,
-  )
+  throw new McpAuthDependencyError('jwks_configuration_invalid')
 }
 
 async function getOrCreateJwks(issuer: string): Promise<RemoteJwks> {
-  const { getOidcConfiguration } = await import('@/lib/auth/oidc')
-  const metadata = (await getOidcConfiguration()).serverMetadata()
+  let metadata: { jwks_uri?: string }
+  try {
+    const { getOidcConfiguration } = await import('@/lib/auth/oidc')
+    metadata = (await getOidcConfiguration()).serverMetadata()
+  } catch {
+    throw new McpAuthDependencyError('oidc_discovery_failed')
+  }
   const jwksUri = metadata.jwks_uri
   if (!jwksUri) {
-    throw new Error('OIDC discovery metadata did not include `jwks_uri`.')
+    throw new McpAuthDependencyError('jwks_configuration_invalid')
   }
   if (
     jwksCache &&
@@ -53,7 +107,13 @@ async function getOrCreateJwks(issuer: string): Promise<RemoteJwks> {
   ) {
     return jwksCache.jwks
   }
-  const jwks = createRemoteJWKSet(parseJwksUrl(jwksUri))
+  let jwks: RemoteJwks
+  try {
+    jwks = createRemoteJWKSet(parseJwksUrl(jwksUri))
+  } catch (error) {
+    if (error instanceof McpAuthDependencyError) throw error
+    throw new McpAuthDependencyError('jwks_configuration_invalid')
+  }
   jwksCache = { issuer, jwksUri, jwks }
   return jwks
 }
@@ -63,13 +123,51 @@ export function resetMcpJwksCacheForTests(): void {
 }
 
 export class McpAuthError extends Error {
-  constructor(
-    message: string,
-    public status: number,
-  ) {
-    super(message)
+  public readonly status: number
+
+  constructor(public readonly reason: McpAuthFailureReason) {
+    const contract = MCP_AUTH_FAILURE_CONTRACTS[reason]
+    super(contract.message)
     this.name = 'McpAuthError'
+    this.status = contract.status
   }
+}
+
+function rejectMcpAuthentication(
+  request: Request,
+  reason: McpAuthFailureReason,
+): never {
+  recordSecurityEvent({
+    event: 'auth.token.rejected',
+    outcome: 'failure',
+    actor: { source: 'mcp' },
+    request,
+    detail: { reason },
+  })
+  throw new McpAuthError(reason)
+}
+
+function errorProperty(error: unknown, key: string): unknown {
+  return error && typeof error === 'object'
+    ? (error as Record<string, unknown>)[key]
+    : undefined
+}
+
+function classifyVerificationFailure(error: unknown): McpAuthFailureReason {
+  if (error instanceof McpAuthDependencyError) return error.reason
+
+  const code = errorProperty(error, 'code')
+  const claim = errorProperty(error, 'claim')
+  if (code === 'ERR_JWT_CLAIM_VALIDATION_FAILED' && claim === 'iss') {
+    return 'token_issuer_invalid'
+  }
+  if (code === 'ERR_JWT_CLAIM_VALIDATION_FAILED' && claim === 'aud') {
+    return 'token_audience_invalid'
+  }
+  if (code === 'ERR_JWKS_TIMEOUT' || error instanceof TypeError) {
+    return 'jwks_unavailable'
+  }
+  return 'token_verification_failed'
 }
 
 /**
@@ -80,27 +178,23 @@ export class McpAuthError extends Error {
 export async function verifyMcpBearerToken(
   request: Request,
 ): Promise<VerifiedMcpToken> {
-  const { getAuthConfig } = await import('@/lib/auth/config')
-  const cfg = getAuthConfig()
-
   const header = request.headers.get('authorization') ?? ''
   const match = /^Bearer\s+(\S+)$/i.exec(header)
   if (!match) {
-    recordSecurityEvent({
-      event: 'auth.token.rejected',
-      outcome: 'failure',
-      actor: { source: 'mcp' },
-      request,
-      detail: { reason: 'bearer_missing' },
-    })
-    throw new McpAuthError('Missing Bearer token.', 401)
+    rejectMcpAuthentication(request, 'bearer_missing')
   }
   const token = match[1]
 
-  const issuer = cfg.issuerUrl
-  const audience = cfg.apiAudience
-
   try {
+    const { getAuthConfig } = await import('@/lib/auth/config')
+    let cfg: ReturnType<typeof getAuthConfig>
+    try {
+      cfg = getAuthConfig()
+    } catch {
+      rejectMcpAuthentication(request, 'auth_configuration_invalid')
+    }
+    const issuer = cfg.issuerUrl
+    const audience = cfg.apiAudience
     const jwks = await getOrCreateJwks(issuer)
     const { payload } = await jwtVerify(token, jwks, {
       issuer,
@@ -120,30 +214,10 @@ export async function verifyMcpBearerToken(
     const hsaIdRaw =
       typeof hsaIdClaim === 'string' && hsaIdClaim !== '' ? hsaIdClaim : null
     if (!hsaIdRaw) {
-      recordSecurityEvent({
-        event: 'auth.token.rejected',
-        outcome: 'failure',
-        actor: clientId ? { source: 'mcp', clientId } : { source: 'mcp' },
-        request,
-        detail: { reason: 'hsa_id_missing' },
-      })
-      throw new McpAuthError(
-        'Invalid Bearer token: missing required `employeeHsaId` claim.',
-        401,
-      )
+      rejectMcpAuthentication(request, 'hsa_id_missing')
     }
     if (!isHsaId(hsaIdRaw)) {
-      recordSecurityEvent({
-        event: 'auth.token.rejected',
-        outcome: 'failure',
-        actor: clientId ? { source: 'mcp', clientId } : { source: 'mcp' },
-        request,
-        detail: { reason: 'hsa_id_invalid' },
-      })
-      throw new McpAuthError(
-        'Invalid Bearer token: `employeeHsaId` is not a valid HSA-id.',
-        401,
-      )
+      rejectMcpAuthentication(request, 'hsa_id_invalid')
     }
     const scopeRaw = payloadRecord.scope
     const scopes =
@@ -172,17 +246,6 @@ export async function verifyMcpBearerToken(
     }
   } catch (err) {
     if (err instanceof McpAuthError) throw err
-    const message = err instanceof Error ? err.message : 'Invalid token.'
-    recordSecurityEvent({
-      event: 'auth.token.rejected',
-      outcome: 'failure',
-      actor: { source: 'mcp' },
-      request,
-      detail: {
-        reason: 'jwt_verify_failed',
-        errorName: err instanceof Error ? err.name : 'Error',
-      },
-    })
-    throw new McpAuthError(`Invalid Bearer token: ${message}`, 401)
+    rejectMcpAuthentication(request, classifyVerificationFailure(err))
   }
 }

--- a/lib/http/safe-errors.ts
+++ b/lib/http/safe-errors.ts
@@ -1,3 +1,5 @@
+import { HSA_ID_PATTERN_SOURCE } from '@/lib/auth/hsa-id'
+
 export const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal server error'
 export const AI_PROVIDER_UNAVAILABLE_MESSAGE = 'AI provider is unavailable'
 export const AI_CREDIT_INFORMATION_UNAVAILABLE_MESSAGE =
@@ -12,7 +14,10 @@ interface SafeErrorLogValue {
 const OPENROUTER_KEY_PATTERN = /\bsk-or-(?:v1|mgmt)-[A-Za-z0-9_-]+\b/g
 const BEARER_TOKEN_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+\b/gi
 const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g
-const HSA_ID_PATTERN = /\bSE\d{10}-[A-Za-z0-9_-]+\b/g
+const HSA_ID_PATTERN = new RegExp(
+  `(?<![A-Za-z0-9])${HSA_ID_PATTERN_SOURCE}(?![A-Za-z0-9])`,
+  'gu',
+)
 const SECRET_ASSIGNMENT_PATTERN =
   /\b([A-Za-z0-9_.-]*(?:api[_-]?key|authorization[_-]?code|code[_-]?verifier|nonce|password|secret|state|token)[A-Za-z0-9_.-]*)\s*[:=]\s*["']?[^"',\s}]+/gi
 

--- a/lib/mcp/http.ts
+++ b/lib/mcp/http.ts
@@ -3,6 +3,7 @@ import {
   formatMcpRequestPayloadKiB,
   MCP_REQUEST_PAYLOAD_DEFAULT_BYTES,
 } from '@/lib/ai/generation-availability'
+import { recordSecurityEvent } from '@/lib/auth/audit'
 import { McpAuthError, verifyMcpBearerToken } from '@/lib/auth/mcp-token'
 import { getCachedMcpRuntimeSettings } from '@/lib/dal/ai-settings'
 import type { SqlServerDatabase } from '@/lib/db'
@@ -111,23 +112,33 @@ export async function handleRequirementsMcpRequest(
     const verified = await verifyMcpBearerToken(request)
     attachVerifiedActor(request, verified.actor)
   } catch (err) {
-    if (err instanceof McpAuthError) {
-      return new Response(
-        JSON.stringify({
-          error: { code: -32000, message: err.message },
-          id: null,
-          jsonrpc: '2.0',
-        }),
-        {
-          headers: {
-            'Content-Type': 'application/json',
-            'WWW-Authenticate': 'Bearer',
-          },
-          status: err.status,
-        },
-      )
+    const authError =
+      err instanceof McpAuthError
+        ? err
+        : new McpAuthError('auth_boundary_failed')
+    if (!(err instanceof McpAuthError)) {
+      recordSecurityEvent({
+        event: 'auth.token.rejected',
+        outcome: 'failure',
+        actor: { source: 'mcp' },
+        request,
+        detail: { reason: authError.reason },
+      })
     }
-    throw err
+    return new Response(
+      JSON.stringify({
+        error: { code: -32000, message: authError.message },
+        id: null,
+        jsonrpc: '2.0',
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'WWW-Authenticate': 'Bearer',
+        },
+        status: authError.status,
+      },
+    )
   }
 
   const mcpSettings = await getCachedMcpRuntimeSettings(db)

--- a/lib/specifications/preload.ts
+++ b/lib/specifications/preload.ts
@@ -1,3 +1,4 @@
+import { getTranslations } from 'next-intl/server'
 import { DEFAULT_AI_REQUIREMENT_GENERATION_AVAILABILITY } from '@/lib/ai/generation-availability'
 import { getAiGenerationAvailability } from '@/lib/dal/ai-settings'
 import {
@@ -20,6 +21,7 @@ import { listSpecificationItemStatuses } from '@/lib/dal/specification-item-stat
 import { listSpecificationLifecycleStatuses } from '@/lib/dal/specification-lifecycle-statuses'
 import type { SqlServerDatabase } from '@/lib/db'
 import { getRequestSqlServerDataSource } from '@/lib/db'
+import { logSanitizedError } from '@/lib/http/safe-errors'
 import { positiveIntegerStringSchema } from '@/lib/http/validation'
 import { forbiddenError } from '@/lib/requirements/errors'
 import { queryRequirementList } from '@/lib/requirements/list-query'
@@ -60,24 +62,42 @@ import {
 
 const PAGE_SIZE = 200
 
-function toErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : String(error)
+interface CaptureResult<T> {
+  error?: SpecificationPreloadError
+  value: T
 }
 
-async function capture<T>(
+type Capture = <T>(
   key: string,
   fallback: T,
   load: () => Promise<T>,
-): Promise<{ error?: SpecificationPreloadError; value: T }> {
-  try {
-    return { value: await load() }
-  } catch (error) {
-    console.error(`Failed to preload ${key}`, error)
-    return {
-      error: { key, message: toErrorMessage(error) },
-      value: fallback,
+) => Promise<CaptureResult<T>>
+
+function createCapture(errorMessage: string): Capture {
+  return async function capture<T>(
+    key: string,
+    fallback: T,
+    load: () => Promise<T>,
+  ): Promise<CaptureResult<T>> {
+    try {
+      return { value: await load() }
+    } catch (error) {
+      logSanitizedError('Failed to preload specification data', error, {
+        resourceKey: key,
+      })
+      return {
+        error: { key, message: errorMessage },
+        value: fallback,
+      }
     }
   }
+}
+
+async function specificationPreloadErrorMessage(
+  locale: 'en' | 'sv',
+): Promise<string> {
+  const t = await getTranslations({ locale, namespace: 'specification' })
+  return t('partialDataLoadWarning')
 }
 
 async function listLinkedNormReferenceOptions(
@@ -189,6 +209,7 @@ export async function loadRequirementsSpecificationDetailInitialData({
   locale: 'en' | 'sv'
   specificationId: number
 }): Promise<RequirementsSpecificationDetailInitialData> {
+  const capture = createCapture(await specificationPreloadErrorMessage(locale))
   const db = await getRequestSqlServerDataSource()
   const { service } = createRequirementsRuntime(db)
   const context = await createServerComponentRequestContext({
@@ -429,7 +450,10 @@ export async function resolveRequirementsSpecificationRouteParam(
   return specification ? { fromCode: true, id: specification.id } : null
 }
 
-export async function loadRequirementsSpecificationsInitialData(): Promise<RequirementsSpecificationsInitialData> {
+export async function loadRequirementsSpecificationsInitialData(
+  locale: 'en' | 'sv',
+): Promise<RequirementsSpecificationsInitialData> {
+  const capture = createCapture(await specificationPreloadErrorMessage(locale))
   const db = await getRequestSqlServerDataSource()
   const context = await createServerComponentRequestContext({
     path: '/specifications',

--- a/tests/unit/mcp-http.test.ts
+++ b/tests/unit/mcp-http.test.ts
@@ -28,28 +28,23 @@ vi.mock('@/lib/requirements/service', async () => {
   }
 })
 
-vi.mock('@/lib/auth/mcp-token', () => ({
-  McpAuthError: class McpAuthError extends Error {
-    readonly status: number
-
-    constructor(message: string, status = 401) {
-      super(message)
-      this.name = 'McpAuthError'
-      this.status = status
-    }
-  },
-  verifyMcpBearerToken: vi.fn(async () => ({
-    actor: {
-      id: 'mcp-test-actor',
-      displayName: 'MCP Test Actor',
-      hsaId: 'SE5560000001-mcp1',
-      isAuthenticated: true,
-      roles: ['Admin'],
-      source: 'mcp' as const,
-    },
-    expiresAt: null,
-  })),
-}))
+vi.mock('@/lib/auth/mcp-token', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/auth/mcp-token')>()
+  return {
+    ...actual,
+    verifyMcpBearerToken: vi.fn(async () => ({
+      actor: {
+        id: 'mcp-test-actor',
+        displayName: 'MCP Test Actor',
+        hsaId: 'SE5560000001-mcp1',
+        isAuthenticated: true,
+        roles: ['Admin'],
+        source: 'mcp' as const,
+      },
+      expiresAt: null,
+    })),
+  }
+})
 
 vi.mock('@/lib/dal/ai-settings', () => ({
   getCachedMcpRuntimeSettings: serviceState.getCachedMcpRuntimeSettings,
@@ -1604,7 +1599,7 @@ describe('handleRequirementsMcpRequest', () => {
 
   it('returns a bearer challenge and skips service creation when MCP auth fails', async () => {
     vi.mocked(verifyMcpBearerToken).mockRejectedValueOnce(
-      new McpAuthError('Missing Bearer token.', 401),
+      new McpAuthError('bearer_missing'),
     )
 
     const response = await handleRequirementsMcpRequest(
@@ -1646,17 +1641,25 @@ describe('handleRequirementsMcpRequest', () => {
     expect(serviceState.getService).not.toHaveBeenCalled()
   })
 
-  it('propagates unexpected authentication failures', async () => {
+  it('contains unexpected authentication failures behind a stable response', async () => {
     vi.mocked(verifyMcpBearerToken).mockRejectedValueOnce(
-      new Error('OIDC discovery unavailable'),
+      new Error(
+        'OIDC discovery unavailable at https://private.issuer for secret-token',
+      ),
     )
 
-    await expect(
-      handleRequirementsMcpRequest(
-        new Request('https://example.test/api/mcp'),
-        {} as never,
-      ),
-    ).rejects.toThrow('OIDC discovery unavailable')
+    const response = await handleRequirementsMcpRequest(
+      new Request('https://example.test/api/mcp'),
+      {} as never,
+    )
+
+    expect(response.status).toBe(500)
+    expect(response.headers.get('WWW-Authenticate')).toBe('Bearer')
+    const serializedResponse = JSON.stringify(await response.json())
+    expect(serializedResponse).toContain('Authentication failed.')
+    expect(serializedResponse).not.toMatch(
+      /private\.issuer|secret-token|OIDC discovery unavailable/,
+    )
     expect(serviceState.getCachedMcpRuntimeSettings).not.toHaveBeenCalled()
     expect(serviceState.getService).not.toHaveBeenCalled()
   })
@@ -1681,7 +1684,7 @@ describe('handleRequirementsMcpRequest', () => {
 
   it('returns 401 before payload size inspection when MCP auth fails', async () => {
     vi.mocked(verifyMcpBearerToken).mockRejectedValueOnce(
-      new McpAuthError('Missing Bearer token.', 401),
+      new McpAuthError('bearer_missing'),
     )
 
     const response = await handleRequirementsMcpRequest(

--- a/tests/unit/mcp-token.test.ts
+++ b/tests/unit/mcp-token.test.ts
@@ -142,7 +142,8 @@ describe('verifyMcpBearerToken', () => {
       e =>
         e instanceof McpAuthError &&
         e.status === 401 &&
-        /employeeHsaId/.test(e.message),
+        e.message === 'Invalid Bearer token.' &&
+        e.reason === 'hsa_id_missing',
     )
   })
 
@@ -171,7 +172,8 @@ describe('verifyMcpBearerToken', () => {
       e =>
         e instanceof McpAuthError &&
         e.status === 401 &&
-        /employeeHsaId/.test(e.message),
+        e.message === 'Invalid Bearer token.' &&
+        e.reason === 'hsa_id_missing',
     )
   })
 
@@ -200,7 +202,8 @@ describe('verifyMcpBearerToken', () => {
       e =>
         e instanceof McpAuthError &&
         e.status === 401 &&
-        /HSA-id/.test(e.message),
+        e.message === 'Invalid Bearer token.' &&
+        e.reason === 'hsa_id_invalid',
     )
   })
 
@@ -246,8 +249,9 @@ describe('verifyMcpBearerToken', () => {
     ).rejects.toSatisfy(
       e =>
         e instanceof McpAuthError &&
-        e.status === 401 &&
-        /jwks_uri/.test(e.message),
+        e.status === 500 &&
+        e.message === 'Authentication failed.' &&
+        e.reason === 'jwks_configuration_invalid',
     )
   })
 
@@ -271,8 +275,9 @@ describe('verifyMcpBearerToken', () => {
     ).rejects.toSatisfy(
       e =>
         e instanceof McpAuthError &&
-        e.status === 401 &&
-        /unsupported JWKS URI protocol/.test(e.message),
+        e.status === 500 &&
+        e.message === 'Authentication failed.' &&
+        e.reason === 'jwks_configuration_invalid',
     )
     expect(createRemoteJWKSetMock).not.toHaveBeenCalled()
     expect(jwtVerifyMock).not.toHaveBeenCalled()
@@ -298,7 +303,9 @@ describe('verifyMcpBearerToken', () => {
     ).rejects.toSatisfy(
       error =>
         error instanceof McpAuthError &&
-        /invalid `jwks_uri`/.test(error.message),
+        error.status === 500 &&
+        error.message === 'Authentication failed.' &&
+        error.reason === 'jwks_configuration_invalid',
     )
     expect(createRemoteJWKSetMock).not.toHaveBeenCalled()
   })
@@ -402,7 +409,8 @@ describe('verifyMcpBearerToken', () => {
       ),
     ).rejects.toEqual(
       expect.objectContaining({
-        message: 'Invalid Bearer token: Invalid token.',
+        message: 'Invalid Bearer token.',
+        reason: 'token_verification_failed',
         status: 401,
       }),
     )
@@ -413,7 +421,11 @@ describe('verifyMcpBearerToken', () => {
       issuerUrl: 'https://issuer.example.com',
       apiAudience: 'kravhantering-app',
     })
-    jwtVerifyMock.mockRejectedValue(new Error('unexpected "iss" claim value'))
+    const issuerError = Object.assign(
+      new Error('unexpected "iss" claim value for https://private.issuer'),
+      { claim: 'iss', code: 'ERR_JWT_CLAIM_VALIDATION_FAILED' },
+    )
+    jwtVerifyMock.mockRejectedValue(issuerError)
 
     const { verifyMcpBearerToken, McpAuthError } = await import(
       '@/lib/auth/mcp-token'
@@ -425,7 +437,13 @@ describe('verifyMcpBearerToken', () => {
           headers: { authorization: 'Bearer wrong.issuer.token' },
         }),
       ),
-    ).rejects.toSatisfy(e => e instanceof McpAuthError && e.status === 401)
+    ).rejects.toSatisfy(
+      e =>
+        e instanceof McpAuthError &&
+        e.status === 401 &&
+        e.message === 'Invalid Bearer token.' &&
+        e.reason === 'token_issuer_invalid',
+    )
     expect(jwtVerifyMock).toHaveBeenCalledWith(
       'wrong.issuer.token',
       { kind: 'jwks' },
@@ -440,7 +458,11 @@ describe('verifyMcpBearerToken', () => {
       issuerUrl: 'https://issuer.example.com',
       apiAudience: 'kravhantering-app',
     })
-    jwtVerifyMock.mockRejectedValue(new Error('unexpected "aud" claim value'))
+    const audienceError = Object.assign(
+      new Error('unexpected "aud" claim value kravhantering-private'),
+      { claim: 'aud', code: 'ERR_JWT_CLAIM_VALIDATION_FAILED' },
+    )
+    jwtVerifyMock.mockRejectedValue(audienceError)
 
     const { verifyMcpBearerToken, McpAuthError } = await import(
       '@/lib/auth/mcp-token'
@@ -452,13 +474,99 @@ describe('verifyMcpBearerToken', () => {
           headers: { authorization: 'Bearer wrong.audience.token' },
         }),
       ),
-    ).rejects.toSatisfy(e => e instanceof McpAuthError && e.status === 401)
+    ).rejects.toSatisfy(
+      e =>
+        e instanceof McpAuthError &&
+        e.status === 401 &&
+        e.message === 'Invalid Bearer token.' &&
+        e.reason === 'token_audience_invalid',
+    )
     expect(jwtVerifyMock).toHaveBeenCalledWith(
       'wrong.audience.token',
       { kind: 'jwks' },
       expect.objectContaining({
         audience: 'kravhantering-app',
       }),
+    )
+  })
+
+  it('normalizes discovery failures without exposing issuer or network details', async () => {
+    getAuthConfigMock.mockReturnValue({
+      issuerUrl: 'https://private.issuer',
+      apiAudience: 'kravhantering-app',
+    })
+    getOidcConfigurationMock.mockRejectedValue(
+      new Error('connect ECONNREFUSED 10.0.0.4 for https://private.issuer'),
+    )
+    const { verifyMcpBearerToken, McpAuthError } = await import(
+      '@/lib/auth/mcp-token'
+    )
+
+    await expect(
+      verifyMcpBearerToken(
+        new Request('http://x/', {
+          headers: { authorization: 'Bearer secret.discovery.token' },
+        }),
+      ),
+    ).rejects.toSatisfy(
+      error =>
+        error instanceof McpAuthError &&
+        error.status === 503 &&
+        error.message === 'Authentication service unavailable.' &&
+        error.reason === 'oidc_discovery_failed' &&
+        !JSON.stringify(error).includes('private.issuer'),
+    )
+  })
+
+  it('normalizes remote JWKS network failures without exposing dependency text', async () => {
+    getAuthConfigMock.mockReturnValue({
+      issuerUrl: 'https://issuer.example.com',
+      apiAudience: 'kravhantering-app',
+    })
+    jwtVerifyMock.mockRejectedValue(
+      new TypeError('fetch failed for jwks.internal.example'),
+    )
+    const { verifyMcpBearerToken, McpAuthError } = await import(
+      '@/lib/auth/mcp-token'
+    )
+
+    await expect(
+      verifyMcpBearerToken(
+        new Request('http://x/', {
+          headers: { authorization: 'Bearer secret.jwks.token' },
+        }),
+      ),
+    ).rejects.toSatisfy(
+      error =>
+        error instanceof McpAuthError &&
+        error.status === 503 &&
+        error.message === 'Authentication service unavailable.' &&
+        error.reason === 'jwks_unavailable' &&
+        !JSON.stringify(error).includes('jwks.internal.example'),
+    )
+  })
+
+  it('contains authentication configuration failures behind a stable contract', async () => {
+    getAuthConfigMock.mockImplementation(() => {
+      throw new Error('AUTH_ISSUER_URL exposes https://private.issuer')
+    })
+    const { verifyMcpBearerToken, McpAuthError } = await import(
+      '@/lib/auth/mcp-token'
+    )
+
+    await expect(
+      verifyMcpBearerToken(
+        new Request('http://x/', {
+          headers: { authorization: 'Bearer secret.config.token' },
+        }),
+      ),
+    ).rejects.toSatisfy(
+      error =>
+        error instanceof McpAuthError &&
+        error.status === 500 &&
+        error.message === 'Authentication failed.' &&
+        error.reason === 'auth_configuration_invalid' &&
+        !JSON.stringify(error).includes('private.issuer'),
     )
   })
 })
@@ -565,9 +673,8 @@ describe('verifyMcpBearerToken security audit events', () => {
     expect((events[0].detail as Record<string, unknown>).reason).toBe(
       'hsa_id_missing',
     )
-    expect((events[0].actor as Record<string, unknown>).clientId).toBe(
-      'mcp-cli',
-    )
+    expect(events[0].actor).toEqual({ source: 'mcp' })
+    expect(JSON.stringify(events[0])).not.toContain('mcp-cli')
   })
 
   it('emits auth.token.rejected with reason=hsa_id_invalid', async () => {
@@ -587,12 +694,14 @@ describe('verifyMcpBearerToken security audit events', () => {
     ).toBe('hsa_id_invalid')
   })
 
-  it('emits auth.token.rejected with reason=jwt_verify_failed and errorName', async () => {
+  it('emits only an allowlisted reason for verifier failures', async () => {
     class JWSSignatureVerificationFailed extends Error {
       override name = 'JWSSignatureVerificationFailed'
     }
     jwtVerifyMock.mockRejectedValue(
-      new JWSSignatureVerificationFailed('bad sig'),
+      new JWSSignatureVerificationFailed(
+        'bad sig for SE5560000001-private and issuer.internal',
+      ),
     )
     const { verifyMcpBearerToken } = await import('@/lib/auth/mcp-token')
     await expect(
@@ -605,10 +714,10 @@ describe('verifyMcpBearerToken security audit events', () => {
     const events = emittedSecurityEvents()
     expect(events).toHaveLength(1)
     expect(events[0].event).toBe('auth.token.rejected')
-    expect(events[0].detail).toEqual({
-      reason: 'jwt_verify_failed',
-      errorName: 'JWSSignatureVerificationFailed',
-    })
+    expect(events[0].detail).toEqual({ reason: 'token_verification_failed' })
+    expect(JSON.stringify(events)).not.toMatch(
+      /SE5560000001-private|issuer\.internal|JWSSignatureVerificationFailed|bad sig|nope/,
+    )
   })
 
   it('emits auth.mcp.token.accepted on a successful verification', async () => {

--- a/tests/unit/mcp-token.test.ts
+++ b/tests/unit/mcp-token.test.ts
@@ -514,7 +514,8 @@ describe('verifyMcpBearerToken', () => {
         error.status === 503 &&
         error.message === 'Authentication service unavailable.' &&
         error.reason === 'oidc_discovery_failed' &&
-        !JSON.stringify(error).includes('private.issuer'),
+        !error.message.includes('private.issuer') &&
+        !(error.stack ?? '').includes('private.issuer'),
     )
   })
 
@@ -542,7 +543,42 @@ describe('verifyMcpBearerToken', () => {
         error.status === 503 &&
         error.message === 'Authentication service unavailable.' &&
         error.reason === 'jwks_unavailable' &&
-        !JSON.stringify(error).includes('jwks.internal.example'),
+        !error.message.includes('jwks.internal.example') &&
+        !(error.stack ?? '').includes('jwks.internal.example'),
+    )
+  })
+
+  it('keeps unrelated payload TypeErrors classified as token verification failures', async () => {
+    getAuthConfigMock.mockReturnValue({
+      issuerUrl: 'https://issuer.example.com',
+      apiAudience: 'kravhantering-app',
+    })
+    const payload = {
+      sub: 'svc-account',
+      employeeHsaId: 'SE5560000001-mcp1',
+    }
+    Object.defineProperty(payload, 'roles', {
+      get: () => {
+        throw new TypeError('unrelated payload extraction failure')
+      },
+    })
+    jwtVerifyMock.mockResolvedValue({ payload })
+    const { verifyMcpBearerToken, McpAuthError } = await import(
+      '@/lib/auth/mcp-token'
+    )
+
+    await expect(
+      verifyMcpBearerToken(
+        new Request('http://x/', {
+          headers: { authorization: 'Bearer valid.jwt.token' },
+        }),
+      ),
+    ).rejects.toSatisfy(
+      error =>
+        error instanceof McpAuthError &&
+        error.status === 401 &&
+        error.message === 'Invalid Bearer token.' &&
+        error.reason === 'token_verification_failed',
     )
   })
 
@@ -566,7 +602,8 @@ describe('verifyMcpBearerToken', () => {
         error.status === 500 &&
         error.message === 'Authentication failed.' &&
         error.reason === 'auth_configuration_invalid' &&
-        !JSON.stringify(error).includes('private.issuer'),
+        !error.message.includes('private.issuer') &&
+        !(error.stack ?? '').includes('private.issuer'),
     )
   })
 })

--- a/tests/unit/specifications-page.test.tsx
+++ b/tests/unit/specifications-page.test.tsx
@@ -81,11 +81,15 @@ describe('specifications pages', () => {
     const metadata = await generateMetadata()
     expect(metadata.title).toBe('specifications')
 
-    render(await RequirementsSpecificationsPage())
+    render(
+      await RequirementsSpecificationsPage({
+        params: Promise.resolve({ locale: 'en' }),
+      }),
+    )
     expect(
       screen.getByText('RequirementsSpecificationsClient mounted: 1'),
     ).toBeInTheDocument()
-    expect(loadRequirementsSpecificationsInitialData).toHaveBeenCalledWith()
+    expect(loadRequirementsSpecificationsInitialData).toHaveBeenCalledWith('en')
   })
 
   it('RequirementsSpecificationDetailPage passes the numeric id to RequirementsSpecificationDetailClient', async () => {

--- a/tests/unit/specifications-preload.test.ts
+++ b/tests/unit/specifications-preload.test.ts
@@ -26,6 +26,18 @@ const mocks = vi.hoisted(() => ({
   recordAuthorizationDenied: vi.fn(),
 }))
 
+vi.mock('next-intl/server', () => ({
+  getTranslations: vi.fn(
+    async ({ locale }: { locale: 'en' | 'sv'; namespace: string }) =>
+      (key: string) => {
+        if (key !== 'partialDataLoadWarning') return key
+        return locale === 'sv'
+          ? 'Vissa underlagsdata kunde inte läsas in. Befintliga data visas fortfarande där de finns.'
+          : 'Some specification data could not be loaded. Existing data is still shown where available.'
+      },
+  ),
+}))
+
 vi.mock('@/lib/db', () => ({
   getRequestSqlServerDataSource: mocks.getRequestSqlServerDataSource,
 }))
@@ -274,18 +286,40 @@ describe('specifications preload', () => {
   })
 
   it('returns a not-found preload shell when specification lookup fails', async () => {
-    mocks.getSpecificationById.mockRejectedValueOnce('database unavailable')
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    mocks.getSpecificationById.mockRejectedValueOnce(
+      new Error(
+        'SELECT client_secret FROM auth_configuration for NO5560000001-owner',
+      ),
+    )
 
-    const data = await loadRequirementsSpecificationDetailInitialData({
-      locale: 'sv',
-      specificationId: 404,
-    })
+    try {
+      const data = await loadRequirementsSpecificationDetailInitialData({
+        locale: 'sv',
+        specificationId: 404,
+      })
 
-    expect(data.notFound).toBe(true)
-    expect(data.spec).toBeNull()
-    expect(data.errors).toEqual([
-      { key: 'specification', message: 'database unavailable' },
-    ])
+      expect(data.notFound).toBe(true)
+      expect(data.spec).toBeNull()
+      expect(data.errors).toEqual([
+        {
+          key: 'specification',
+          message:
+            'Vissa underlagsdata kunde inte läsas in. Befintliga data visas fortfarande där de finns.',
+        },
+      ])
+      const serializedData = JSON.stringify(data)
+      expect(serializedData).not.toMatch(
+        /SELECT|client_secret|auth_configuration|NO5560000001-owner/,
+      )
+      expect(JSON.stringify(consoleErrorSpy.mock.calls)).not.toMatch(
+        /SELECT client_secret|NO5560000001-owner/,
+      )
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
   })
 
   it('returns assignment guidance and audits a forbidden preload', async () => {
@@ -339,30 +373,38 @@ describe('specifications preload', () => {
       name: 'Specification',
       responsibleHsaId: 'SE5560000001-owner',
     })
-    mocks.getAiGenerationAvailability.mockRejectedValueOnce(new Error('ai'))
-    mocks.listAreas.mockRejectedValueOnce(new Error('areas'))
-    mocks.listRequirementPackages.mockRejectedValueOnce(new Error('packages'))
+    mocks.getAiGenerationAvailability.mockRejectedValueOnce(
+      new Error('raw-ai-failure'),
+    )
+    mocks.listAreas.mockRejectedValueOnce(new Error('raw-areas-failure'))
+    mocks.listRequirementPackages.mockRejectedValueOnce(
+      new Error('raw-packages-failure'),
+    )
     mocks.listSpecificationNeedsReferences.mockRejectedValueOnce(
-      new Error('needs'),
+      new Error('raw-needs-failure'),
     )
     mocks.listSpecificationGovernanceObjectTypes.mockRejectedValueOnce(
-      new Error('governance'),
+      new Error('raw-governance-failure'),
     )
     mocks.listSpecificationImplementationTypes.mockRejectedValueOnce(
-      new Error('implementation'),
+      new Error('raw-implementation-failure'),
     )
     mocks.listSpecificationLifecycleStatuses.mockRejectedValueOnce(
-      new Error('lifecycle'),
+      new Error('raw-lifecycle-failure'),
     )
     mocks.listSpecificationItemStatuses.mockRejectedValueOnce(
-      new Error('statuses'),
+      new Error('raw-statuses-failure'),
     )
-    mocks.getSpecificationItems.mockRejectedValueOnce(new Error('items'))
-    mocks.queryRequirementList.mockRejectedValueOnce(new Error('available'))
+    mocks.getSpecificationItems.mockRejectedValueOnce(
+      new Error('raw-items-failure'),
+    )
+    mocks.queryRequirementList.mockRejectedValueOnce(
+      new Error('raw-available-failure'),
+    )
     mocks.querySpecificationRequirementPackagePage.mockRejectedValueOnce(
-      new Error('package catalog'),
+      new Error('raw-package-catalog-failure'),
     )
-    mocks.listNormReferences.mockRejectedValue(new Error('norms'))
+    mocks.listNormReferences.mockRejectedValue(new Error('raw-norms-failure'))
 
     const data = await loadRequirementsSpecificationDetailInitialData({
       locale: 'en',
@@ -370,28 +412,20 @@ describe('specifications preload', () => {
     })
 
     expect(data.spec?.id).toBe(42)
-    expect(data.errors.map(error => error.message)).toEqual(
-      expect.arrayContaining([
-        'ai',
-        'areas',
-        'packages',
-        'needs',
-        'governance',
-        'implementation',
-        'lifecycle',
-        'statuses',
-        'items',
-        'available',
-        'package catalog',
-        'norms',
+    expect(new Set(data.errors.map(error => error.message))).toEqual(
+      new Set([
+        'Some specification data could not be loaded. Existing data is still shown where available.',
       ]),
+    )
+    expect(JSON.stringify(data)).not.toMatch(
+      /raw-(?:ai|areas|packages|needs|governance|implementation|lifecycle|statuses|items|available|package-catalog|norms)-failure/,
     )
     expect(data.availableRequirements.rows).toEqual([])
     expect(data.specificationItems.items).toEqual([])
   })
 
   it('preloads the visible specification catalog with row permissions', async () => {
-    const data = await loadRequirementsSpecificationsInitialData()
+    const data = await loadRequirementsSpecificationsInitialData('en')
 
     expect(data.collectionPermissions?.canCreateSpecification).toBe(true)
     expect(data.specifications).toEqual([
@@ -423,17 +457,19 @@ describe('specifications preload', () => {
       new Error('lifecycle'),
     )
 
-    const data = await loadRequirementsSpecificationsInitialData()
+    const data = await loadRequirementsSpecificationsInitialData('en')
 
     expect(data.specifications).toEqual([])
     expect(data.governanceObjectTypes).toEqual([])
     expect(data.implementationTypes).toEqual([])
     expect(data.lifecycleStatuses).toEqual([])
-    expect(data.errors.map(error => error.message)).toEqual([
-      'specifications',
-      'governance',
-      'implementation',
-      'lifecycle',
-    ])
+    expect(data.errors.map(error => error.message)).toEqual(
+      Array(4).fill(
+        'Some specification data could not be loaded. Existing data is still shown where available.',
+      ),
+    )
+    expect(JSON.stringify(data)).not.toMatch(
+      /"message":"(?:specifications|governance|implementation|lifecycle)"/,
+    )
   })
 })


### PR DESCRIPTION
## Description

- Normalize MCP authentication failures into stable public JSON-RPC contracts
  and allowlisted security-log reason codes.
- Derive HSA-id redaction from the canonical validator so valid international
  identifiers are covered.
- Keep raw specification preload failures out of serialized server-component
  data while retaining localized fallback messages and sanitized server logs.
- Align MCP authentication and security documentation with the new contracts.

## Related Issues

Fixes #480

## Reviewer Notes

- `npm run check` passes, including 6,523 tests and both HSA support package
  suites.
- The required two-axis review found no Spec issues. Two Standards issues were
  fixed before the final check: explicit utility typing and an updated auth
  sequence diagram.
- No Playwright/manual-case update is needed because the visible fallback and
  retry experience is unchanged; this change hardens diagnostic payloads and
  logs.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
MCP authentication failures now use stable generic responses. Invalid
credentials remain `401`; local authentication configuration failures return
`500`, and identity-provider discovery or signing-key availability failures
return `503`. All retain the Bearer challenge.

Ensure MCP clients and monitoring classify failures by HTTP status rather than
provider-specific error text. During rollout, validate identity-provider
discovery and signing-key reachability and monitor the new `500` and `503`
outcomes.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/978)
<!-- Reviewable:end -->
