### PR TITLE
docs: persist operator upgrade notes from #978

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -100,6 +100,17 @@ recovery, and retire reusable bootstrap access. Validate both the user-facing
 denials and authorized management access, and use the profile-specific backup,
 rollback, recovery, uninstall, and incident procedures during its lifecycle.
 <!-- operator-upgrade:source pr-967 end -->
+
+<!-- operator-upgrade:source pr-978 start -->
+MCP authentication failures now use stable generic responses. Invalid
+credentials remain `401`; local authentication configuration failures return
+`500`, and identity-provider discovery or signing-key availability failures
+return `503`. All retain the Bearer challenge.
+Ensure MCP clients and monitoring classify failures by HTTP status rather than
+provider-specific error text. During rollout, validate identity-provider
+discovery and signing-key reachability and monitor the new `500` and `503`
+outcomes.
+<!-- operator-upgrade:source pr-978 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #978
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/31496646702

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/979)
<!-- Reviewable:end -->
