### PR TITLE
Sanitize and bound AI-provider error handling

### DIFF
--- a/app/api/ai/credits/route.ts
+++ b/app/api/ai/credits/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server'
 import { getKeyInfo } from '@/lib/ai/openrouter-client'
 import {
-  AI_CREDIT_INFORMATION_UNAVAILABLE_MESSAGE,
-  logSanitizedError,
-} from '@/lib/http/safe-errors'
+  aiProviderErrorPayload,
+  normalizeAiProviderError,
+} from '@/lib/ai/provider-errors'
 import {
   observeCapacity,
   recordCapacityEvent,
@@ -74,16 +74,21 @@ export async function GET(request: Request) {
         slowThresholdMs: AI_CREDITS_SLOW_THRESHOLD_MS,
         source: 'rest',
       },
-      getKeyInfo,
+      () =>
+        getKeyInfo({
+          correlationId: context.correlationId,
+          requestId: context.requestId,
+        }),
     )
     return applyResponseCorrelationHeaders(NextResponse.json(info), context)
   } catch (err) {
-    logSanitizedError('Failed to get AI credit information', err)
+    const providerError = normalizeAiProviderError(err, {
+      correlationId: context.correlationId,
+      operation: 'key.info',
+      requestId: context.requestId,
+    })
     return applyResponseCorrelationHeaders(
-      NextResponse.json(
-        { error: AI_CREDIT_INFORMATION_UNAVAILABLE_MESSAGE },
-        { status: 503 },
-      ),
+      NextResponse.json(aiProviderErrorPayload(providerError), { status: 503 }),
       context,
     )
   }

--- a/app/api/ai/generate-requirement-import/route.ts
+++ b/app/api/ai/generate-requirement-import/route.ts
@@ -295,7 +295,7 @@ export const POST = secureMutationRoute({
       return createAiErrorStreamResponse(
         context,
         aiProviderStreamError(providerError),
-        () => recordStreamEvent('failure', 503),
+        statusCode => recordStreamEvent('failure', statusCode),
       )
     }
     const resolvedModel = modelCapabilities.id
@@ -329,10 +329,11 @@ export const POST = secureMutationRoute({
       return createAiErrorStreamResponse(
         context,
         aiProviderStreamError(providerError),
-        () => recordStreamEvent('failure', 503),
+        statusCode => recordStreamEvent('failure', statusCode),
       )
     }
     if (firstProviderEvent.done) {
+      recordStreamEvent('failure', 499)
       return applyResponseCorrelationHeaders(
         new Response(null, { status: 499 }),
         context,
@@ -343,12 +344,13 @@ export const POST = secureMutationRoute({
       return createAiErrorStreamResponse(
         context,
         firstProviderEvent.value,
-        () => recordStreamEvent('failure', 503),
+        statusCode => recordStreamEvent('failure', statusCode),
       )
     }
+    const firstStreamEvent: StreamEvent = firstProviderEvent.value
 
     async function* streamProviderEvents(): AsyncGenerator<StreamEvent> {
-      yield firstProviderEvent.value
+      yield firstStreamEvent
       yield* providerEvents
     }
 

--- a/app/api/ai/generate-requirement-import/route.ts
+++ b/app/api/ai/generate-requirement-import/route.ts
@@ -2,14 +2,17 @@ import { z } from 'zod'
 import {
   type GenerationStats,
   generateChatStream,
+  type StreamEvent,
 } from '@/lib/ai/openrouter-client'
 import { resolveOpenRouterModelCapabilities } from '@/lib/ai/openrouter-model-catalog'
+import {
+  aiProviderStreamError,
+  normalizeAiProviderError,
+} from '@/lib/ai/provider-errors'
 import {
   buildRequirementImportResponseFormatSchema,
   buildRequirementImportSystemPrompt,
   buildRequirementImportUserPrompt,
-  formatSchemaIssues,
-  getPromptMessage,
   parseJsonObject,
 } from '@/lib/ai/requirement-prompt'
 import {
@@ -43,6 +46,7 @@ import {
   aiRequirementImportBaseBodySchema,
   checkAiRequirementImportThrottle,
   countImageBytes,
+  createAiErrorStreamResponse,
   createAiRequirementImportThrottleResponse,
   createUnavailableAiStreamResponse,
   formatAiSafetyBlockedMessage,
@@ -145,32 +149,16 @@ function createStreamRecorder(
 
 function parseAndValidatePayload(
   rawContent: string,
-  locale: 'en' | 'sv',
-): {
-  issues?: ReturnType<typeof formatSchemaIssues>
-  payload?: ImportRequirementsPayload
-} {
+): ImportRequirementsPayload | undefined {
   let parsed: unknown
   try {
     parsed = parseJsonObject(rawContent)
   } catch {
-    return {
-      issues: [
-        {
-          code: 'invalid_json',
-          message: getPromptMessage(locale, ['ai', 'invalidGeneratedJson']),
-          path: '$',
-        },
-      ],
-    }
+    return undefined
   }
 
   const validation = requirementsImportPayloadSchema.safeParse(parsed)
-  if (!validation.success) {
-    return { issues: formatSchemaIssues(validation.error) }
-  }
-
-  return { payload: validation.data }
+  return validation.success ? validation.data : undefined
 }
 
 function imageMetadataForSafety(
@@ -290,6 +278,80 @@ export const POST = secureMutationRoute({
     })
     const userContent = withImages(userPrompt, images)
 
+    let modelCapabilities: Awaited<
+      ReturnType<typeof resolveOpenRouterModelCapabilities>
+    >
+    try {
+      modelCapabilities = await resolveOpenRouterModelCapabilities(body.model, {
+        correlationId: context.correlationId,
+        requestId: context.requestId,
+      })
+    } catch (error) {
+      const providerError = normalizeAiProviderError(error, {
+        correlationId: context.correlationId,
+        operation: 'models.list',
+        requestId: context.requestId,
+      })
+      return createAiErrorStreamResponse(
+        context,
+        aiProviderStreamError(providerError),
+        () => recordStreamEvent('failure', 503),
+      )
+    }
+    const resolvedModel = modelCapabilities.id
+    const providerEvents = generateChatStream({
+      format: buildRequirementImportResponseFormatSchema(locale),
+      messages: [
+        { content: systemPrompt, role: 'system' },
+        { content: userContent, role: 'user' },
+      ],
+      model: resolvedModel,
+      correlationId: context.correlationId,
+      providerPreferences: body.providerPreferences,
+      reasoningEffort:
+        typeof body.reasoningEffort === 'string'
+          ? body.reasoningEffort
+          : undefined,
+      requestId: context.requestId,
+      signal: request.signal,
+      supportedParameters: modelCapabilities.supportedParameters,
+    })
+    let firstProviderEvent: IteratorResult<StreamEvent>
+    try {
+      firstProviderEvent = await providerEvents.next()
+    } catch (error) {
+      const providerError = normalizeAiProviderError(error, {
+        correlationId: context.correlationId,
+        modelProvider: modelCapabilities.provider,
+        operation: 'chat.completions',
+        requestId: context.requestId,
+      })
+      return createAiErrorStreamResponse(
+        context,
+        aiProviderStreamError(providerError),
+        () => recordStreamEvent('failure', 503),
+      )
+    }
+    if (firstProviderEvent.done) {
+      return applyResponseCorrelationHeaders(
+        new Response(null, { status: 499 }),
+        context,
+      )
+    }
+    if (firstProviderEvent.value.phase === 'error') {
+      await providerEvents.return(undefined)
+      return createAiErrorStreamResponse(
+        context,
+        firstProviderEvent.value,
+        () => recordStreamEvent('failure', 503),
+      )
+    }
+
+    async function* streamProviderEvents(): AsyncGenerator<StreamEvent> {
+      yield firstProviderEvent.value
+      yield* providerEvents
+    }
+
     const stream = new ReadableStream({
       async start(controller) {
         const encoder = new TextEncoder()
@@ -303,27 +365,10 @@ export const POST = secureMutationRoute({
         }
 
         try {
-          const modelCapabilities = await resolveOpenRouterModelCapabilities(
-            body.model,
-          )
-          const resolvedModel = modelCapabilities.id
           let sentGeneratingProgress = false
           let screenedThinkingLength = 0
-          for await (const event of generateChatStream({
-            format: buildRequirementImportResponseFormatSchema(locale),
-            messages: [
-              { content: systemPrompt, role: 'system' },
-              { content: userContent, role: 'user' },
-            ],
-            model: resolvedModel,
-            providerPreferences: body.providerPreferences,
-            reasoningEffort:
-              typeof body.reasoningEffort === 'string'
-                ? body.reasoningEffort
-                : undefined,
-            signal: request.signal,
-            supportedParameters: modelCapabilities.supportedParameters,
-          })) {
+          let latestThinking = ''
+          for await (const event of streamProviderEvents()) {
             switch (event.phase) {
               case 'thinking': {
                 let progressSafetyScreening: Awaited<
@@ -348,7 +393,10 @@ export const POST = secureMutationRoute({
                   ])
                 } catch (error) {
                   recordSafetyFilterFailure(error)
-                  send('error', { message: AI_PROVIDER_UNAVAILABLE_MESSAGE })
+                  send('error', {
+                    code: 'ai_provider_unavailable',
+                    message: AI_PROVIDER_UNAVAILABLE_MESSAGE,
+                  })
                   recordStreamEvent('failure', 503)
                   return
                 }
@@ -377,7 +425,7 @@ export const POST = secureMutationRoute({
                   return
                 }
                 screenedThinkingLength = thinkingText.length
-                send('thinking', { thinkingSoFar: event.thinkingSoFar })
+                latestThinking = thinkingText
                 break
               }
               case 'generating':
@@ -387,17 +435,21 @@ export const POST = secureMutationRoute({
                 }
                 break
               case 'done': {
+                const safeThinking = event.thinking || latestThinking
                 let outputSafetyScreening: Awaited<
                   ReturnType<typeof screenAiOutputDetailed>
                 >
                 try {
                   outputSafetyScreening = await screenAiOutputDetailed(db, [
                     { label: 'rawContent', text: event.rawContent },
-                    { label: 'thinking', text: event.thinking },
+                    { label: 'thinking', text: safeThinking },
                   ])
                 } catch (error) {
                   recordSafetyFilterFailure(error)
-                  send('error', { message: AI_PROVIDER_UNAVAILABLE_MESSAGE })
+                  send('error', {
+                    code: 'ai_provider_unavailable',
+                    message: AI_PROVIDER_UNAVAILABLE_MESSAGE,
+                  })
                   recordStreamEvent('failure', 503, event.stats)
                   return
                 }
@@ -427,61 +479,55 @@ export const POST = secureMutationRoute({
                   return
                 }
 
-                const validation = parseAndValidatePayload(
-                  event.rawContent,
-                  body.locale,
-                )
-                if (!validation.payload) {
-                  logSanitizedError(
-                    'AI requirement import output validation failed',
-                    new Error('Generated import JSON failed validation'),
-                    {
-                      issueCount: validation.issues?.length ?? 0,
-                      issues: validation.issues?.map(issue => ({
-                        code: issue.code,
-                        path: issue.path,
-                      })),
-                    },
-                  )
-                  send('validation_error', {
-                    issues: validation.issues ?? [],
-                    message: getPromptMessage(body.locale, [
-                      'ai',
-                      'generatedJsonSchemaMismatch',
-                    ]),
-                    model: resolvedModel,
-                    rawContent: event.rawContent,
-                    stats: event.stats,
-                    thinking: event.thinking,
+                const payload = parseAndValidatePayload(event.rawContent)
+                if (!payload) {
+                  const providerError = normalizeAiProviderError(null, {
+                    code: 'ai_provider_invalid_response',
+                    correlationId: context.correlationId,
+                    modelProvider: modelCapabilities.provider,
+                    operation: 'chat.completions',
+                    requestId: context.requestId,
                   })
-                  recordStreamEvent('failure', 422, event.stats)
+                  const streamError = aiProviderStreamError(providerError)
+                  send('error', {
+                    code: streamError.code,
+                    message: streamError.message,
+                  })
+                  recordStreamEvent('failure', 503, event.stats)
                   return
                 }
 
-                const rawContent = JSON.stringify(validation.payload)
+                const rawContent = JSON.stringify(payload)
+                if (safeThinking) {
+                  send('thinking', { thinkingSoFar: safeThinking })
+                }
                 send('done', {
                   model: resolvedModel,
-                  payload: validation.payload,
+                  payload,
                   rawContent,
                   stats: event.stats,
-                  thinking: event.thinking,
+                  thinking: safeThinking,
                 })
                 recordStreamEvent('success', 200, event.stats)
                 return
               }
               case 'error':
-                logSanitizedError(
-                  'AI requirement import stream failed',
-                  event.cause ?? event.message,
-                )
-                send('error', { message: AI_PROVIDER_UNAVAILABLE_MESSAGE })
+                send('error', { code: event.code, message: event.message })
                 recordStreamEvent('failure', 503)
                 return
             }
           }
         } catch (error) {
-          logSanitizedError('AI requirement import generation failed', error)
-          send('error', { message: AI_PROVIDER_UNAVAILABLE_MESSAGE })
+          const providerError = normalizeAiProviderError(error, {
+            correlationId: context.correlationId,
+            operation: 'chat.completions',
+            requestId: context.requestId,
+          })
+          const streamError = aiProviderStreamError(providerError)
+          send('error', {
+            code: streamError.code,
+            message: streamError.message,
+          })
           recordStreamEvent('failure', 503)
         } finally {
           controller.close()

--- a/app/api/ai/models/route.ts
+++ b/app/api/ai/models/route.ts
@@ -3,9 +3,9 @@ import { z } from 'zod'
 import type { OpenRouterModel } from '@/lib/ai/openrouter-client'
 import { listOpenRouterModelCatalog } from '@/lib/ai/openrouter-model-catalog'
 import {
-  AI_PROVIDER_UNAVAILABLE_MESSAGE,
-  logSanitizedError,
-} from '@/lib/http/safe-errors'
+  aiProviderErrorPayload,
+  normalizeAiProviderError,
+} from '@/lib/ai/provider-errors'
 import {
   ARRAY_INPUT_MAX_ITEMS,
   boundedDbStringSchema,
@@ -215,6 +215,10 @@ export async function GET(request: NextRequest) {
       },
       async () =>
         listOpenRouterModelCatalog({
+          requestContext: {
+            correlationId: context.correlationId,
+            requestId: context.requestId,
+          },
           supportedParameters: paramList,
         }),
     )
@@ -224,12 +228,13 @@ export async function GET(request: NextRequest) {
       context,
     )
   } catch (err) {
-    logSanitizedError('Failed to list AI models', err)
+    const providerError = normalizeAiProviderError(err, {
+      correlationId: context.correlationId,
+      operation: 'models.list',
+      requestId: context.requestId,
+    })
     return applyResponseCorrelationHeaders(
-      NextResponse.json(
-        { error: AI_PROVIDER_UNAVAILABLE_MESSAGE, models: [] },
-        { status: 503 },
-      ),
+      NextResponse.json(aiProviderErrorPayload(providerError), { status: 503 }),
       context,
     )
   }

--- a/app/api/ai/repair-requirement-import-json/route.ts
+++ b/app/api/ai/repair-requirement-import-json/route.ts
@@ -191,30 +191,67 @@ export const POST = secureMutationRoute({
     })
     if (inputGuardResponse) return inputGuardResponse
 
+    let modelCapabilities: Awaited<
+      ReturnType<typeof resolveOpenRouterModelCapabilities>
+    >
     try {
-      const modelCapabilities = await resolveOpenRouterModelCapabilities(
-        body.model,
-        {
-          correlationId: context.correlationId,
-          requestId: context.requestId,
-        },
+      modelCapabilities = await resolveOpenRouterModelCapabilities(body.model, {
+        correlationId: context.correlationId,
+        requestId: context.requestId,
+      })
+    } catch (error) {
+      const providerError = normalizeAiProviderError(error, {
+        correlationId: context.correlationId,
+        operation: 'models.list',
+        requestId: context.requestId,
+      })
+      recordRepairEvent('failure', 503)
+      return applyResponseCorrelationHeaders(
+        Response.json(aiProviderErrorPayload(providerError), { status: 503 }),
+        context,
       )
-      const importInstruction = await createRequirementsRuntime(
+    }
+
+    let importInstruction: string
+    try {
+      importInstruction = await createRequirementsRuntime(
         db,
       ).service.buildImportInstruction(
         body.locale,
         requirementImportDestination(body),
       )
-      const systemPrompt = buildRequirementImportSystemPrompt(
-        importInstruction,
-        body.locale,
+    } catch (error) {
+      logSanitizedError(
+        'AI requirement import repair instruction loading failed',
+        error,
       )
-      const repairPrompt = buildRequirementImportRepairPrompt({
-        brokenJson: body.rawJson,
-        errors: body.errors,
-        locale: body.locale,
-      })
-      const result = await generateChat<ImportRequirementsPayload>({
+      recordRepairEvent('failure', 503)
+      return applyResponseCorrelationHeaders(
+        Response.json(
+          {
+            code: 'ai_provider_unavailable',
+            error: AI_PROVIDER_UNAVAILABLE_MESSAGE,
+          },
+          { status: 503 },
+        ),
+        context,
+      )
+    }
+
+    const systemPrompt = buildRequirementImportSystemPrompt(
+      importInstruction,
+      body.locale,
+    )
+    const repairPrompt = buildRequirementImportRepairPrompt({
+      brokenJson: body.rawJson,
+      errors: body.errors,
+      locale: body.locale,
+    })
+    let result: Awaited<
+      ReturnType<typeof generateChat<ImportRequirementsPayload>>
+    >
+    try {
+      result = await generateChat<ImportRequirementsPayload>({
         format: buildRequirementImportResponseFormatSchema(body.locale),
         messages: [
           { content: systemPrompt, role: 'system' },
@@ -231,87 +268,9 @@ export const POST = secureMutationRoute({
         signal: request.signal,
         supportedParameters: modelCapabilities.supportedParameters,
       })
-      let outputSafetyScreening: Awaited<
-        ReturnType<typeof screenAiOutputDetailed>
-      >
-      try {
-        outputSafetyScreening = await screenAiOutputDetailed(db, [
-          { label: 'rawContent', text: JSON.stringify(result.content) },
-          { label: 'thinking', text: result.thinking },
-        ])
-      } catch (error) {
-        recordSafetyFilterFailure(error)
-        recordRepairEvent('failure', 503, result.stats)
-        return applyResponseCorrelationHeaders(
-          Response.json(
-            {
-              code: 'ai_provider_unavailable',
-              error: AI_PROVIDER_UNAVAILABLE_MESSAGE,
-            },
-            { status: 503 },
-          ),
-          context,
-        )
-      }
-      if (!outputSafetyScreening.decision.allowed) {
-        await recordAiSafetyBlock({
-          blockedStep: 'repaired_model_output',
-          context,
-          db,
-          direction: 'output',
-          event: 'ai.output_safety.blocked',
-          model: modelCapabilities.id,
-          operation: AI_REPAIR_REQUIREMENT_IMPORT_OPERATION,
-          provider: modelCapabilities.provider,
-          request,
-          screening: outputSafetyScreening,
-        })
-        recordRepairEvent('failure', 422, result.stats)
-        return applyResponseCorrelationHeaders(
-          Response.json(
-            {
-              error: formatAiSafetyBlockedMessage(
-                body.locale,
-                'outputSafetyBlocked',
-                outputSafetyScreening.decision,
-              ),
-            },
-            { status: 422 },
-          ),
-          context,
-        )
-      }
-      const validation = requirementsImportPayloadSchema.safeParse(
-        result.content,
-      )
-      if (!validation.success) {
-        const providerError = normalizeAiProviderError(null, {
-          code: 'ai_provider_invalid_response',
-          correlationId: context.correlationId,
-          modelProvider: modelCapabilities.provider,
-          operation: 'chat.completions',
-          requestId: context.requestId,
-        })
-        recordRepairEvent('failure', 503, result.stats)
-        return applyResponseCorrelationHeaders(
-          Response.json(aiProviderErrorPayload(providerError), { status: 503 }),
-          context,
-        )
-      }
-
-      recordRepairEvent('success', 200, result.stats)
-      return applyResponseCorrelationHeaders(
-        Response.json({
-          model: modelCapabilities.id,
-          payload: validation.data,
-          rawContent: JSON.stringify(validation.data),
-          stats: result.stats,
-          thinking: result.thinking,
-        }),
-        context,
-      )
     } catch (error) {
       if (isAiProviderCallerCancelledError(error)) {
+        recordRepairEvent('failure', 499)
         return applyResponseCorrelationHeaders(
           new Response(null, { status: 499 }),
           context,
@@ -328,5 +287,83 @@ export const POST = secureMutationRoute({
         context,
       )
     }
+
+    let outputSafetyScreening: Awaited<
+      ReturnType<typeof screenAiOutputDetailed>
+    >
+    try {
+      outputSafetyScreening = await screenAiOutputDetailed(db, [
+        { label: 'rawContent', text: JSON.stringify(result.content) },
+        { label: 'thinking', text: result.thinking },
+      ])
+    } catch (error) {
+      recordSafetyFilterFailure(error)
+      recordRepairEvent('failure', 503, result.stats)
+      return applyResponseCorrelationHeaders(
+        Response.json(
+          {
+            code: 'ai_provider_unavailable',
+            error: AI_PROVIDER_UNAVAILABLE_MESSAGE,
+          },
+          { status: 503 },
+        ),
+        context,
+      )
+    }
+    if (!outputSafetyScreening.decision.allowed) {
+      await recordAiSafetyBlock({
+        blockedStep: 'repaired_model_output',
+        context,
+        db,
+        direction: 'output',
+        event: 'ai.output_safety.blocked',
+        model: modelCapabilities.id,
+        operation: AI_REPAIR_REQUIREMENT_IMPORT_OPERATION,
+        provider: modelCapabilities.provider,
+        request,
+        screening: outputSafetyScreening,
+      })
+      recordRepairEvent('failure', 422, result.stats)
+      return applyResponseCorrelationHeaders(
+        Response.json(
+          {
+            error: formatAiSafetyBlockedMessage(
+              body.locale,
+              'outputSafetyBlocked',
+              outputSafetyScreening.decision,
+            ),
+          },
+          { status: 422 },
+        ),
+        context,
+      )
+    }
+    const validation = requirementsImportPayloadSchema.safeParse(result.content)
+    if (!validation.success) {
+      const providerError = normalizeAiProviderError(null, {
+        code: 'ai_provider_invalid_response',
+        correlationId: context.correlationId,
+        modelProvider: modelCapabilities.provider,
+        operation: 'chat.completions',
+        requestId: context.requestId,
+      })
+      recordRepairEvent('failure', 503, result.stats)
+      return applyResponseCorrelationHeaders(
+        Response.json(aiProviderErrorPayload(providerError), { status: 503 }),
+        context,
+      )
+    }
+
+    recordRepairEvent('success', 200, result.stats)
+    return applyResponseCorrelationHeaders(
+      Response.json({
+        model: modelCapabilities.id,
+        payload: validation.data,
+        rawContent: JSON.stringify(validation.data),
+        stats: result.stats,
+        thinking: result.thinking,
+      }),
+      context,
+    )
   },
 })

--- a/app/api/ai/repair-requirement-import-json/route.ts
+++ b/app/api/ai/repair-requirement-import-json/route.ts
@@ -2,11 +2,14 @@ import { z } from 'zod'
 import { generateChat } from '@/lib/ai/openrouter-client'
 import { resolveOpenRouterModelCapabilities } from '@/lib/ai/openrouter-model-catalog'
 import {
+  aiProviderErrorPayload,
+  isAiProviderCallerCancelledError,
+  normalizeAiProviderError,
+} from '@/lib/ai/provider-errors'
+import {
   buildRequirementImportRepairPrompt,
   buildRequirementImportResponseFormatSchema,
   buildRequirementImportSystemPrompt,
-  formatSchemaIssues,
-  getPromptMessage,
 } from '@/lib/ai/requirement-prompt'
 import {
   recordAiSafetyBlock,
@@ -129,7 +132,10 @@ export const POST = secureMutationRoute({
         recordRepairEvent('failure', 503)
         return applyResponseCorrelationHeaders(
           Response.json(
-            { error: AI_PROVIDER_UNAVAILABLE_MESSAGE },
+            {
+              code: 'ai_provider_unavailable',
+              error: AI_PROVIDER_UNAVAILABLE_MESSAGE,
+            },
             { status: 503 },
           ),
           context,
@@ -143,7 +149,10 @@ export const POST = secureMutationRoute({
       recordRepairEvent('failure', 503)
       return applyResponseCorrelationHeaders(
         Response.json(
-          { error: AI_PROVIDER_UNAVAILABLE_MESSAGE },
+          {
+            code: 'ai_provider_unavailable',
+            error: AI_PROVIDER_UNAVAILABLE_MESSAGE,
+          },
           { status: 503 },
         ),
         context,
@@ -161,7 +170,10 @@ export const POST = secureMutationRoute({
         recordRepairEvent('failure', 503)
         return applyResponseCorrelationHeaders(
           Response.json(
-            { error: AI_PROVIDER_UNAVAILABLE_MESSAGE },
+            {
+              code: 'ai_provider_unavailable',
+              error: AI_PROVIDER_UNAVAILABLE_MESSAGE,
+            },
             { status: 503 },
           ),
           context,
@@ -182,6 +194,10 @@ export const POST = secureMutationRoute({
     try {
       const modelCapabilities = await resolveOpenRouterModelCapabilities(
         body.model,
+        {
+          correlationId: context.correlationId,
+          requestId: context.requestId,
+        },
       )
       const importInstruction = await createRequirementsRuntime(
         db,
@@ -205,11 +221,13 @@ export const POST = secureMutationRoute({
           { content: repairPrompt, role: 'user' },
         ],
         model: modelCapabilities.id,
+        correlationId: context.correlationId,
         providerPreferences: body.providerPreferences,
         reasoningEffort:
           typeof body.reasoningEffort === 'string'
             ? body.reasoningEffort
             : undefined,
+        requestId: context.requestId,
         signal: request.signal,
         supportedParameters: modelCapabilities.supportedParameters,
       })
@@ -226,7 +244,10 @@ export const POST = secureMutationRoute({
         recordRepairEvent('failure', 503, result.stats)
         return applyResponseCorrelationHeaders(
           Response.json(
-            { error: AI_PROVIDER_UNAVAILABLE_MESSAGE },
+            {
+              code: 'ai_provider_unavailable',
+              error: AI_PROVIDER_UNAVAILABLE_MESSAGE,
+            },
             { status: 503 },
           ),
           context,
@@ -264,30 +285,16 @@ export const POST = secureMutationRoute({
         result.content,
       )
       if (!validation.success) {
-        const issues = formatSchemaIssues(validation.error)
-        logSanitizedError(
-          'AI requirement import repair validation failed',
-          new Error('Repaired import JSON failed validation'),
-          {
-            issueCount: issues.length,
-            issues: issues.map(issue => ({
-              code: issue.code,
-              path: issue.path,
-            })),
-          },
-        )
-        recordRepairEvent('failure', 422, result.stats)
+        const providerError = normalizeAiProviderError(null, {
+          code: 'ai_provider_invalid_response',
+          correlationId: context.correlationId,
+          modelProvider: modelCapabilities.provider,
+          operation: 'chat.completions',
+          requestId: context.requestId,
+        })
+        recordRepairEvent('failure', 503, result.stats)
         return applyResponseCorrelationHeaders(
-          Response.json(
-            {
-              error: getPromptMessage(body.locale, [
-                'ai',
-                'repairedJsonSchemaMismatch',
-              ]),
-              issues,
-            },
-            { status: 422 },
-          ),
+          Response.json(aiProviderErrorPayload(providerError), { status: 503 }),
           context,
         )
       }
@@ -304,13 +311,20 @@ export const POST = secureMutationRoute({
         context,
       )
     } catch (error) {
-      logSanitizedError('AI requirement import repair failed', error)
+      if (isAiProviderCallerCancelledError(error)) {
+        return applyResponseCorrelationHeaders(
+          new Response(null, { status: 499 }),
+          context,
+        )
+      }
+      const providerError = normalizeAiProviderError(error, {
+        correlationId: context.correlationId,
+        operation: 'chat.completions',
+        requestId: context.requestId,
+      })
       recordRepairEvent('failure', 503)
       return applyResponseCorrelationHeaders(
-        Response.json(
-          { error: AI_PROVIDER_UNAVAILABLE_MESSAGE },
-          { status: 503 },
-        ),
+        Response.json(aiProviderErrorPayload(providerError), { status: 503 }),
         context,
       )
     }

--- a/app/api/ai/requirement-import-shared.ts
+++ b/app/api/ai/requirement-import-shared.ts
@@ -369,15 +369,16 @@ export function createUnavailableAiStreamResponse(
 export function createAiErrorStreamResponse(
   context: RequestCorrelationIds,
   error: { code: AiProviderErrorCode; message: string },
-  recordFailure: () => void,
+  recordFailure: (statusCode: number) => void,
 ) {
+  const statusCode = error.code === 'ai_provider_rate_limited' ? 429 : 503
   const stream = new ReadableStream({
     start(controller) {
       const encoder = new TextEncoder()
       controller.enqueue(
         encoder.encode(`event: error\ndata: ${JSON.stringify(error)}\n\n`),
       )
-      recordFailure()
+      recordFailure(statusCode)
       controller.close()
     },
   })
@@ -388,7 +389,7 @@ export function createAiErrorStreamResponse(
         Connection: 'keep-alive',
         'Content-Type': 'text/event-stream',
       },
-      status: 503,
+      status: statusCode,
     }),
     context,
   )

--- a/app/api/ai/requirement-import-shared.ts
+++ b/app/api/ai/requirement-import-shared.ts
@@ -1,5 +1,6 @@
 import { type RefinementCtx, z } from 'zod'
 import type { ContentPart } from '@/lib/ai/openrouter-client'
+import type { AiProviderErrorCode } from '@/lib/ai/provider-errors'
 import {
   DEFAULT_REQUIREMENT_CANDIDATE_COUNT,
   getPromptMessage,
@@ -355,15 +356,26 @@ export function createUnavailableAiStreamResponse(
   context: RequestCorrelationIds,
   recordFailure: () => void,
 ) {
+  return createAiErrorStreamResponse(
+    context,
+    {
+      code: 'ai_provider_unavailable',
+      message: AI_PROVIDER_UNAVAILABLE_MESSAGE,
+    },
+    recordFailure,
+  )
+}
+
+export function createAiErrorStreamResponse(
+  context: RequestCorrelationIds,
+  error: { code: AiProviderErrorCode; message: string },
+  recordFailure: () => void,
+) {
   const stream = new ReadableStream({
     start(controller) {
       const encoder = new TextEncoder()
       controller.enqueue(
-        encoder.encode(
-          `event: error\ndata: ${JSON.stringify({
-            message: AI_PROVIDER_UNAVAILABLE_MESSAGE,
-          })}\n\n`,
-        ),
+        encoder.encode(`event: error\ndata: ${JSON.stringify(error)}\n\n`),
       )
       recordFailure()
       controller.close()

--- a/docs/development/ai-assisted-authoring-developer-workflow.md
+++ b/docs/development/ai-assisted-authoring-developer-workflow.md
@@ -66,6 +66,37 @@ Do not add production OpenRouter keys or live provider calls to CI. A manual
 provider smoke test may be run outside CI when changing provider configuration
 or investigating an integration incident.
 
+## Provider Failure Contract
+
+All OpenRouter operations use the same bounded provider-response readers and
+stable failure classification. JSON responses return `{ code, error }` and SSE
+error events return `{ code, message }`. Request and correlation identifiers
+remain in response headers rather than error payloads.
+
+Provider failures use these codes:
+
+- `ai_provider_configuration_error` for missing configuration and upstream
+  request/configuration `4xx` responses;
+- `ai_provider_rate_limited` for upstream `429`;
+- `ai_provider_timeout` for provider or application deadlines;
+- `ai_provider_unavailable` for network and remaining upstream `5xx` failures;
+- `ai_provider_invalid_response` for missing, unexpected, malformed, or
+  incomplete responses;
+- `ai_provider_response_too_large` when a response bound is exceeded;
+- `ai_provider_response_read_failed` when an upstream body cannot be read.
+
+Error bodies are inspected only for JSON media types and stop at 16 KiB.
+Successful JSON bodies stop at 4 MiB. SSE frames stop at 256 KiB, and combined
+model content plus reasoning stops at 4 MiB. Diagnostics use the
+`ai-provider-observability` channel and contain only stable codes, operation,
+gateway, validated provider/status/identifier fields, content-type category,
+observed byte count, and truncation state. They never contain provider body
+text, prompts, model output, personal data, secrets, or nested exception text.
+
+Caller cancellation produces no provider error payload or provider-failure
+diagnostic. An unavailable optional purchased-credit lookup leaves
+`totalCredits` as `null` when the primary key-information request succeeds.
+
 ## Security Scan Disable Guard
 
 Full active DAST runs set `AI_REQUIREMENT_GENERATION_DISABLED=1`. This is a

--- a/docs/development/ai-assisted-authoring-developer-workflow.md
+++ b/docs/development/ai-assisted-authoring-developer-workflow.md
@@ -72,6 +72,8 @@ All OpenRouter operations use the same bounded provider-response readers and
 stable failure classification. JSON responses return `{ code, error }` and SSE
 error events return `{ code, message }`. Request and correlation identifiers
 remain in response headers rather than error payloads.
+An upstream rate limit detected before streaming begins returns HTTP `429`;
+other provider failures return HTTP `503`.
 
 Provider failures use these codes:
 

--- a/lib/__tests__/provider-errors.test.ts
+++ b/lib/__tests__/provider-errors.test.ts
@@ -57,6 +57,8 @@ describe('AI provider errors', () => {
           provider_code: 'safe_code',
         }),
       )
+      recordAiProviderError(error)
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
     } finally {
       consoleErrorSpy.mockRestore()
     }

--- a/lib/__tests__/provider-errors.test.ts
+++ b/lib/__tests__/provider-errors.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  aiProviderErrorPayload,
+  classifyAiProviderStatus,
+  createAiProviderError,
+  getAiProviderContentTypeCategory,
+  recordAiProviderError,
+} from '@/lib/ai/provider-errors'
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('AI provider errors', () => {
+  it.each([
+    [400, 'ai_provider_configuration_error'],
+    [408, 'ai_provider_timeout'],
+    [429, 'ai_provider_rate_limited'],
+    [500, 'ai_provider_unavailable'],
+    [504, 'ai_provider_timeout'],
+  ] as const)('classifies status %i as %s', (status, code) => {
+    expect(classifyAiProviderStatus(status)).toBe(code)
+  })
+
+  it('keeps public and diagnostic data bounded to validated fields', () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const error = createAiProviderError({
+      code: 'ai_provider_unavailable',
+      correlationId: 'unsafe email@example.test',
+      metadata: {
+        providerCode: 'safe_code',
+        upstreamRequestId: 'unsafe identifier with spaces',
+      },
+      modelProvider: 'anthropic',
+      operation: 'models.list',
+      requestId: 'request-479',
+      status: 503,
+    })
+
+    try {
+      recordAiProviderError(error)
+
+      expect(aiProviderErrorPayload(error)).toEqual({
+        code: 'ai_provider_unavailable',
+        error: 'AI provider is unavailable',
+      })
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        JSON.stringify({
+          channel: 'ai-provider-observability',
+          event: 'ai_provider.request_failed',
+          code: 'ai_provider_unavailable',
+          gateway: 'openrouter',
+          operation: 'models.list',
+          model_provider: 'anthropic',
+          upstream_status: 503,
+          request_id: 'request-479',
+          provider_code: 'safe_code',
+        }),
+      )
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
+  it.each([
+    ['application/problem+json; charset=utf-8', 'json'],
+    ['text/event-stream', 'event-stream'],
+    ['text/plain', 'unexpected'],
+    [null, 'missing'],
+  ] as const)('classifies %s as %s', (contentType, category) => {
+    expect(getAiProviderContentTypeCategory(contentType)).toBe(category)
+  })
+})

--- a/lib/__tests__/provider-response.test.ts
+++ b/lib/__tests__/provider-response.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  readAiProviderErrorResponse,
+  readAiProviderJson,
+} from '@/lib/ai/provider-response'
+
+const options = { operation: 'chat.completions' as const }
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('AI provider response readers', () => {
+  it('does not read an error body with an unexpected media type', async () => {
+    const stream = new ReadableStream<Uint8Array>()
+    const getReaderSpy = vi.spyOn(stream, 'getReader')
+    const response = new Response(stream, {
+      headers: { 'Content-Type': 'text/plain' },
+      status: 500,
+    })
+
+    const error = await readAiProviderErrorResponse(response, options)
+
+    expect(error.code).toBe('ai_provider_unavailable')
+    expect(getReaderSpy).not.toHaveBeenCalled()
+  })
+
+  it('reads recognized bounded JSON success data', async () => {
+    const response = new Response(JSON.stringify({ data: 'safe' }), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    await expect(readAiProviderJson(response, options)).resolves.toEqual({
+      data: 'safe',
+    })
+  })
+
+  it('fails with a stable code when a recognized body cannot be read', async () => {
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          controller.error(new Error('secret provider exception'))
+        },
+      }),
+      { headers: { 'Content-Type': 'application/json' }, status: 502 },
+    )
+
+    await expect(readAiProviderJson(response, options)).rejects.toMatchObject({
+      code: 'ai_provider_response_read_failed',
+      message: 'AI provider response could not be read',
+    })
+  })
+})

--- a/lib/__tests__/provider-response.test.ts
+++ b/lib/__tests__/provider-response.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AI_PROVIDER_RESPONSE_LIMITS } from '@/lib/ai/provider-errors'
 import {
   readAiProviderErrorResponse,
   readAiProviderJson,
@@ -11,6 +12,7 @@ beforeEach(() => vi.clearAllMocks())
 describe('AI provider response readers', () => {
   it('does not read an error body with an unexpected media type', async () => {
     const stream = new ReadableStream<Uint8Array>()
+    const cancelSpy = vi.spyOn(stream, 'cancel')
     const getReaderSpy = vi.spyOn(stream, 'getReader')
     const response = new Response(stream, {
       headers: { 'Content-Type': 'text/plain' },
@@ -20,7 +22,21 @@ describe('AI provider response readers', () => {
     const error = await readAiProviderErrorResponse(response, options)
 
     expect(error.code).toBe('ai_provider_unavailable')
+    expect(cancelSpy).toHaveBeenCalledOnce()
     expect(getReaderSpy).not.toHaveBeenCalled()
+  })
+
+  it('cancels an unexpected success body before rejecting it', async () => {
+    const stream = new ReadableStream<Uint8Array>()
+    const cancelSpy = vi.spyOn(stream, 'cancel')
+    const response = new Response(stream, {
+      headers: { 'Content-Type': 'text/plain' },
+    })
+
+    await expect(readAiProviderJson(response, options)).rejects.toMatchObject({
+      code: 'ai_provider_invalid_response',
+    })
+    expect(cancelSpy).toHaveBeenCalledOnce()
   })
 
   it('reads recognized bounded JSON success data', async () => {
@@ -46,6 +62,37 @@ describe('AI provider response readers', () => {
     await expect(readAiProviderJson(response, options)).rejects.toMatchObject({
       code: 'ai_provider_response_read_failed',
       message: 'AI provider response could not be read',
+    })
+  })
+
+  it('stops reading oversized JSON at the shared success-body limit', async () => {
+    const response = new Response(
+      'x'.repeat(AI_PROVIDER_RESPONSE_LIMITS.jsonBodyBytes + 1),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+
+    await expect(readAiProviderJson(response, options)).rejects.toMatchObject({
+      code: 'ai_provider_response_too_large',
+      metadata: { truncated: true },
+    })
+  })
+
+  it('does not retain malformed JSON body text in the error', async () => {
+    const providerBody = '{"secret":"recognizable-provider-body"'
+    const response = new Response(providerBody, {
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const rejection = readAiProviderJson(response, options)
+    await expect(rejection).rejects.toMatchObject({
+      code: 'ai_provider_invalid_response',
+      message: 'AI provider returned an invalid response',
+    })
+    await rejection.catch(error => {
+      expect(JSON.stringify(error)).not.toContain('recognizable-provider-body')
+      expect(JSON.stringify(error.metadata)).not.toContain(
+        'recognizable-provider-body',
+      )
     })
   })
 })

--- a/lib/ai/openrouter-client.ts
+++ b/lib/ai/openrouter-client.ts
@@ -3,9 +3,9 @@ import {
   AiProviderCallerCancelledError,
   type AiProviderError,
   type AiProviderErrorCode,
+  type AiProviderErrorMetadata,
   type AiProviderOperation,
   aiProviderStreamError,
-  classifyAiProviderStatus,
   createAiProviderError,
   getAiProviderContentTypeCategory,
   getSafeUpstreamRequestId,
@@ -139,10 +139,6 @@ export function getDefaultModel(): string {
 }
 
 const OPENROUTER_BASE = 'https://openrouter.ai/api/v1'
-
-function isRuntimeResponse(response: Response): boolean {
-  return response instanceof Response
-}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
@@ -323,17 +319,10 @@ export async function generateChat<T>(
 
   try {
     if (!response.ok) {
-      let error = isRuntimeResponse(response)
-        ? await readAiProviderErrorResponse(response, {
-            ...diagnosticContext,
-            operation,
-          })
-        : createAiProviderError({
-            ...diagnosticContext,
-            code: classifyAiProviderStatus(response.status),
-            operation,
-            status: response.status,
-          })
+      let error = await readAiProviderErrorResponse(response, {
+        ...diagnosticContext,
+        operation,
+      })
       if (callerAbortTriggered) throw new AiProviderCallerCancelledError()
       if (timeoutTriggered) {
         error = createAiProviderError({
@@ -365,12 +354,10 @@ export async function generateChat<T>(
       }
     }
     try {
-      data = isRuntimeResponse(response)
-        ? await readAiProviderJson<typeof data>(response, {
-            ...diagnosticContext,
-            operation,
-          })
-        : ((await response.json()) as typeof data)
+      data = await readAiProviderJson<typeof data>(response, {
+        ...diagnosticContext,
+        operation,
+      })
     } catch (error) {
       if (callerAbortTriggered) throw new AiProviderCallerCancelledError()
       const providerError = isAiProviderError(error)
@@ -591,17 +578,10 @@ export async function* generateChatStream(
     let error: AiProviderError
     try {
       startIdleTimeout()
-      error = isRuntimeResponse(response)
-        ? await readAiProviderErrorResponse(response, {
-            ...diagnosticContext,
-            operation,
-          })
-        : createAiProviderError({
-            ...diagnosticContext,
-            code: classifyAiProviderStatus(response.status),
-            operation,
-            status: response.status,
-          })
+      error = await readAiProviderErrorResponse(response, {
+        ...diagnosticContext,
+        operation,
+      })
     } finally {
       clearIdleTimeout()
       options.signal?.removeEventListener('abort', onCallerAbort)
@@ -620,40 +600,39 @@ export async function* generateChatStream(
     return
   }
 
-  if (
-    isRuntimeResponse(response) &&
-    getAiProviderContentTypeCategory(response.headers.get('content-type')) !==
-      'event-stream'
-  ) {
-    options.signal?.removeEventListener('abort', onCallerAbort)
+  const streamFailure = (
+    code: AiProviderErrorCode,
+    metadata?: AiProviderErrorMetadata,
+  ): StreamEvent => {
     const error = createAiProviderError({
       ...diagnosticContext,
-      code: 'ai_provider_invalid_response',
-      metadata: {
-        contentTypeCategory: getAiProviderContentTypeCategory(
-          response.headers.get('content-type'),
-        ),
-        upstreamRequestId: getSafeUpstreamRequestId(response.headers),
-      },
+      code,
+      metadata,
       operation,
       status: response.status,
     })
     recordAiProviderError(error)
-    yield aiProviderStreamError(error)
+    return aiProviderStreamError(error)
+  }
+
+  if (
+    getAiProviderContentTypeCategory(response.headers.get('content-type')) !==
+    'event-stream'
+  ) {
+    options.signal?.removeEventListener('abort', onCallerAbort)
+    yield streamFailure('ai_provider_invalid_response', {
+      contentTypeCategory: getAiProviderContentTypeCategory(
+        response.headers.get('content-type'),
+      ),
+      upstreamRequestId: getSafeUpstreamRequestId(response.headers),
+    })
     return
   }
 
   if (!response.body) {
     clearIdleTimeout()
     options.signal?.removeEventListener('abort', onCallerAbort)
-    const error = createAiProviderError({
-      ...diagnosticContext,
-      code: 'ai_provider_invalid_response',
-      operation,
-      status: response.status,
-    })
-    recordAiProviderError(error)
-    yield aiProviderStreamError(error)
+    yield streamFailure('ai_provider_invalid_response')
     return
   }
 
@@ -681,16 +660,11 @@ export async function* generateChatStream(
         readResult = await reader.read()
       } catch {
         if (callerAbortTriggered) return
-        const error = createAiProviderError({
-          ...diagnosticContext,
-          code: idleTimeoutTriggered
+        yield streamFailure(
+          idleTimeoutTriggered
             ? 'ai_provider_timeout'
             : 'ai_provider_response_read_failed',
-          operation,
-          status: response.status,
-        })
-        recordAiProviderError(error)
-        yield aiProviderStreamError(error)
+        )
         return
       } finally {
         clearIdleTimeout()
@@ -704,37 +678,21 @@ export async function* generateChatStream(
       try {
         buffer += decoder.decode(value, { stream: true })
       } catch {
-        const error = createAiProviderError({
-          ...diagnosticContext,
-          code: 'ai_provider_invalid_response',
-          metadata: { contentTypeCategory: 'event-stream' },
-          operation,
-          status: response.status,
+        yield streamFailure('ai_provider_invalid_response', {
+          contentTypeCategory: 'event-stream',
         })
-        recordAiProviderError(error)
-        yield aiProviderStreamError(error)
         return
       }
       const lines = buffer.split('\n')
       buffer = lines.pop() ?? ''
-      if (
-        encoder.encode(buffer).byteLength >
-        AI_PROVIDER_RESPONSE_LIMITS.sseFrameBytes
-      ) {
+      const residualBufferBytes = encoder.encode(buffer).byteLength
+      if (residualBufferBytes > AI_PROVIDER_RESPONSE_LIMITS.sseFrameBytes) {
         await reader.cancel().catch(() => undefined)
-        const error = createAiProviderError({
-          ...diagnosticContext,
-          code: 'ai_provider_response_too_large',
-          metadata: {
-            contentTypeCategory: 'event-stream',
-            observedBytes: encoder.encode(buffer).byteLength,
-            truncated: true,
-          },
-          operation,
-          status: response.status,
+        yield streamFailure('ai_provider_response_too_large', {
+          contentTypeCategory: 'event-stream',
+          observedBytes: residualBufferBytes,
+          truncated: true,
         })
-        recordAiProviderError(error)
-        yield aiProviderStreamError(error)
         return
       }
 
@@ -747,19 +705,11 @@ export async function* generateChatStream(
         currentFrameBytes += encoder.encode(line).byteLength + 1
         if (currentFrameBytes > AI_PROVIDER_RESPONSE_LIMITS.sseFrameBytes) {
           await reader.cancel().catch(() => undefined)
-          const error = createAiProviderError({
-            ...diagnosticContext,
-            code: 'ai_provider_response_too_large',
-            metadata: {
-              contentTypeCategory: 'event-stream',
-              observedBytes: currentFrameBytes,
-              truncated: true,
-            },
-            operation,
-            status: response.status,
+          yield streamFailure('ai_provider_response_too_large', {
+            contentTypeCategory: 'event-stream',
+            observedBytes: currentFrameBytes,
+            truncated: true,
           })
-          recordAiProviderError(error)
-          yield aiProviderStreamError(error)
           return
         }
         if (trimmed.startsWith(':')) continue
@@ -797,15 +747,9 @@ export async function* generateChatStream(
         try {
           chunk = JSON.parse(jsonStr) as typeof chunk
         } catch {
-          const error = createAiProviderError({
-            ...diagnosticContext,
-            code: 'ai_provider_invalid_response',
-            metadata: { contentTypeCategory: 'event-stream' },
-            operation,
-            status: response.status,
+          yield streamFailure('ai_provider_invalid_response', {
+            contentTypeCategory: 'event-stream',
           })
-          recordAiProviderError(error)
-          yield aiProviderStreamError(error)
           return
         }
 
@@ -814,15 +758,9 @@ export async function* generateChatStream(
           (chunk.choices !== undefined && !Array.isArray(chunk.choices)) ||
           (chunk.usage !== undefined && !isRecord(chunk.usage))
         ) {
-          const error = createAiProviderError({
-            ...diagnosticContext,
-            code: 'ai_provider_invalid_response',
-            metadata: { contentTypeCategory: 'event-stream' },
-            operation,
-            status: response.status,
+          yield streamFailure('ai_provider_invalid_response', {
+            contentTypeCategory: 'event-stream',
           })
-          recordAiProviderError(error)
-          yield aiProviderStreamError(error)
           return
         }
 
@@ -844,15 +782,9 @@ export async function* generateChatStream(
                     'reasoning_tokens',
                   )))))
         ) {
-          const error = createAiProviderError({
-            ...diagnosticContext,
-            code: 'ai_provider_invalid_response',
-            metadata: { contentTypeCategory: 'event-stream' },
-            operation,
-            status: response.status,
+          yield streamFailure('ai_provider_invalid_response', {
+            contentTypeCategory: 'event-stream',
           })
-          recordAiProviderError(error)
-          yield aiProviderStreamError(error)
           return
         }
 
@@ -867,19 +799,11 @@ export async function* generateChatStream(
             AI_PROVIDER_RESPONSE_LIMITS.sseAccumulatedBytes
           ) {
             await reader.cancel().catch(() => undefined)
-            const error = createAiProviderError({
-              ...diagnosticContext,
-              code: 'ai_provider_response_too_large',
-              metadata: {
-                contentTypeCategory: 'event-stream',
-                observedBytes: accumulatedOutputBytes,
-                truncated: true,
-              },
-              operation,
-              status: response.status,
+            yield streamFailure('ai_provider_response_too_large', {
+              contentTypeCategory: 'event-stream',
+              observedBytes: accumulatedOutputBytes,
+              truncated: true,
             })
-            recordAiProviderError(error)
-            yield aiProviderStreamError(error)
             return
           }
           thinkingSoFar += reasoningChunk
@@ -898,19 +822,11 @@ export async function* generateChatStream(
             AI_PROVIDER_RESPONSE_LIMITS.sseAccumulatedBytes
           ) {
             await reader.cancel().catch(() => undefined)
-            const error = createAiProviderError({
-              ...diagnosticContext,
-              code: 'ai_provider_response_too_large',
-              metadata: {
-                contentTypeCategory: 'event-stream',
-                observedBytes: accumulatedOutputBytes,
-                truncated: true,
-              },
-              operation,
-              status: response.status,
+            yield streamFailure('ai_provider_response_too_large', {
+              contentTypeCategory: 'event-stream',
+              observedBytes: accumulatedOutputBytes,
+              truncated: true,
             })
-            recordAiProviderError(error)
-            yield aiProviderStreamError(error)
             return
           }
           contentSoFar += delta.content
@@ -933,15 +849,9 @@ export async function* generateChatStream(
       }
     }
 
-    const error = createAiProviderError({
-      ...diagnosticContext,
-      code: 'ai_provider_invalid_response',
-      metadata: { contentTypeCategory: 'event-stream' },
-      operation,
-      status: response.status,
+    yield streamFailure('ai_provider_invalid_response', {
+      contentTypeCategory: 'event-stream',
     })
-    recordAiProviderError(error)
-    yield aiProviderStreamError(error)
   } finally {
     clearIdleTimeout()
     options.signal?.removeEventListener('abort', onCallerAbort)
@@ -952,6 +862,58 @@ export async function* generateChatStream(
 // ---------------------------------------------------------------------------
 // Model listing
 // ---------------------------------------------------------------------------
+
+interface ProviderCatalogModel {
+  architecture?: { modality?: string }
+  context_length?: number
+  id: string
+  name: string
+  pricing?: {
+    completion?: string
+    prompt?: string
+    reasoning?: string
+  }
+  supported_parameters?: string[]
+}
+
+function isValidCatalogModel(model: unknown): model is ProviderCatalogModel {
+  if (!isRecord(model)) return false
+  if (typeof model.id !== 'string' || typeof model.name !== 'string')
+    return false
+  if (!hasOptionalFiniteNumber(model, 'context_length')) return false
+
+  if (model.architecture !== undefined) {
+    if (!isRecord(model.architecture)) return false
+    if (
+      model.architecture.modality !== undefined &&
+      typeof model.architecture.modality !== 'string'
+    ) {
+      return false
+    }
+  }
+
+  if (model.pricing !== undefined) {
+    if (!isRecord(model.pricing)) return false
+    if (
+      (model.pricing.completion !== undefined &&
+        typeof model.pricing.completion !== 'string') ||
+      (model.pricing.prompt !== undefined &&
+        typeof model.pricing.prompt !== 'string') ||
+      (model.pricing.reasoning !== undefined &&
+        typeof model.pricing.reasoning !== 'string')
+    ) {
+      return false
+    }
+  }
+
+  return (
+    model.supported_parameters === undefined ||
+    (Array.isArray(model.supported_parameters) &&
+      model.supported_parameters.every(
+        parameter => typeof parameter === 'string',
+      ))
+  )
+}
 
 async function fetchProviderJson<T>(
   url: string,
@@ -978,14 +940,10 @@ async function fetchProviderJson<T>(
   }
 
   if (!response.ok) {
-    let error = isRuntimeResponse(response)
-      ? await readAiProviderErrorResponse(response, { ...context, operation })
-      : createAiProviderError({
-          ...context,
-          code: classifyAiProviderStatus(response.status),
-          operation,
-          status: response.status,
-        })
+    let error = await readAiProviderErrorResponse(response, {
+      ...context,
+      operation,
+    })
     if (signal.aborted) {
       error = createAiProviderError({
         ...context,
@@ -999,9 +957,7 @@ async function fetchProviderJson<T>(
   }
 
   try {
-    return isRuntimeResponse(response)
-      ? await readAiProviderJson<T>(response, { ...context, operation })
-      : ((await response.json()) as T)
+    return await readAiProviderJson<T>(response, { ...context, operation })
   } catch (error) {
     const providerError = isAiProviderError(error)
       ? signal.aborted
@@ -1039,50 +995,18 @@ export async function listModels(
   }
   url.searchParams.set('supported_parameters', params.join(','))
 
-  const data = await fetchProviderJson<{
-    data: Array<{
-      architecture?: { modality?: string }
-      context_length?: number
-      id: string
-      name: string
-      pricing?: {
-        completion?: string
-        prompt?: string
-        reasoning?: string
-      }
-      supported_parameters?: string[]
-    }>
-  }>(url.toString(), apiKey, 'models.list', context, 10_000)
+  const data = await fetchProviderJson<{ data: ProviderCatalogModel[] }>(
+    url.toString(),
+    apiKey,
+    'models.list',
+    context,
+    10_000,
+  )
 
   if (!data || !Array.isArray(data.data)) {
     throwInvalidProviderResponse('models.list', context)
   }
-  if (
-    !data.data.every(
-      model =>
-        isRecord(model) &&
-        typeof model.id === 'string' &&
-        typeof model.name === 'string' &&
-        (model.architecture === undefined || isRecord(model.architecture)) &&
-        (model.pricing === undefined || isRecord(model.pricing)) &&
-        hasOptionalFiniteNumber(model, 'context_length') &&
-        (model.architecture === undefined ||
-          model.architecture.modality === undefined ||
-          typeof model.architecture.modality === 'string') &&
-        (model.pricing === undefined ||
-          ((model.pricing.completion === undefined ||
-            typeof model.pricing.completion === 'string') &&
-            (model.pricing.prompt === undefined ||
-              typeof model.pricing.prompt === 'string') &&
-            (model.pricing.reasoning === undefined ||
-              typeof model.pricing.reasoning === 'string'))) &&
-        (model.supported_parameters === undefined ||
-          (Array.isArray(model.supported_parameters) &&
-            model.supported_parameters.every(
-              parameter => typeof parameter === 'string',
-            ))),
-    )
-  ) {
+  if (!data.data.every(isValidCatalogModel)) {
     throwInvalidProviderResponse('models.list', context)
   }
 

--- a/lib/ai/openrouter-client.ts
+++ b/lib/ai/openrouter-client.ts
@@ -1,4 +1,23 @@
-import { AI_PROVIDER_UNAVAILABLE_MESSAGE } from '@/lib/http/safe-errors'
+import {
+  AI_PROVIDER_RESPONSE_LIMITS,
+  AiProviderCallerCancelledError,
+  type AiProviderError,
+  type AiProviderErrorCode,
+  type AiProviderOperation,
+  aiProviderStreamError,
+  classifyAiProviderStatus,
+  createAiProviderError,
+  getAiProviderContentTypeCategory,
+  getSafeUpstreamRequestId,
+  isAiProviderError,
+  recordAiProviderError,
+} from '@/lib/ai/provider-errors'
+import {
+  readAiProviderErrorResponse,
+  readAiProviderJson,
+} from '@/lib/ai/provider-response'
+
+export { AiProviderError } from '@/lib/ai/provider-errors'
 
 /**
  * OpenRouter API client for AI requirement generation.
@@ -17,6 +36,12 @@ export interface OpenRouterModel {
   pricing: { completion: string; prompt: string; reasoning: string }
   provider: string
   supportedParameters: string[]
+}
+
+export interface OpenRouterRequestContext {
+  correlationId?: string
+  modelProvider?: string
+  requestId?: string
 }
 
 export interface GenerationStats {
@@ -42,7 +67,7 @@ export type StreamEvent =
       stats: GenerationStats
       thinking: string
     }
-  | { cause?: string; message: string; phase: 'error' }
+  | { code: AiProviderErrorCode; message: string; phase: 'error' }
 
 export interface NonStreamingResult<T> {
   content: T
@@ -74,6 +99,7 @@ export interface ProviderPreferences {
 }
 
 interface GenerateOptions {
+  correlationId?: string
   format?: Record<string, unknown>
   messages: ChatMessage[]
   model?: string
@@ -81,6 +107,7 @@ interface GenerateOptions {
   providerPreferences?: ProviderPreferences
   /** Reasoning effort level (default: 'high'). Use 'none' to disable reasoning. */
   reasoningEffort?: string
+  requestId?: string
   signal?: AbortSignal
   /** Model capabilities from the server catalog. Required when format is supplied. */
   supportedParameters?: string[]
@@ -90,10 +117,19 @@ interface GenerateOptions {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function getApiKey(): string {
+function getApiKey(
+  operation: AiProviderOperation,
+  options: Pick<GenerateOptions, 'correlationId' | 'requestId'> = {},
+): string {
   const key = process.env.OPENROUTER_API_KEY
   if (!key) {
-    throw new Error('OPENROUTER_API_KEY environment variable is not set')
+    const error = createAiProviderError({
+      ...options,
+      code: 'ai_provider_configuration_error',
+      operation,
+    })
+    recordAiProviderError(error)
+    throw error
   }
   return key
 }
@@ -103,6 +139,46 @@ export function getDefaultModel(): string {
 }
 
 const OPENROUTER_BASE = 'https://openrouter.ai/api/v1'
+
+function isRuntimeResponse(response: Response): boolean {
+  return response instanceof Response
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function hasOptionalFiniteNumber(
+  value: Record<string, unknown>,
+  key: string,
+): boolean {
+  return (
+    value[key] === undefined ||
+    (typeof value[key] === 'number' && Number.isFinite(value[key]))
+  )
+}
+
+function hasOptionalFiniteNumberOrNull(
+  value: Record<string, unknown>,
+  key: string,
+): boolean {
+  return value[key] === null || hasOptionalFiniteNumber(value, key)
+}
+
+function throwInvalidProviderResponse(
+  operation: AiProviderOperation,
+  context: OpenRouterRequestContext,
+  status?: number,
+): never {
+  const error = createAiProviderError({
+    ...context,
+    code: 'ai_provider_invalid_response',
+    operation,
+    status,
+  })
+  recordAiProviderError(error)
+  throw error
+}
 
 /**
  * Apply the best response_format strategy based on the model's capabilities.
@@ -171,7 +247,13 @@ function readReasoningText(input: {
 export async function generateChat<T>(
   options: GenerateOptions,
 ): Promise<NonStreamingResult<T>> {
-  const apiKey = getApiKey()
+  const operation = 'chat.completions' as const
+  const diagnosticContext = {
+    correlationId: options.correlationId,
+    modelProvider: options.model?.split('/', 1)[0],
+    requestId: options.requestId,
+  }
+  const apiKey = getApiKey(operation, options)
   const model = options.model || getDefaultModel()
 
   const effort = options.reasoningEffort || 'high'
@@ -194,15 +276,20 @@ export async function generateChat<T>(
   // wire it so that either the timeout or the caller's abort cancels the fetch.
   const DEFAULT_TIMEOUT_MS = 120_000
   const childController = new AbortController()
-  const timeoutId = setTimeout(
-    () => childController.abort(),
-    DEFAULT_TIMEOUT_MS,
-  )
+  let timeoutTriggered = false
+  let callerAbortTriggered = false
+  const timeoutId = setTimeout(() => {
+    timeoutTriggered = true
+    childController.abort()
+  }, DEFAULT_TIMEOUT_MS)
 
-  const onCallerAbort = () => childController.abort()
+  const onCallerAbort = (): void => {
+    callerAbortTriggered = true
+    childController.abort()
+  }
   if (options.signal) {
     if (options.signal.aborted) {
-      childController.abort()
+      onCallerAbort()
     } else {
       options.signal.addEventListener('abort', onCallerAbort, { once: true })
     }
@@ -219,19 +306,48 @@ export async function generateChat<T>(
       method: 'POST',
       signal: childController.signal,
     })
-  } catch (err) {
+  } catch {
     clearTimeout(timeoutId)
     options.signal?.removeEventListener('abort', onCallerAbort)
-    throw err
+    if (callerAbortTriggered) throw new AiProviderCallerCancelledError()
+    const error = createAiProviderError({
+      ...diagnosticContext,
+      code: timeoutTriggered
+        ? 'ai_provider_timeout'
+        : 'ai_provider_unavailable',
+      operation,
+    })
+    recordAiProviderError(error)
+    throw error
   }
 
   try {
     if (!response.ok) {
-      const text = await response.text().catch(() => '')
-      throw new Error(`OpenRouter request failed (${response.status}): ${text}`)
+      let error = isRuntimeResponse(response)
+        ? await readAiProviderErrorResponse(response, {
+            ...diagnosticContext,
+            operation,
+          })
+        : createAiProviderError({
+            ...diagnosticContext,
+            code: classifyAiProviderStatus(response.status),
+            operation,
+            status: response.status,
+          })
+      if (callerAbortTriggered) throw new AiProviderCallerCancelledError()
+      if (timeoutTriggered) {
+        error = createAiProviderError({
+          ...diagnosticContext,
+          code: 'ai_provider_timeout',
+          operation,
+          status: response.status,
+        })
+      }
+      recordAiProviderError(error)
+      throw error
     }
 
-    const data = (await response.json()) as {
+    let data: {
       choices: Array<{
         message: {
           content: string | null
@@ -248,17 +364,97 @@ export async function generateChat<T>(
         }
       }
     }
+    try {
+      data = isRuntimeResponse(response)
+        ? await readAiProviderJson<typeof data>(response, {
+            ...diagnosticContext,
+            operation,
+          })
+        : ((await response.json()) as typeof data)
+    } catch (error) {
+      if (callerAbortTriggered) throw new AiProviderCallerCancelledError()
+      const providerError = isAiProviderError(error)
+        ? timeoutTriggered
+          ? createAiProviderError({
+              ...diagnosticContext,
+              code: 'ai_provider_timeout',
+              operation,
+              status: response.status,
+            })
+          : error
+        : createAiProviderError({
+            ...diagnosticContext,
+            code: 'ai_provider_invalid_response',
+            operation,
+            status: response.status,
+          })
+      recordAiProviderError(providerError)
+      throw providerError
+    }
 
-    const message = data.choices?.[0]?.message
-    if (!message?.content) {
-      throw new Error('OpenRouter returned empty response')
+    if (!isRecord(data) || !Array.isArray(data.choices)) {
+      throwInvalidProviderResponse(
+        operation,
+        diagnosticContext,
+        response.status,
+      )
+    }
+    const choice = data.choices[0]
+    if (!isRecord(choice) || !isRecord(choice.message)) {
+      throwInvalidProviderResponse(
+        operation,
+        diagnosticContext,
+        response.status,
+      )
+    }
+    const message = choice.message
+    if (typeof message.content !== 'string' || !message.content) {
+      throwInvalidProviderResponse(
+        operation,
+        diagnosticContext,
+        response.status,
+      )
+    }
+
+    if (data.usage !== undefined) {
+      if (
+        !isRecord(data.usage) ||
+        !hasOptionalFiniteNumber(data.usage, 'completion_tokens') ||
+        !hasOptionalFiniteNumber(data.usage, 'cost') ||
+        !hasOptionalFiniteNumber(data.usage, 'prompt_tokens')
+      ) {
+        throwInvalidProviderResponse(
+          operation,
+          diagnosticContext,
+          response.status,
+        )
+      }
+      const details = data.usage.completion_tokens_details
+      if (
+        details !== undefined &&
+        (!isRecord(details) ||
+          !hasOptionalFiniteNumber(details, 'reasoning_tokens'))
+      ) {
+        throwInvalidProviderResponse(
+          operation,
+          diagnosticContext,
+          response.status,
+        )
+      }
     }
 
     let content: T
     try {
       content = JSON.parse(message.content) as T
     } catch {
-      throw new Error('Failed to parse OpenRouter JSON response')
+      const error = createAiProviderError({
+        ...diagnosticContext,
+        code: 'ai_provider_invalid_response',
+        operation,
+        status: response.status,
+      })
+      recordAiProviderError(error)
+      throw error
     }
 
     const usage = data.usage
@@ -288,7 +484,19 @@ export async function generateChat<T>(
 export async function* generateChatStream(
   options: GenerateOptions,
 ): AsyncGenerator<StreamEvent> {
-  const apiKey = getApiKey()
+  const operation = 'chat.completions' as const
+  const diagnosticContext = {
+    correlationId: options.correlationId,
+    modelProvider: options.model?.split('/', 1)[0],
+    requestId: options.requestId,
+  }
+  let apiKey: string
+  try {
+    apiKey = getApiKey(operation, options)
+  } catch (error) {
+    if (isAiProviderError(error)) yield aiProviderStreamError(error)
+    return
+  }
   const model = options.model || getDefaultModel()
 
   const effort = options.reasoningEffort || 'high'
@@ -316,14 +524,14 @@ export async function* generateChatStream(
   let idleTimeoutTriggered = false
   let callerAbortTriggered = false
 
-  const clearIdleTimeout = () => {
+  const clearIdleTimeout = (): void => {
     if (idleTimeoutId) {
       clearTimeout(idleTimeoutId)
       idleTimeoutId = undefined
     }
   }
 
-  const startIdleTimeout = () => {
+  const startIdleTimeout = (): void => {
     clearIdleTimeout()
     idleTimeoutTriggered = false
     idleTimeoutId = setTimeout(() => {
@@ -332,7 +540,7 @@ export async function* generateChatStream(
     }, STREAM_IDLE_TIMEOUT_MS)
   }
 
-  const onCallerAbort = () => {
+  const onCallerAbort = (): void => {
     callerAbortTriggered = true
     childController.abort()
   }
@@ -356,49 +564,105 @@ export async function* generateChatStream(
       method: 'POST',
       signal: childController.signal,
     })
-  } catch (err) {
+  } catch {
     clearIdleTimeout()
     options.signal?.removeEventListener('abort', onCallerAbort)
     if (callerAbortTriggered) return
-    const message = err instanceof Error ? err.message : 'Fetch failed'
-    yield {
-      cause: idleTimeoutTriggered
-        ? `OpenRouter stream idle timeout after ${STREAM_IDLE_TIMEOUT_MS} ms`
-        : `OpenRouter fetch error: ${message}`,
-      message: AI_PROVIDER_UNAVAILABLE_MESSAGE,
-      phase: 'error',
-    }
+    const error = createAiProviderError({
+      ...diagnosticContext,
+      code: idleTimeoutTriggered
+        ? 'ai_provider_timeout'
+        : 'ai_provider_unavailable',
+      operation,
+    })
+    recordAiProviderError(error)
+    yield aiProviderStreamError(error)
     return
   } finally {
     clearIdleTimeout()
   }
 
-  if (!response.ok) {
-    clearIdleTimeout()
+  if (callerAbortTriggered) {
     options.signal?.removeEventListener('abort', onCallerAbort)
-    const text = await response.text().catch(() => '')
-    yield {
-      cause: `OpenRouter error (${response.status}): ${text}`,
-      message: AI_PROVIDER_UNAVAILABLE_MESSAGE,
-      phase: 'error',
+    return
+  }
+
+  if (!response.ok) {
+    let error: AiProviderError
+    try {
+      startIdleTimeout()
+      error = isRuntimeResponse(response)
+        ? await readAiProviderErrorResponse(response, {
+            ...diagnosticContext,
+            operation,
+          })
+        : createAiProviderError({
+            ...diagnosticContext,
+            code: classifyAiProviderStatus(response.status),
+            operation,
+            status: response.status,
+          })
+    } finally {
+      clearIdleTimeout()
+      options.signal?.removeEventListener('abort', onCallerAbort)
     }
+    if (callerAbortTriggered) return
+    if (idleTimeoutTriggered) {
+      error = createAiProviderError({
+        ...diagnosticContext,
+        code: 'ai_provider_timeout',
+        operation,
+        status: response.status,
+      })
+    }
+    recordAiProviderError(error)
+    yield aiProviderStreamError(error)
+    return
+  }
+
+  if (
+    isRuntimeResponse(response) &&
+    getAiProviderContentTypeCategory(response.headers.get('content-type')) !==
+      'event-stream'
+  ) {
+    options.signal?.removeEventListener('abort', onCallerAbort)
+    const error = createAiProviderError({
+      ...diagnosticContext,
+      code: 'ai_provider_invalid_response',
+      metadata: {
+        contentTypeCategory: getAiProviderContentTypeCategory(
+          response.headers.get('content-type'),
+        ),
+        upstreamRequestId: getSafeUpstreamRequestId(response.headers),
+      },
+      operation,
+      status: response.status,
+    })
+    recordAiProviderError(error)
+    yield aiProviderStreamError(error)
     return
   }
 
   if (!response.body) {
     clearIdleTimeout()
     options.signal?.removeEventListener('abort', onCallerAbort)
-    yield {
-      cause: 'No response body from OpenRouter',
-      message: AI_PROVIDER_UNAVAILABLE_MESSAGE,
-      phase: 'error',
-    }
+    const error = createAiProviderError({
+      ...diagnosticContext,
+      code: 'ai_provider_invalid_response',
+      operation,
+      status: response.status,
+    })
+    recordAiProviderError(error)
+    yield aiProviderStreamError(error)
     return
   }
 
   const reader = response.body.getReader()
-  const decoder = new TextDecoder()
+  const decoder = new TextDecoder('utf-8', { fatal: true })
+  const encoder = new TextEncoder()
   let buffer = ''
+  let currentFrameBytes = 0
+  let accumulatedOutputBytes = 0
   let thinkingSoFar = ''
   let contentSoFar = ''
   let lastStats: GenerationStats = {
@@ -415,31 +679,90 @@ export async function* generateChatStream(
       try {
         startIdleTimeout()
         readResult = await reader.read()
-      } catch (err) {
+      } catch {
         if (callerAbortTriggered) return
-        const message = err instanceof Error ? err.message : 'Stream failed'
-        yield {
-          cause: idleTimeoutTriggered
-            ? `OpenRouter stream idle timeout after ${STREAM_IDLE_TIMEOUT_MS} ms`
-            : `OpenRouter stream read error: ${message}`,
-          message: AI_PROVIDER_UNAVAILABLE_MESSAGE,
-          phase: 'error',
-        }
+        const error = createAiProviderError({
+          ...diagnosticContext,
+          code: idleTimeoutTriggered
+            ? 'ai_provider_timeout'
+            : 'ai_provider_response_read_failed',
+          operation,
+          status: response.status,
+        })
+        recordAiProviderError(error)
+        yield aiProviderStreamError(error)
         return
       } finally {
         clearIdleTimeout()
       }
 
+      if (callerAbortTriggered) return
+
       const { done, value } = readResult
       if (done) break
 
-      buffer += decoder.decode(value, { stream: true })
+      try {
+        buffer += decoder.decode(value, { stream: true })
+      } catch {
+        const error = createAiProviderError({
+          ...diagnosticContext,
+          code: 'ai_provider_invalid_response',
+          metadata: { contentTypeCategory: 'event-stream' },
+          operation,
+          status: response.status,
+        })
+        recordAiProviderError(error)
+        yield aiProviderStreamError(error)
+        return
+      }
       const lines = buffer.split('\n')
       buffer = lines.pop() ?? ''
+      if (
+        encoder.encode(buffer).byteLength >
+        AI_PROVIDER_RESPONSE_LIMITS.sseFrameBytes
+      ) {
+        await reader.cancel().catch(() => undefined)
+        const error = createAiProviderError({
+          ...diagnosticContext,
+          code: 'ai_provider_response_too_large',
+          metadata: {
+            contentTypeCategory: 'event-stream',
+            observedBytes: encoder.encode(buffer).byteLength,
+            truncated: true,
+          },
+          operation,
+          status: response.status,
+        })
+        recordAiProviderError(error)
+        yield aiProviderStreamError(error)
+        return
+      }
 
       for (const line of lines) {
         const trimmed = line.trim()
-        if (!trimmed || trimmed.startsWith(':')) continue
+        if (!trimmed) {
+          currentFrameBytes = 0
+          continue
+        }
+        currentFrameBytes += encoder.encode(line).byteLength + 1
+        if (currentFrameBytes > AI_PROVIDER_RESPONSE_LIMITS.sseFrameBytes) {
+          await reader.cancel().catch(() => undefined)
+          const error = createAiProviderError({
+            ...diagnosticContext,
+            code: 'ai_provider_response_too_large',
+            metadata: {
+              contentTypeCategory: 'event-stream',
+              observedBytes: currentFrameBytes,
+              truncated: true,
+            },
+            operation,
+            status: response.status,
+          })
+          recordAiProviderError(error)
+          yield aiProviderStreamError(error)
+          return
+        }
+        if (trimmed.startsWith(':')) continue
         if (trimmed === 'data: [DONE]') {
           yield {
             phase: 'done',
@@ -474,14 +797,91 @@ export async function* generateChatStream(
         try {
           chunk = JSON.parse(jsonStr) as typeof chunk
         } catch {
-          continue
+          const error = createAiProviderError({
+            ...diagnosticContext,
+            code: 'ai_provider_invalid_response',
+            metadata: { contentTypeCategory: 'event-stream' },
+            operation,
+            status: response.status,
+          })
+          recordAiProviderError(error)
+          yield aiProviderStreamError(error)
+          return
         }
 
-        const delta = chunk.choices?.[0]?.delta
+        if (
+          !isRecord(chunk) ||
+          (chunk.choices !== undefined && !Array.isArray(chunk.choices)) ||
+          (chunk.usage !== undefined && !isRecord(chunk.usage))
+        ) {
+          const error = createAiProviderError({
+            ...diagnosticContext,
+            code: 'ai_provider_invalid_response',
+            metadata: { contentTypeCategory: 'event-stream' },
+            operation,
+            status: response.status,
+          })
+          recordAiProviderError(error)
+          yield aiProviderStreamError(error)
+          return
+        }
+
+        const firstChoice = chunk.choices?.[0]
+        if (
+          (firstChoice !== undefined && !isRecord(firstChoice)) ||
+          (firstChoice?.delta !== undefined && !isRecord(firstChoice.delta)) ||
+          (firstChoice?.delta?.content !== undefined &&
+            firstChoice.delta.content !== null &&
+            typeof firstChoice.delta.content !== 'string') ||
+          (chunk.usage !== undefined &&
+            (!hasOptionalFiniteNumber(chunk.usage, 'completion_tokens') ||
+              !hasOptionalFiniteNumber(chunk.usage, 'cost') ||
+              !hasOptionalFiniteNumber(chunk.usage, 'prompt_tokens') ||
+              (chunk.usage.completion_tokens_details !== undefined &&
+                (!isRecord(chunk.usage.completion_tokens_details) ||
+                  !hasOptionalFiniteNumber(
+                    chunk.usage.completion_tokens_details,
+                    'reasoning_tokens',
+                  )))))
+        ) {
+          const error = createAiProviderError({
+            ...diagnosticContext,
+            code: 'ai_provider_invalid_response',
+            metadata: { contentTypeCategory: 'event-stream' },
+            operation,
+            status: response.status,
+          })
+          recordAiProviderError(error)
+          yield aiProviderStreamError(error)
+          return
+        }
+
+        const delta = firstChoice?.delta
 
         // Reasoning/thinking content
         const reasoningChunk = delta ? readReasoningText(delta) : ''
         if (reasoningChunk) {
+          accumulatedOutputBytes += encoder.encode(reasoningChunk).byteLength
+          if (
+            accumulatedOutputBytes >
+            AI_PROVIDER_RESPONSE_LIMITS.sseAccumulatedBytes
+          ) {
+            await reader.cancel().catch(() => undefined)
+            const error = createAiProviderError({
+              ...diagnosticContext,
+              code: 'ai_provider_response_too_large',
+              metadata: {
+                contentTypeCategory: 'event-stream',
+                observedBytes: accumulatedOutputBytes,
+                truncated: true,
+              },
+              operation,
+              status: response.status,
+            })
+            recordAiProviderError(error)
+            yield aiProviderStreamError(error)
+            return
+          }
           thinkingSoFar += reasoningChunk
           yield {
             chunk: reasoningChunk,
@@ -492,6 +892,27 @@ export async function* generateChatStream(
 
         // Generated content
         if (delta?.content) {
+          accumulatedOutputBytes += encoder.encode(delta.content).byteLength
+          if (
+            accumulatedOutputBytes >
+            AI_PROVIDER_RESPONSE_LIMITS.sseAccumulatedBytes
+          ) {
+            await reader.cancel().catch(() => undefined)
+            const error = createAiProviderError({
+              ...diagnosticContext,
+              code: 'ai_provider_response_too_large',
+              metadata: {
+                contentTypeCategory: 'event-stream',
+                observedBytes: accumulatedOutputBytes,
+                truncated: true,
+              },
+              operation,
+              status: response.status,
+            })
+            recordAiProviderError(error)
+            yield aiProviderStreamError(error)
+            return
+          }
           contentSoFar += delta.content
           yield { chunk: delta.content, phase: 'generating' }
         }
@@ -512,12 +933,15 @@ export async function* generateChatStream(
       }
     }
 
-    yield {
-      phase: 'done',
-      rawContent: contentSoFar,
-      stats: lastStats,
-      thinking: thinkingSoFar,
-    }
+    const error = createAiProviderError({
+      ...diagnosticContext,
+      code: 'ai_provider_invalid_response',
+      metadata: { contentTypeCategory: 'event-stream' },
+      operation,
+      status: response.status,
+    })
+    recordAiProviderError(error)
+    yield aiProviderStreamError(error)
   } finally {
     clearIdleTimeout()
     options.signal?.removeEventListener('abort', onCallerAbort)
@@ -529,10 +953,81 @@ export async function* generateChatStream(
 // Model listing
 // ---------------------------------------------------------------------------
 
+async function fetchProviderJson<T>(
+  url: string,
+  apiKey: string,
+  operation: Exclude<AiProviderOperation, 'chat.completions'>,
+  context: OpenRouterRequestContext,
+  timeoutMs: number,
+): Promise<T> {
+  const signal = AbortSignal.timeout(timeoutMs)
+  let response: Response
+  try {
+    response = await fetch(url, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal,
+    })
+  } catch {
+    const error = createAiProviderError({
+      ...context,
+      code: signal.aborted ? 'ai_provider_timeout' : 'ai_provider_unavailable',
+      operation,
+    })
+    recordAiProviderError(error)
+    throw error
+  }
+
+  if (!response.ok) {
+    let error = isRuntimeResponse(response)
+      ? await readAiProviderErrorResponse(response, { ...context, operation })
+      : createAiProviderError({
+          ...context,
+          code: classifyAiProviderStatus(response.status),
+          operation,
+          status: response.status,
+        })
+    if (signal.aborted) {
+      error = createAiProviderError({
+        ...context,
+        code: 'ai_provider_timeout',
+        operation,
+        status: response.status,
+      })
+    }
+    recordAiProviderError(error)
+    throw error
+  }
+
+  try {
+    return isRuntimeResponse(response)
+      ? await readAiProviderJson<T>(response, { ...context, operation })
+      : ((await response.json()) as T)
+  } catch (error) {
+    const providerError = isAiProviderError(error)
+      ? signal.aborted
+        ? createAiProviderError({
+            ...context,
+            code: 'ai_provider_timeout',
+            operation,
+            status: response.status,
+          })
+        : error
+      : createAiProviderError({
+          ...context,
+          code: 'ai_provider_invalid_response',
+          operation,
+          status: response.status,
+        })
+    recordAiProviderError(providerError)
+    throw providerError
+  }
+}
+
 export async function listModels(
   supportedParameters?: string[],
+  context: OpenRouterRequestContext = {},
 ): Promise<OpenRouterModel[]> {
-  const apiKey = getApiKey()
+  const apiKey = getApiKey('models.list', context)
 
   const url = new URL(`${OPENROUTER_BASE}/models`)
   // Always require reasoning + stream + response_format (at minimum json_object)
@@ -544,16 +1039,7 @@ export async function listModels(
   }
   url.searchParams.set('supported_parameters', params.join(','))
 
-  const response = await fetch(url.toString(), {
-    headers: { Authorization: `Bearer ${apiKey}` },
-    signal: AbortSignal.timeout(10_000),
-  })
-
-  if (!response.ok) {
-    throw new Error(`Failed to list OpenRouter models (${response.status})`)
-  }
-
-  const data = (await response.json()) as {
+  const data = await fetchProviderJson<{
     data: Array<{
       architecture?: { modality?: string }
       context_length?: number
@@ -566,6 +1052,38 @@ export async function listModels(
       }
       supported_parameters?: string[]
     }>
+  }>(url.toString(), apiKey, 'models.list', context, 10_000)
+
+  if (!data || !Array.isArray(data.data)) {
+    throwInvalidProviderResponse('models.list', context)
+  }
+  if (
+    !data.data.every(
+      model =>
+        isRecord(model) &&
+        typeof model.id === 'string' &&
+        typeof model.name === 'string' &&
+        (model.architecture === undefined || isRecord(model.architecture)) &&
+        (model.pricing === undefined || isRecord(model.pricing)) &&
+        hasOptionalFiniteNumber(model, 'context_length') &&
+        (model.architecture === undefined ||
+          model.architecture.modality === undefined ||
+          typeof model.architecture.modality === 'string') &&
+        (model.pricing === undefined ||
+          ((model.pricing.completion === undefined ||
+            typeof model.pricing.completion === 'string') &&
+            (model.pricing.prompt === undefined ||
+              typeof model.pricing.prompt === 'string') &&
+            (model.pricing.reasoning === undefined ||
+              typeof model.pricing.reasoning === 'string'))) &&
+        (model.supported_parameters === undefined ||
+          (Array.isArray(model.supported_parameters) &&
+            model.supported_parameters.every(
+              parameter => typeof parameter === 'string',
+            ))),
+    )
+  ) {
+    throwInvalidProviderResponse('models.list', context)
   }
 
   return (data.data ?? []).map(m => ({
@@ -597,44 +1115,58 @@ export interface KeyInfo {
   usageDaily: number
 }
 
-export async function getKeyInfo(): Promise<KeyInfo> {
-  const apiKey = getApiKey()
+export async function getKeyInfo(
+  context: OpenRouterRequestContext = {},
+): Promise<KeyInfo> {
+  const apiKey = getApiKey('key.info', context)
   const mgmtKey = process.env.OPENROUTER_MGMT_API_KEY
 
   const creditsPromise = mgmtKey
-    ? fetch(`${OPENROUTER_BASE}/credits`, {
-        headers: { Authorization: `Bearer ${mgmtKey}` },
-        signal: AbortSignal.timeout(5_000),
-      }).catch(() => null)
+    ? fetchProviderJson<{
+        data: { total_credits?: number; total_usage?: number }
+      }>(`${OPENROUTER_BASE}/credits`, mgmtKey, 'credits', context, 5_000)
+        .then(data => {
+          if (
+            !isRecord(data) ||
+            !isRecord(data.data) ||
+            !hasOptionalFiniteNumber(data.data, 'total_credits') ||
+            !hasOptionalFiniteNumber(data.data, 'total_usage')
+          ) {
+            throwInvalidProviderResponse('credits', context)
+          }
+          return data
+        })
+        .catch(() => null)
     : Promise.resolve(null)
 
-  const [keyResponse, creditsResponse] = await Promise.all([
-    fetch(`${OPENROUTER_BASE}/auth/key`, {
-      headers: { Authorization: `Bearer ${apiKey}` },
-      signal: AbortSignal.timeout(5_000),
-    }),
+  const [keyData, creditsData] = await Promise.all([
+    fetchProviderJson<{
+      data: {
+        is_free_tier?: boolean
+        limit?: number | null
+        limit_remaining?: number | null
+        usage?: number
+        usage_daily?: number
+      }
+    }>(`${OPENROUTER_BASE}/auth/key`, apiKey, 'key.info', context, 5_000),
     creditsPromise,
   ])
 
-  if (!keyResponse.ok) {
-    throw new Error(`Failed to get OpenRouter key info (${keyResponse.status})`)
-  }
-
-  const keyData = (await keyResponse.json()) as {
-    data?: {
-      is_free_tier?: boolean
-      limit?: number | null
-      limit_remaining?: number | null
-      usage?: number
-      usage_daily?: number
-    }
+  if (
+    !isRecord(keyData) ||
+    !isRecord(keyData.data) ||
+    (keyData.data.is_free_tier !== undefined &&
+      typeof keyData.data.is_free_tier !== 'boolean') ||
+    !hasOptionalFiniteNumberOrNull(keyData.data, 'limit') ||
+    !hasOptionalFiniteNumberOrNull(keyData.data, 'limit_remaining') ||
+    !hasOptionalFiniteNumber(keyData.data, 'usage') ||
+    !hasOptionalFiniteNumber(keyData.data, 'usage_daily')
+  ) {
+    throwInvalidProviderResponse('key.info', context)
   }
 
   let totalCredits: number | null = null
-  if (creditsResponse?.ok) {
-    const creditsData = (await creditsResponse.json()) as {
-      data?: { total_credits?: number; total_usage?: number }
-    }
+  if (creditsData) {
     const purchased = creditsData.data?.total_credits
     const used = creditsData.data?.total_usage
     if (purchased != null) {
@@ -642,7 +1174,7 @@ export async function getKeyInfo(): Promise<KeyInfo> {
     }
   }
 
-  const d = keyData.data ?? {}
+  const d = keyData.data
   return {
     isFreeTier: d.is_free_tier ?? false,
     limit: d.limit ?? null,

--- a/lib/ai/openrouter-model-catalog.ts
+++ b/lib/ai/openrouter-model-catalog.ts
@@ -2,6 +2,7 @@ import {
   getDefaultModel,
   listModels,
   type OpenRouterModel,
+  type OpenRouterRequestContext,
 } from '@/lib/ai/openrouter-client'
 
 export const OPENROUTER_STRUCTURED_OUTPUTS_PARAMETER = 'structured_outputs'
@@ -16,6 +17,7 @@ export class OpenRouterModelCatalogError extends Error {
 }
 
 export interface OpenRouterModelCatalogOptions {
+  requestContext?: OpenRouterRequestContext
   supportedParameters?: string[]
 }
 
@@ -81,10 +83,14 @@ export async function listOpenRouterModelCatalog(
     ...(providerParameters ?? []),
     OPENROUTER_STRUCTURED_OUTPUTS_PARAMETER,
   ])
+  const loadModels = (parameters?: string[]): Promise<OpenRouterModel[]> =>
+    options.requestContext
+      ? listModels(parameters, options.requestContext)
+      : listModels(parameters)
 
   const [models, structuredModels] = await Promise.all([
-    listModels(providerParameters),
-    listModels(structuredFilter),
+    loadModels(providerParameters),
+    loadModels(structuredFilter),
   ])
   const enrichedModels = enrichModelCapabilities(models, structuredModels)
 
@@ -99,9 +105,10 @@ export async function listOpenRouterModelCatalog(
 
 export async function resolveOpenRouterModelCapabilities(
   model?: string,
+  requestContext?: OpenRouterRequestContext,
 ): Promise<OpenRouterModel> {
   const modelId = model || getDefaultModel()
-  const models = await listOpenRouterModelCatalog()
+  const models = await listOpenRouterModelCatalog({ requestContext })
   const resolved = models.find(candidate => candidate.id === modelId)
   if (!resolved) {
     throw new OpenRouterModelCatalogError(

--- a/lib/ai/openrouter-model-catalog.ts
+++ b/lib/ai/openrouter-model-catalog.ts
@@ -84,9 +84,7 @@ export async function listOpenRouterModelCatalog(
     OPENROUTER_STRUCTURED_OUTPUTS_PARAMETER,
   ])
   const loadModels = (parameters?: string[]): Promise<OpenRouterModel[]> =>
-    options.requestContext
-      ? listModels(parameters, options.requestContext)
-      : listModels(parameters)
+    listModels(parameters, options.requestContext)
 
   const [models, structuredModels] = await Promise.all([
     loadModels(providerParameters),

--- a/lib/ai/provider-errors.ts
+++ b/lib/ai/provider-errors.ts
@@ -1,0 +1,253 @@
+export const AI_PROVIDER_RESPONSE_LIMITS = {
+  errorBodyBytes: 16 * 1024,
+  jsonBodyBytes: 4 * 1024 * 1024,
+  sseAccumulatedBytes: 4 * 1024 * 1024,
+  sseFrameBytes: 256 * 1024,
+} as const
+
+export type AiProviderErrorCode =
+  | 'ai_provider_configuration_error'
+  | 'ai_provider_invalid_response'
+  | 'ai_provider_rate_limited'
+  | 'ai_provider_response_read_failed'
+  | 'ai_provider_response_too_large'
+  | 'ai_provider_timeout'
+  | 'ai_provider_unavailable'
+
+export type AiProviderOperation =
+  | 'chat.completions'
+  | 'credits'
+  | 'key.info'
+  | 'models.list'
+
+export interface AiProviderDiagnosticContext {
+  correlationId?: string
+  modelProvider?: string
+  requestId?: string
+}
+
+export type AiProviderContentTypeCategory =
+  | 'event-stream'
+  | 'json'
+  | 'missing'
+  | 'unexpected'
+
+export interface AiProviderErrorMetadata {
+  contentTypeCategory?: AiProviderContentTypeCategory
+  observedBytes?: number
+  providerCode?: string
+  truncated?: boolean
+  upstreamRequestId?: string
+}
+
+interface AiProviderErrorOptions extends AiProviderDiagnosticContext {
+  code: AiProviderErrorCode
+  metadata?: AiProviderErrorMetadata
+  operation: AiProviderOperation
+  status?: number
+}
+
+const AI_PROVIDER_ERROR_MESSAGES: Record<AiProviderErrorCode, string> = {
+  ai_provider_configuration_error: 'AI provider configuration is invalid',
+  ai_provider_invalid_response: 'AI provider returned an invalid response',
+  ai_provider_rate_limited: 'AI provider rate limit reached',
+  ai_provider_response_read_failed: 'AI provider response could not be read',
+  ai_provider_response_too_large: 'AI provider response was too large',
+  ai_provider_timeout: 'AI provider request timed out',
+  ai_provider_unavailable: 'AI provider is unavailable',
+}
+
+const recordedDiagnostics = new WeakSet<AiProviderError>()
+const SAFE_IDENTIFIER_PATTERN = /^[A-Za-z0-9._:/-]{1,128}$/
+const SAFE_PROVIDER_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/
+const SAFE_PROVIDER_CODE_PATTERN = /^[A-Za-z0-9._:-]{1,64}$/
+
+function boundedIdentifier(value: unknown): string | undefined {
+  return typeof value === 'string' && SAFE_IDENTIFIER_PATTERN.test(value)
+    ? value
+    : undefined
+}
+
+function boundedProvider(value: unknown): string | undefined {
+  return typeof value === 'string' && SAFE_PROVIDER_PATTERN.test(value)
+    ? value
+    : undefined
+}
+
+function boundedProviderCode(value: unknown): string | undefined {
+  return typeof value === 'string' && SAFE_PROVIDER_CODE_PATTERN.test(value)
+    ? value
+    : undefined
+}
+
+function boundedStatus(value: unknown): number | undefined {
+  return typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 100 &&
+    value <= 599
+    ? value
+    : undefined
+}
+
+function boundedObservedBytes(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : undefined
+}
+
+export class AiProviderError extends Error {
+  readonly code: AiProviderErrorCode
+  readonly correlationId?: string
+  readonly gateway = 'openrouter'
+  readonly metadata: AiProviderErrorMetadata
+  readonly modelProvider?: string
+  readonly operation: AiProviderOperation
+  readonly requestId?: string
+  readonly status?: number
+
+  constructor(options: AiProviderErrorOptions) {
+    super(AI_PROVIDER_ERROR_MESSAGES[options.code])
+    this.name = 'AiProviderError'
+    this.code = options.code
+    this.correlationId = boundedIdentifier(options.correlationId)
+    this.modelProvider = boundedProvider(options.modelProvider)
+    this.operation = options.operation
+    this.requestId = boundedIdentifier(options.requestId)
+    this.status = boundedStatus(options.status)
+    this.metadata = {
+      contentTypeCategory: options.metadata?.contentTypeCategory,
+      observedBytes: boundedObservedBytes(options.metadata?.observedBytes),
+      providerCode: boundedProviderCode(options.metadata?.providerCode),
+      truncated:
+        typeof options.metadata?.truncated === 'boolean'
+          ? options.metadata.truncated
+          : undefined,
+      upstreamRequestId: boundedIdentifier(options.metadata?.upstreamRequestId),
+    }
+  }
+}
+
+export class AiProviderCallerCancelledError extends Error {
+  constructor() {
+    super('AI provider request cancelled')
+    this.name = 'AiProviderCallerCancelledError'
+  }
+}
+
+export function isAiProviderError(error: unknown): error is AiProviderError {
+  return error instanceof AiProviderError
+}
+
+export function isAiProviderCallerCancelledError(
+  error: unknown,
+): error is AiProviderCallerCancelledError {
+  return error instanceof AiProviderCallerCancelledError
+}
+
+export function classifyAiProviderStatus(status: number): AiProviderErrorCode {
+  if (status === 429) return 'ai_provider_rate_limited'
+  if (status === 408 || status === 504) return 'ai_provider_timeout'
+  if (status >= 400 && status < 500) {
+    return 'ai_provider_configuration_error'
+  }
+  return 'ai_provider_unavailable'
+}
+
+export function createAiProviderError(
+  options: AiProviderErrorOptions,
+): AiProviderError {
+  return new AiProviderError(options)
+}
+
+export function recordAiProviderError(error: AiProviderError): void {
+  if (recordedDiagnostics.has(error)) return
+  recordedDiagnostics.add(error)
+  const payload = {
+    channel: 'ai-provider-observability',
+    event: 'ai_provider.request_failed',
+    code: error.code,
+    gateway: error.gateway,
+    operation: error.operation,
+    ...(error.modelProvider ? { model_provider: error.modelProvider } : {}),
+    ...(error.status ? { upstream_status: error.status } : {}),
+    ...(error.requestId ? { request_id: error.requestId } : {}),
+    ...(error.correlationId ? { correlation_id: error.correlationId } : {}),
+    ...(error.metadata.upstreamRequestId
+      ? { upstream_request_id: error.metadata.upstreamRequestId }
+      : {}),
+    ...(error.metadata.providerCode
+      ? { provider_code: error.metadata.providerCode }
+      : {}),
+    ...(error.metadata.contentTypeCategory
+      ? { content_type_category: error.metadata.contentTypeCategory }
+      : {}),
+    ...(error.metadata.observedBytes !== undefined
+      ? { observed_byte_count: error.metadata.observedBytes }
+      : {}),
+    ...(error.metadata.truncated !== undefined
+      ? { truncated: error.metadata.truncated }
+      : {}),
+  }
+
+  // eslint-disable-next-line no-console
+  console.error(JSON.stringify(payload))
+}
+
+export function normalizeAiProviderError(
+  error: unknown,
+  fallback: Omit<AiProviderErrorOptions, 'code'> & {
+    code?: AiProviderErrorCode
+  },
+): AiProviderError {
+  const providerError = isAiProviderError(error)
+    ? error
+    : createAiProviderError({
+        ...fallback,
+        code: fallback.code ?? 'ai_provider_unavailable',
+      })
+  recordAiProviderError(providerError)
+  return providerError
+}
+
+export function aiProviderErrorPayload(error: AiProviderError): {
+  code: AiProviderErrorCode
+  error: string
+} {
+  return { code: error.code, error: error.message }
+}
+
+export function aiProviderStreamError(error: AiProviderError): {
+  code: AiProviderErrorCode
+  message: string
+  phase: 'error'
+} {
+  return { code: error.code, message: error.message, phase: 'error' }
+}
+
+export function getAiProviderContentTypeCategory(
+  contentType: string | null,
+): AiProviderContentTypeCategory {
+  if (!contentType) return 'missing'
+  const mediaType = contentType.split(';', 1)[0]?.trim().toLowerCase()
+  if (mediaType === 'text/event-stream') return 'event-stream'
+  if (mediaType === 'application/json' || mediaType?.endsWith('+json')) {
+    return 'json'
+  }
+  return 'unexpected'
+}
+
+export function getSafeUpstreamRequestId(headers: Headers): string | undefined {
+  return boundedIdentifier(
+    headers.get('x-request-id') ?? headers.get('x-openrouter-request-id'),
+  )
+}
+
+export function getSafeProviderCode(value: unknown): string | undefined {
+  if (!value || typeof value !== 'object') return undefined
+  const record = value as Record<string, unknown>
+  const nested =
+    record.error && typeof record.error === 'object'
+      ? (record.error as Record<string, unknown>)
+      : undefined
+  return boundedProviderCode(record.code) ?? boundedProviderCode(nested?.code)
+}

--- a/lib/ai/provider-response.ts
+++ b/lib/ai/provider-response.ts
@@ -1,0 +1,196 @@
+import {
+  AI_PROVIDER_RESPONSE_LIMITS,
+  type AiProviderDiagnosticContext,
+  type AiProviderError,
+  type AiProviderOperation,
+  classifyAiProviderStatus,
+  createAiProviderError,
+  getAiProviderContentTypeCategory,
+  getSafeProviderCode,
+  getSafeUpstreamRequestId,
+  isAiProviderError,
+} from '@/lib/ai/provider-errors'
+
+interface ProviderResponseOptions extends AiProviderDiagnosticContext {
+  operation: AiProviderOperation
+}
+
+interface BoundedBody {
+  bytes: Uint8Array
+  observedBytes: number
+}
+
+async function readBoundedBody(
+  response: Response,
+  limit: number,
+  options: ProviderResponseOptions,
+): Promise<BoundedBody> {
+  if (!response.body) {
+    throw createAiProviderError({
+      ...options,
+      code: 'ai_provider_invalid_response',
+      metadata: {
+        contentTypeCategory: getAiProviderContentTypeCategory(
+          response.headers.get('content-type'),
+        ),
+        upstreamRequestId: getSafeUpstreamRequestId(response.headers),
+      },
+      status: response.status,
+    })
+  }
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let observedBytes = 0
+  try {
+    for (;;) {
+      let result: ReadableStreamReadResult<Uint8Array>
+      try {
+        result = await reader.read()
+      } catch {
+        throw createAiProviderError({
+          ...options,
+          code: 'ai_provider_response_read_failed',
+          metadata: {
+            contentTypeCategory: getAiProviderContentTypeCategory(
+              response.headers.get('content-type'),
+            ),
+            observedBytes,
+            upstreamRequestId: getSafeUpstreamRequestId(response.headers),
+          },
+          status: response.status,
+        })
+      }
+      if (result.done) break
+      observedBytes += result.value.byteLength
+      if (observedBytes > limit) {
+        await reader.cancel().catch(() => undefined)
+        throw createAiProviderError({
+          ...options,
+          code: 'ai_provider_response_too_large',
+          metadata: {
+            contentTypeCategory: getAiProviderContentTypeCategory(
+              response.headers.get('content-type'),
+            ),
+            observedBytes,
+            truncated: true,
+            upstreamRequestId: getSafeUpstreamRequestId(response.headers),
+          },
+          status: response.status,
+        })
+      }
+      chunks.push(result.value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  const bytes = new Uint8Array(observedBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return { bytes, observedBytes }
+}
+
+function decodeUtf8(bytes: Uint8Array): string {
+  return new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+}
+
+export async function readAiProviderErrorResponse(
+  response: Response,
+  options: ProviderResponseOptions,
+): Promise<AiProviderError> {
+  const contentTypeCategory = getAiProviderContentTypeCategory(
+    response.headers.get('content-type'),
+  )
+  const baseMetadata = {
+    contentTypeCategory,
+    upstreamRequestId: getSafeUpstreamRequestId(response.headers),
+  }
+
+  if (contentTypeCategory !== 'json') {
+    return createAiProviderError({
+      ...options,
+      code: classifyAiProviderStatus(response.status),
+      metadata: baseMetadata,
+      status: response.status,
+    })
+  }
+
+  try {
+    const body = await readBoundedBody(
+      response,
+      AI_PROVIDER_RESPONSE_LIMITS.errorBodyBytes,
+      options,
+    )
+    let providerCode: string | undefined
+    try {
+      providerCode = getSafeProviderCode(
+        JSON.parse(decodeUtf8(body.bytes)) as unknown,
+      )
+    } catch {
+      providerCode = undefined
+    }
+    return createAiProviderError({
+      ...options,
+      code: classifyAiProviderStatus(response.status),
+      metadata: {
+        ...baseMetadata,
+        observedBytes: body.observedBytes,
+        providerCode,
+        truncated: false,
+      },
+      status: response.status,
+    })
+  } catch (error) {
+    if (isAiProviderError(error)) return error
+    return createAiProviderError({
+      ...options,
+      code: 'ai_provider_response_read_failed',
+      metadata: baseMetadata,
+      status: response.status,
+    })
+  }
+}
+
+export async function readAiProviderJson<T>(
+  response: Response,
+  options: ProviderResponseOptions,
+): Promise<T> {
+  const contentTypeCategory = getAiProviderContentTypeCategory(
+    response.headers.get('content-type'),
+  )
+  if (contentTypeCategory !== 'json') {
+    throw createAiProviderError({
+      ...options,
+      code: 'ai_provider_invalid_response',
+      metadata: {
+        contentTypeCategory,
+        upstreamRequestId: getSafeUpstreamRequestId(response.headers),
+      },
+      status: response.status,
+    })
+  }
+
+  const body = await readBoundedBody(
+    response,
+    AI_PROVIDER_RESPONSE_LIMITS.jsonBodyBytes,
+    options,
+  )
+  try {
+    return JSON.parse(decodeUtf8(body.bytes)) as T
+  } catch {
+    throw createAiProviderError({
+      ...options,
+      code: 'ai_provider_invalid_response',
+      metadata: {
+        contentTypeCategory,
+        observedBytes: body.observedBytes,
+        upstreamRequestId: getSafeUpstreamRequestId(response.headers),
+      },
+      status: response.status,
+    })
+  }
+}

--- a/lib/ai/provider-response.ts
+++ b/lib/ai/provider-response.ts
@@ -111,6 +111,7 @@ export async function readAiProviderErrorResponse(
   }
 
   if (contentTypeCategory !== 'json') {
+    await response.body?.cancel().catch(() => undefined)
     return createAiProviderError({
       ...options,
       code: classifyAiProviderStatus(response.status),
@@ -163,6 +164,7 @@ export async function readAiProviderJson<T>(
     response.headers.get('content-type'),
   )
   if (contentTypeCategory !== 'json') {
+    await response.body?.cancel().catch(() => undefined)
     throw createAiProviderError({
       ...options,
       code: 'ai_provider_invalid_response',

--- a/lib/http/safe-errors.ts
+++ b/lib/http/safe-errors.ts
@@ -2,8 +2,6 @@ import { HSA_ID_PATTERN_SOURCE } from '@/lib/auth/hsa-id'
 
 export const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal server error'
 export const AI_PROVIDER_UNAVAILABLE_MESSAGE = 'AI provider is unavailable'
-export const AI_CREDIT_INFORMATION_UNAVAILABLE_MESSAGE =
-  'AI credit information is unavailable'
 
 interface SafeErrorLogValue {
   message: string

--- a/tests/unit/ai-credits-route.test.ts
+++ b/tests/unit/ai-credits-route.test.ts
@@ -190,7 +190,8 @@ describe('GET /api/ai/credits', () => {
 
       expect(response.status).toBe(503)
       await expect(response.json()).resolves.toEqual({
-        error: 'AI credit information is unavailable',
+        code: 'ai_provider_unavailable',
+        error: 'AI provider is unavailable',
       })
       expect(JSON.stringify(consoleErrorSpy.mock.calls)).not.toContain(
         'sk-or-v1-secret',

--- a/tests/unit/ai-generate-requirements-route.test.ts
+++ b/tests/unit/ai-generate-requirements-route.test.ts
@@ -712,11 +712,40 @@ describe('POST /api/ai/generate-requirement-import', () => {
     try {
       const response = await POST(makeRequest())
       const body = await response.text()
-      expect(response.status).toBe(503)
+      expect(response.status).toBe(429)
       expect(body).toContain('event: error')
       expect(body).toContain('ai_provider_rate_limited')
       expect(body).toContain('AI provider rate limit reached')
       expect(body).not.toContain('provider account secret')
+      expect(parseCapacityEvents(consoleErrorSpy)[0]).toMatchObject({
+        status_code: 429,
+      })
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
+  it('records a terminal capacity failure when provider setup is cancelled', async () => {
+    routeState.generateChatStream.mockReturnValue({
+      [Symbol.asyncIterator]() {
+        return this
+      },
+      next: vi.fn().mockResolvedValue({ done: true, value: undefined }),
+    })
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    try {
+      const response = await POST(makeRequest())
+
+      expect(response.status).toBe(499)
+      expect(await response.text()).toBe('')
+      expect(parseCapacityEvents(consoleErrorSpy)[0]).toMatchObject({
+        event: 'capacity.operation.failed',
+        operation: 'ai.generate-requirement-import',
+        status_code: 499,
+      })
     } finally {
       consoleErrorSpy.mockRestore()
     }

--- a/tests/unit/ai-generate-requirements-route.test.ts
+++ b/tests/unit/ai-generate-requirements-route.test.ts
@@ -212,11 +212,12 @@ describe('POST /api/ai/generate-requirement-import', () => {
     expect(text).not.toContain('unvalidated draft content')
   })
 
-  it('streams validation_error when model output does not match import schema', async () => {
+  it('streams a stable invalid-response error when model output does not match the schema', async () => {
     routeState.generateChatStream.mockImplementation(async function* () {
       yield {
         phase: 'done',
-        rawContent: '{"requirements":[]}',
+        rawContent:
+          '{"requirements":[],"echo":"Ada Lovelace ada@example.test payroll prompt"}',
         stats: {
           completionTokens: 7,
           cost: 0.02,
@@ -224,16 +225,18 @@ describe('POST /api/ai/generate-requirement-import', () => {
           reasoningTokens: 0,
           totalTokens: 10,
         },
-        thinking: '',
+        thinking: 'Prompt echo for Ada Lovelace at ada@example.test',
       }
     })
 
     const response = await POST(makeRequest())
     const text = await response.text()
 
-    expect(text).toContain('event: validation_error')
+    expect(text).toContain('event: error')
     expect(text).not.toContain('event: done')
-    expect(text).toContain('Generated JSON did not match')
+    expect(text).toContain('ai_provider_invalid_response')
+    expect(text).toContain('AI provider returned an invalid response')
+    expect(text).not.toMatch(/Ada Lovelace|ada@example\.test|payroll prompt/)
   })
 
   it('streams provider unavailable when import instruction loading fails before generation starts', async () => {
@@ -505,8 +508,8 @@ describe('POST /api/ai/generate-requirement-import', () => {
       const response = await POST(makeRequest())
       const text = await response.text()
 
-      expect(text).toContain('event: thinking')
-      expect(text).toContain('Authorization: ')
+      expect(text).not.toContain('event: thinking')
+      expect(text).not.toContain('Authorization: ')
       expect(text).toContain('event: error')
       expect(text).toContain(
         'The AI response was blocked by the AI safety filter: System-adjacent content leakage. Revise the request and try again.',
@@ -697,8 +700,8 @@ describe('POST /api/ai/generate-requirement-import', () => {
   it('sanitizes provider error events without returning their cause', async () => {
     routeState.generateChatStream.mockImplementation(async function* () {
       yield {
-        cause: new Error('provider account secret'),
-        message: 'provider account secret',
+        code: 'ai_provider_rate_limited',
+        message: 'AI provider rate limit reached',
         phase: 'error',
       }
     })
@@ -709,8 +712,10 @@ describe('POST /api/ai/generate-requirement-import', () => {
     try {
       const response = await POST(makeRequest())
       const body = await response.text()
+      expect(response.status).toBe(503)
       expect(body).toContain('event: error')
-      expect(body).toContain('AI provider is unavailable')
+      expect(body).toContain('ai_provider_rate_limited')
+      expect(body).toContain('AI provider rate limit reached')
       expect(body).not.toContain('provider account secret')
     } finally {
       consoleErrorSpy.mockRestore()
@@ -735,7 +740,7 @@ describe('POST /api/ai/generate-requirement-import', () => {
     }
   })
 
-  it('reports malformed provider JSON as a localized validation failure', async () => {
+  it('reports malformed provider JSON as a stable invalid-response error', async () => {
     routeState.generateChatStream.mockImplementation(async function* () {
       yield {
         phase: 'done',
@@ -757,9 +762,10 @@ describe('POST /api/ai/generate-requirement-import', () => {
     try {
       const response = await POST(makeRequest())
       const body = await response.text()
-      expect(body).toContain('event: validation_error')
-      expect(body).toContain('invalid_json')
-      expect(body).toContain('Model output was not valid JSON.')
+      expect(body).toContain('event: error')
+      expect(body).toContain('ai_provider_invalid_response')
+      expect(body).toContain('AI provider returned an invalid response')
+      expect(body).not.toContain('{not-json')
     } finally {
       consoleErrorSpy.mockRestore()
     }
@@ -770,7 +776,11 @@ describe('POST /api/ai/generate-requirement-import', () => {
       yield { chunk: 'Checking contract', phase: 'thinking' }
       yield { chunk: '{', phase: 'generating' }
       yield { chunk: '"requirements":[]}', phase: 'generating' }
-      yield { message: 'provider unavailable', phase: 'error' }
+      yield {
+        code: 'ai_provider_unavailable',
+        message: 'AI provider is unavailable',
+        phase: 'error',
+      }
     })
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
@@ -789,7 +799,8 @@ describe('POST /api/ai/generate-requirement-import', () => {
       const body = await response.text()
 
       expect(body.match(/event: generating/g)).toHaveLength(1)
-      expect(body).toContain('event: thinking')
+      expect(body).not.toContain('event: thinking')
+      expect(body).not.toContain('Checking contract')
       expect(body).toContain('AI provider is unavailable')
       expect(body).not.toContain('provider unavailable')
     } finally {
@@ -799,7 +810,11 @@ describe('POST /api/ai/generate-requirement-import', () => {
 
   it('throttles repeated generation before loading instructions or calling the provider', async () => {
     routeState.generateChatStream.mockImplementation(async function* () {
-      yield { message: 'provider unavailable', phase: 'error' }
+      yield {
+        code: 'ai_provider_unavailable',
+        message: 'AI provider is unavailable',
+        phase: 'error',
+      }
     })
     const consoleErrorSpy = vi
       .spyOn(console, 'error')

--- a/tests/unit/ai-models-route.test.ts
+++ b/tests/unit/ai-models-route.test.ts
@@ -215,8 +215,16 @@ describe('GET /api/ai/models', () => {
       models: { id: string; supportedParameters: string[] }[]
     }
 
-    expect(listModels).toHaveBeenNthCalledWith(1, undefined)
-    expect(listModels).toHaveBeenNthCalledWith(2, ['structured_outputs'])
+    const requestContext = {
+      correlationId: 'workflow-models',
+      requestId: 'request-models',
+    }
+    expect(listModels).toHaveBeenNthCalledWith(1, undefined, requestContext)
+    expect(listModels).toHaveBeenNthCalledWith(
+      2,
+      ['structured_outputs'],
+      requestContext,
+    )
     expect(data.models).toHaveLength(1)
     expect(data.models[0].id).toBe('openai/gpt-5-vision')
     expect(data.models[0].supportedParameters).toContain('vision')
@@ -242,10 +250,14 @@ describe('GET /api/ai/models', () => {
 
       expect(response.status).toBe(503)
       const data = (await response.json()) as {
-        models: unknown[]
+        code: string
         error: string
       }
-      expect(data.models).toEqual([])
+      expect(data).toEqual({
+        code: 'ai_provider_unavailable',
+        error: 'AI provider is unavailable',
+      })
+      expect(data.code).toBe('ai_provider_unavailable')
       expect(data.error).toBe('AI provider is unavailable')
       expect(JSON.stringify(data)).not.toMatch(/sk-or-v1|SELECT/)
       expect(JSON.stringify(consoleErrorSpy.mock.calls)).not.toMatch(
@@ -267,9 +279,16 @@ describe('GET /api/ai/models', () => {
     )
 
     // First call: base list with requested params
-    expect(listModels).toHaveBeenCalledWith(['tools'])
+    const requestContext = {
+      correlationId: 'workflow-models',
+      requestId: 'request-models',
+    }
+    expect(listModels).toHaveBeenCalledWith(['tools'], requestContext)
     // Second call: same params plus structured_outputs
-    expect(listModels).toHaveBeenCalledWith(['tools', 'structured_outputs'])
+    expect(listModels).toHaveBeenCalledWith(
+      ['tools', 'structured_outputs'],
+      requestContext,
+    )
   })
 
   it('throttles repeated refresh requests', async () => {

--- a/tests/unit/ai-repair-requirement-import-json-route.test.ts
+++ b/tests/unit/ai-repair-requirement-import-json-route.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { POST } from '@/app/api/ai/repair-requirement-import-json/route'
+import { createAiProviderError } from '@/lib/ai/provider-errors'
 import * as aiSafety from '@/lib/ai/safety'
 import { clearAiSafetyRuntimeSettingsCacheForTests } from '@/lib/dal/ai-settings'
 import { clearInMemoryThrottleForTests } from '@/lib/observability/throttle'
@@ -173,7 +174,7 @@ describe('POST /api/ai/repair-requirement-import-json', () => {
     }
   })
 
-  it('returns 422 with schema issues when repaired JSON is invalid', async () => {
+  it('returns a stable invalid-response error when repaired JSON is invalid', async () => {
     routeState.generateChat.mockResolvedValue({
       content: { requirements: [] },
       stats: {
@@ -189,15 +190,11 @@ describe('POST /api/ai/repair-requirement-import-json', () => {
     const response = await POST(makeRequest())
     const body = await response.json()
 
-    expect(response.status).toBe(422)
-    expect(body).toMatchObject({
-      error: 'Repaired JSON did not match the requirement import schema.',
+    expect(response.status).toBe(503)
+    expect(body).toEqual({
+      code: 'ai_provider_invalid_response',
+      error: 'AI provider returned an invalid response',
     })
-    expect(body.issues).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ path: expect.any(String) }),
-      ]),
-    )
   })
 
   it('blocks unsafe repair input before provider use', async () => {
@@ -348,7 +345,10 @@ describe('POST /api/ai/repair-requirement-import-json', () => {
       const body = await response.json()
 
       expect(response.status).toBe(503)
-      expect(body).toEqual({ error: 'AI provider is unavailable' })
+      expect(body).toEqual({
+        code: 'ai_provider_unavailable',
+        error: 'AI provider is unavailable',
+      })
       expect(routeState.generateChat).not.toHaveBeenCalled()
 
       const securityEvent = parseSecurityAuditEvents(consoleInfoSpy)[0]
@@ -380,6 +380,7 @@ describe('POST /api/ai/repair-requirement-import-json', () => {
 
     expect(response.status).toBe(503)
     await expect(response.json()).resolves.toEqual({
+      code: 'ai_provider_unavailable',
       error: 'AI provider is unavailable',
     })
     expect(routeState.generateChat).not.toHaveBeenCalled()
@@ -398,6 +399,7 @@ describe('POST /api/ai/repair-requirement-import-json', () => {
       const response = await POST(makeRequest())
       expect(response.status).toBe(503)
       await expect(response.json()).resolves.toEqual({
+        code: 'ai_provider_unavailable',
         error: 'AI provider is unavailable',
       })
       expect(routeState.generateChat).not.toHaveBeenCalled()
@@ -429,6 +431,7 @@ describe('POST /api/ai/repair-requirement-import-json', () => {
       const response = await POST(makeRequest())
       expect(response.status).toBe(503)
       await expect(response.json()).resolves.toEqual({
+        code: 'ai_provider_unavailable',
         error: 'AI provider is unavailable',
       })
     } finally {
@@ -448,6 +451,33 @@ describe('POST /api/ai/repair-requirement-import-json', () => {
       const body = JSON.stringify(await response.json())
       expect(body).toContain('AI provider is unavailable')
       expect(body).not.toContain('provider secret')
+      expect(JSON.stringify(consoleErrorSpy.mock.calls)).not.toContain(
+        'provider secret',
+      )
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
+  it('returns the stable reason code from typed provider failures', async () => {
+    routeState.generateChat.mockRejectedValue(
+      createAiProviderError({
+        code: 'ai_provider_rate_limited',
+        operation: 'chat.completions',
+        status: 429,
+      }),
+    )
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    try {
+      const response = await POST(makeRequest())
+      expect(response.status).toBe(503)
+      await expect(response.json()).resolves.toEqual({
+        code: 'ai_provider_rate_limited',
+        error: 'AI provider rate limit reached',
+      })
     } finally {
       consoleErrorSpy.mockRestore()
     }

--- a/tests/unit/ai-repair-requirement-import-json-route.test.ts
+++ b/tests/unit/ai-repair-requirement-import-json-route.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { POST } from '@/app/api/ai/repair-requirement-import-json/route'
-import { createAiProviderError } from '@/lib/ai/provider-errors'
+import {
+  AiProviderCallerCancelledError,
+  createAiProviderError,
+} from '@/lib/ai/provider-errors'
 import * as aiSafety from '@/lib/ai/safety'
 import { clearAiSafetyRuntimeSettingsCacheForTests } from '@/lib/dal/ai-settings'
 import { clearInMemoryThrottleForTests } from '@/lib/observability/throttle'
@@ -12,6 +15,7 @@ import { parseSecurityAuditEvents } from '@/tests/helpers/security-audit-events'
 import { parseSecurityForensicsEvents } from '@/tests/helpers/security-forensics-events'
 
 const routeState = vi.hoisted(() => ({
+  buildImportInstruction: vi.fn(),
   generateChat: vi.fn(),
   getRequestSqlServerDataSource: vi.fn(),
   query: vi.fn(),
@@ -29,7 +33,7 @@ vi.mock('@/lib/requirements/server', async importOriginal => {
     ...original,
     createRequirementsRuntime: vi.fn(() => ({
       service: {
-        buildImportInstruction: vi.fn(async () => '# Import instruction'),
+        buildImportInstruction: routeState.buildImportInstruction,
       },
     })),
   }
@@ -86,6 +90,7 @@ describe('POST /api/ai/repair-requirement-import-json', () => {
       query: routeState.query,
     })
     routeState.query.mockResolvedValue([])
+    routeState.buildImportInstruction.mockResolvedValue('# Import instruction')
     routeState.resolveOpenRouterModelCapabilities.mockResolvedValue({
       contextLength: 200000,
       id: 'anthropic/claude-sonnet-4',
@@ -454,6 +459,75 @@ describe('POST /api/ai/repair-requirement-import-json', () => {
       expect(JSON.stringify(consoleErrorSpy.mock.calls)).not.toContain(
         'provider secret',
       )
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
+  it('attributes model lookup failures to the catalog operation', async () => {
+    routeState.resolveOpenRouterModelCapabilities.mockRejectedValue(
+      new Error('catalog unavailable'),
+    )
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    try {
+      const response = await POST(makeRequest())
+      const logged = JSON.stringify(consoleErrorSpy.mock.calls)
+
+      expect(response.status).toBe(503)
+      expect(logged).toContain('ai-provider-observability')
+      expect(logged).toContain('models.list')
+      expect(logged).not.toContain('chat.completions')
+      expect(routeState.buildImportInstruction).not.toHaveBeenCalled()
+      expect(routeState.generateChat).not.toHaveBeenCalled()
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
+  it('keeps instruction loading failures out of provider diagnostics', async () => {
+    routeState.buildImportInstruction.mockRejectedValue(
+      new Error('database unavailable'),
+    )
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    try {
+      const response = await POST(makeRequest())
+      const logged = JSON.stringify(consoleErrorSpy.mock.calls)
+
+      expect(response.status).toBe(503)
+      expect(logged).toContain(
+        'AI requirement import repair instruction loading failed',
+      )
+      expect(logged).not.toContain('ai-provider-observability')
+      expect(routeState.generateChat).not.toHaveBeenCalled()
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
+  it('records a terminal capacity failure for caller cancellation', async () => {
+    routeState.generateChat.mockRejectedValue(
+      new AiProviderCallerCancelledError(),
+    )
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+
+    try {
+      const response = await POST(makeRequest())
+
+      expect(response.status).toBe(499)
+      expect(await response.text()).toBe('')
+      expect(parseCapacityEvents(consoleErrorSpy)[0]).toMatchObject({
+        event: 'capacity.operation.failed',
+        operation: 'ai.repair-requirement-import-json',
+        status_code: 499,
+      })
     } finally {
       consoleErrorSpy.mockRestore()
     }

--- a/tests/unit/openrouter-client.test.ts
+++ b/tests/unit/openrouter-client.test.ts
@@ -12,6 +12,26 @@ import {
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
+function jsonResponse(data: unknown, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers)
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
+  return new Response(JSON.stringify(data), { ...init, headers })
+}
+
+function streamResponseWithReader(reader: {
+  read: () => Promise<unknown>
+  releaseLock: () => void
+}): Response {
+  const response = new Response(new ReadableStream<Uint8Array>(), {
+    headers: { 'Content-Type': 'text/event-stream' },
+  })
+  if (!response.body) throw new Error('Expected response body')
+  vi.spyOn(response.body, 'getReader').mockReturnValue(reader as never)
+  return response
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   vi.stubEnv('OPENROUTER_API_KEY', 'sk-or-v1-test-key')
@@ -219,18 +239,16 @@ describe('generateChat (non-streaming)', () => {
 
   it('rejects malformed non-streaming response shapes', async () => {
     mockFetch
-      .mockResolvedValueOnce({ json: async () => null, ok: true })
-      .mockResolvedValueOnce({
-        json: async () => ({ choices: [{ message: { content: 42 } }] }),
-        ok: true,
-      })
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(jsonResponse(null))
+      .mockResolvedValueOnce(
+        jsonResponse({ choices: [{ message: { content: 42 } }] }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
           choices: [{ message: { content: '{}' } }],
           usage: { completion_tokens: 'many' },
         }),
-        ok: true,
-      })
+      )
 
     for (let attempt = 0; attempt < 3; attempt += 1) {
       await expect(generateChat({ messages: [] })).rejects.toMatchObject({
@@ -239,8 +257,8 @@ describe('generateChat (non-streaming)', () => {
     }
   })
   it('sends correct request to OpenRouter', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
         choices: [
           {
             message: {
@@ -256,8 +274,7 @@ describe('generateChat (non-streaming)', () => {
           prompt_tokens: 50,
         },
       }),
-      ok: true,
-    })
+    )
 
     const result = await generateChat<{ requirements: unknown[] }>({
       messages: [
@@ -295,8 +312,8 @@ describe('generateChat (non-streaming)', () => {
   })
 
   it('reads non-streaming reasoning_details when reasoning is not present', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
         choices: [
           {
             message: {
@@ -311,8 +328,7 @@ describe('generateChat (non-streaming)', () => {
           },
         ],
       }),
-      ok: true,
-    })
+    )
 
     const result = await generateChat<{ requirements: unknown[] }>({
       messages: [],
@@ -322,8 +338,8 @@ describe('generateChat (non-streaming)', () => {
   })
 
   it('ignores malformed reasoning details and joins text and summary details', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
         choices: [
           {
             message: {
@@ -338,8 +354,7 @@ describe('generateChat (non-streaming)', () => {
           },
         ],
       }),
-      ok: true,
-    })
+    )
 
     const result = await generateChat<{ requirements: unknown[] }>({
       messages: [{ content: 'Generate', role: 'user' }],
@@ -428,8 +443,8 @@ describe('generateChat (non-streaming)', () => {
   })
 
   it('does not duplicate non-streaming reasoning when reasoning_details is also present', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
         choices: [
           {
             message: {
@@ -445,8 +460,7 @@ describe('generateChat (non-streaming)', () => {
           },
         ],
       }),
-      ok: true,
-    })
+    )
 
     const result = await generateChat<{ requirements: unknown[] }>({
       messages: [],
@@ -456,12 +470,11 @@ describe('generateChat (non-streaming)', () => {
   })
 
   it('uses custom model when provided', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
         choices: [{ message: { content: '{"requirements":[]}' } }],
       }),
-      ok: true,
-    })
+    )
 
     await generateChat({ messages: [], model: 'google/gemini-2.5-flash' })
 
@@ -488,12 +501,11 @@ describe('generateChat (non-streaming)', () => {
   })
 
   it('sends json_object when known model capabilities do not include structured_outputs', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
         choices: [{ message: { content: '{"requirements":[]}' } }],
       }),
-      ok: true,
-    })
+    )
 
     await generateChat({
       format: {
@@ -511,12 +523,11 @@ describe('generateChat (non-streaming)', () => {
   })
 
   it('sends json_schema when model supports structured_outputs', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
         choices: [{ message: { content: '{"requirements":[]}' } }],
       }),
-      ok: true,
-    })
+    )
 
     await generateChat({
       format: {
@@ -534,12 +545,11 @@ describe('generateChat (non-streaming)', () => {
   })
 
   it('sends json_object when model supports response_format but not structured_outputs', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
         choices: [{ message: { content: '{"requirements":[]}' } }],
       }),
-      ok: true,
-    })
+    )
 
     await generateChat({
       format: {
@@ -557,11 +567,7 @@ describe('generateChat (non-streaming)', () => {
   })
 
   it('throws on non-OK response', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      text: async () => 'Internal error',
-    })
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 500 }))
 
     await expect(generateChat({ messages: [] })).rejects.toMatchObject({
       code: 'ai_provider_unavailable',
@@ -569,12 +575,11 @@ describe('generateChat (non-streaming)', () => {
   })
 
   it('throws on invalid JSON content', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
         choices: [{ message: { content: 'not json' } }],
       }),
-      ok: true,
-    })
+    )
 
     await expect(generateChat({ messages: [] })).rejects.toMatchObject({
       code: 'ai_provider_invalid_response',
@@ -697,32 +702,16 @@ describe('generateChatStream', () => {
 
   it('rejects malformed SSE JSON and payload shapes', async () => {
     mockFetch
-      .mockResolvedValueOnce({
-        body: {
-          getReader: () => ({
-            read: vi.fn().mockResolvedValueOnce({
-              done: false,
-              value: new TextEncoder().encode('data: {malformed\n\n'),
-            }),
-            releaseLock: vi.fn(),
-          }),
-        },
-        ok: true,
-        status: 200,
-      })
-      .mockResolvedValueOnce({
-        body: {
-          getReader: () => ({
-            read: vi.fn().mockResolvedValueOnce({
-              done: false,
-              value: new TextEncoder().encode('data: null\n\n'),
-            }),
-            releaseLock: vi.fn(),
-          }),
-        },
-        ok: true,
-        status: 200,
-      })
+      .mockResolvedValueOnce(
+        new Response('data: {malformed\n\n', {
+          headers: { 'Content-Type': 'text/event-stream' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response('data: null\n\n', {
+          headers: { 'Content-Type': 'text/event-stream' },
+        }),
+      )
 
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const events = []
@@ -779,10 +768,7 @@ describe('generateChatStream', () => {
       releaseLock: vi.fn(),
     }
 
-    mockFetch.mockResolvedValueOnce({
-      body: { getReader: () => mockReader },
-      ok: true,
-    })
+    mockFetch.mockResolvedValueOnce(streamResponseWithReader(mockReader))
 
     const events = []
     for await (const event of generateChatStream({ messages: [] })) {
@@ -815,11 +801,7 @@ describe('generateChatStream', () => {
   })
 
   it('yields error on non-OK response', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 503,
-      text: async () => 'Service unavailable with sk-or-v1-secret',
-    })
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 503 }))
 
     const events = []
     for await (const event of generateChatStream({ messages: [] })) {
@@ -855,10 +837,7 @@ describe('generateChatStream', () => {
       releaseLock: vi.fn(),
     }
 
-    mockFetch.mockResolvedValueOnce({
-      body: { getReader: () => mockReader },
-      ok: true,
-    })
+    mockFetch.mockResolvedValueOnce(streamResponseWithReader(mockReader))
 
     const events = []
     for await (const event of generateChatStream({ messages: [] })) {
@@ -890,10 +869,7 @@ describe('generateChatStream', () => {
       releaseLock: vi.fn(),
     }
 
-    mockFetch.mockResolvedValueOnce({
-      body: { getReader: () => mockReader },
-      ok: true,
-    })
+    mockFetch.mockResolvedValueOnce(streamResponseWithReader(mockReader))
 
     const events = []
     for await (const event of generateChatStream({ messages: [] })) {
@@ -946,10 +922,7 @@ describe('generateChatStream', () => {
       releaseLock: vi.fn(),
     }
 
-    mockFetch.mockResolvedValueOnce({
-      body: { getReader: () => mockReader },
-      ok: true,
-    })
+    mockFetch.mockResolvedValueOnce(streamResponseWithReader(mockReader))
 
     const events = []
     for await (const event of generateChatStream({ messages: [] })) {
@@ -991,10 +964,7 @@ describe('generateChatStream', () => {
       releaseLock: vi.fn(),
     }
 
-    mockFetch.mockResolvedValueOnce({
-      body: { getReader: () => mockReader },
-      ok: true,
-    })
+    mockFetch.mockResolvedValueOnce(streamResponseWithReader(mockReader))
 
     const events = []
     for await (const event of generateChatStream({ messages: [] })) {
@@ -1038,10 +1008,7 @@ describe('generateChatStream', () => {
       result: ReadableStreamReadResult<Uint8Array>,
     ) => readResolves[index]?.(result)
 
-    mockFetch.mockResolvedValueOnce({
-      body: { getReader: () => mockReader },
-      ok: true,
-    })
+    mockFetch.mockResolvedValueOnce(streamResponseWithReader(mockReader))
 
     const eventsPromise = (async () => {
       const events = []
@@ -1104,10 +1071,7 @@ describe('generateChatStream', () => {
 
     mockFetch.mockImplementationOnce(async (_url, init) => {
       requestSignal = (init as { signal?: AbortSignal }).signal
-      return {
-        body: { getReader: () => mockReader },
-        ok: true,
-      }
+      return streamResponseWithReader(mockReader)
     })
 
     const eventsPromise = (async () => {
@@ -1326,13 +1290,11 @@ describe('listModels', () => {
       .mockRejectedValueOnce(
         new Error('Ada ada@example.test password=network-secret'),
       )
-      .mockResolvedValueOnce({
-        json: async () => {
-          throw new Error('Ada ada@example.test password=parse-secret')
-        },
-        ok: true,
-        status: 200,
-      })
+      .mockResolvedValueOnce(
+        new Response('{"data":', {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
 
     await expect(listModels()).rejects.toMatchObject({
       code: 'ai_provider_unavailable',
@@ -1357,8 +1319,8 @@ describe('listModels', () => {
   })
 
   it('returns models from OpenRouter', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
         data: [
           {
             context_length: 200000,
@@ -1380,8 +1342,7 @@ describe('listModels', () => {
           },
         ],
       }),
-      ok: true,
-    })
+    )
 
     const models = await listModels()
     expect(models).toHaveLength(2)
@@ -1393,12 +1354,11 @@ describe('listModels', () => {
   })
 
   it('maps provider model defaults when optional catalog fields are absent', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
         data: [{ id: 'custom/model', name: 'Minimal model' }],
       }),
-      ok: true,
-    })
+    )
 
     await expect(listModels()).resolves.toEqual([
       {
@@ -1414,17 +1374,14 @@ describe('listModels', () => {
   })
 
   it('rejects a catalog response when the provider omits data', async () => {
-    mockFetch.mockResolvedValueOnce({ json: async () => ({}), ok: true })
+    mockFetch.mockResolvedValueOnce(jsonResponse({}))
     await expect(listModels()).rejects.toMatchObject({
       code: 'ai_provider_invalid_response',
     })
   })
 
   it('passes supported_parameters filter', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({ data: [] }),
-      ok: true,
-    })
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: [] }))
 
     await listModels(['structured_outputs'])
 
@@ -1437,10 +1394,9 @@ describe('listModels', () => {
   })
 
   it('rejects malformed model entries', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({ data: [{ id: 42, name: 'Invalid model' }] }),
-      ok: true,
-    })
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ data: [{ id: 42, name: 'Invalid model' }] }),
+    )
 
     await expect(listModels()).rejects.toMatchObject({
       code: 'ai_provider_invalid_response',
@@ -1448,7 +1404,7 @@ describe('listModels', () => {
   })
 
   it('throws on non-OK response', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 })
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 500 }))
     await expect(listModels()).rejects.toMatchObject({
       code: 'ai_provider_unavailable',
     })
@@ -1458,35 +1414,32 @@ describe('listModels', () => {
 describe('getKeyInfo', () => {
   it('keeps optional credit lookup best-effort under the shared error contract', async () => {
     vi.stubEnv('OPENROUTER_MGMT_API_KEY', 'sk-or-mgmt-test-key')
-    mockFetch
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
+    mockFetch.mockImplementation(async input => {
+      const url = String(input)
+      if (url.includes('/credits')) {
+        return jsonResponse(
+          {
             error: {
               message:
                 'Echo Ada Lovelace ada@example.test password=credit-secret',
             },
-          }),
-          {
-            headers: { 'Content-Type': 'application/json' },
-            status: 503,
           },
-        ),
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            data: {
-              is_free_tier: false,
-              limit: 50,
-              limit_remaining: 40,
-              usage: 10,
-              usage_daily: 1,
-            },
-          }),
-          { headers: { 'Content-Type': 'application/json' } },
-        ),
-      )
+          { status: 503 },
+        )
+      }
+      if (url.includes('/auth/key')) {
+        return jsonResponse({
+          data: {
+            is_free_tier: false,
+            limit: 50,
+            limit_remaining: 40,
+            usage: 10,
+            usage_daily: 1,
+          },
+        })
+      }
+      throw new Error(`Unexpected OpenRouter URL: ${url}`)
+    })
 
     await expect(
       getKeyInfo({
@@ -1498,15 +1451,15 @@ describe('getKeyInfo', () => {
 
   it('returns credit info with org credits when mgmt key is set', async () => {
     vi.stubEnv('OPENROUTER_MGMT_API_KEY', 'sk-or-mgmt-test-key')
-    mockFetch
-      .mockResolvedValueOnce({
-        json: async () => ({
+    mockFetch.mockImplementation(async input => {
+      const url = String(input)
+      if (url.includes('/credits')) {
+        return jsonResponse({
           data: { total_credits: 10, total_usage: 0.13 },
-        }),
-        ok: true,
-      })
-      .mockResolvedValueOnce({
-        json: async () => ({
+        })
+      }
+      if (url.includes('/auth/key')) {
+        return jsonResponse({
           data: {
             is_free_tier: false,
             limit: 50,
@@ -1514,9 +1467,10 @@ describe('getKeyInfo', () => {
             usage: 12.5,
             usage_daily: 2.3,
           },
-        }),
-        ok: true,
-      })
+        })
+      }
+      throw new Error(`Unexpected OpenRouter URL: ${url}`)
+    })
 
     const info = await getKeyInfo()
     expect(info.isFreeTier).toBe(false)
@@ -1539,9 +1493,9 @@ describe('getKeyInfo', () => {
   it('returns null totalCredits when mgmt key credits endpoint fails', async () => {
     vi.stubEnv('OPENROUTER_MGMT_API_KEY', 'sk-or-mgmt-test-key')
     mockFetch
-      .mockResolvedValueOnce({ ok: false, status: 403 })
-      .mockResolvedValueOnce({
-        json: async () => ({
+      .mockResolvedValueOnce(new Response(null, { status: 403 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
           data: {
             is_free_tier: true,
             limit: null,
@@ -1550,8 +1504,7 @@ describe('getKeyInfo', () => {
             usage_daily: 0,
           },
         }),
-        ok: true,
-      })
+      )
 
     const info = await getKeyInfo()
     expect(info.isFreeTier).toBe(true)
@@ -1562,11 +1515,8 @@ describe('getKeyInfo', () => {
   it('rejects a missing primary key envelope and ignores missing optional credit data', async () => {
     vi.stubEnv('OPENROUTER_MGMT_API_KEY', 'sk-or-mgmt-test-key')
     mockFetch
-      .mockResolvedValueOnce({
-        json: async () => ({ data: { total_usage: 2 } }),
-        ok: true,
-      })
-      .mockResolvedValueOnce({ json: async () => ({}), ok: true })
+      .mockResolvedValueOnce(jsonResponse({ data: { total_usage: 2 } }))
+      .mockResolvedValueOnce(jsonResponse({}))
 
     await expect(getKeyInfo()).rejects.toMatchObject({
       code: 'ai_provider_invalid_response',
@@ -1576,19 +1526,16 @@ describe('getKeyInfo', () => {
   it('rejects a malformed primary key payload and ignores malformed optional credits', async () => {
     vi.stubEnv('OPENROUTER_MGMT_API_KEY', 'sk-or-mgmt-test-key')
     mockFetch
-      .mockResolvedValueOnce({ json: async () => ({ data: [] }), ok: true })
-      .mockResolvedValueOnce({ json: async () => ({ data: [] }), ok: true })
+      .mockResolvedValueOnce(jsonResponse({ data: [] }))
+      .mockResolvedValueOnce(jsonResponse({ data: [] }))
 
     await expect(getKeyInfo()).rejects.toMatchObject({
       code: 'ai_provider_invalid_response',
     })
 
     mockFetch
-      .mockResolvedValueOnce({ json: async () => ({ data: [] }), ok: true })
-      .mockResolvedValueOnce({
-        json: async () => ({ data: { usage: 1 } }),
-        ok: true,
-      })
+      .mockResolvedValueOnce(jsonResponse({ data: [] }))
+      .mockResolvedValueOnce(jsonResponse({ data: { usage: 1 } }))
 
     await expect(getKeyInfo()).resolves.toMatchObject({
       totalCredits: null,
@@ -1597,8 +1544,8 @@ describe('getKeyInfo', () => {
   })
 
   it('skips credits fetch and flags managementKeyMissing when mgmt key is not set', async () => {
-    mockFetch.mockResolvedValueOnce({
-      json: async () => ({
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
         data: {
           is_free_tier: false,
           limit: 10,
@@ -1607,8 +1554,7 @@ describe('getKeyInfo', () => {
           usage_daily: 0.5,
         },
       }),
-      ok: true,
-    })
+    )
 
     const info = await getKeyInfo()
     expect(info.managementKeyMissing).toBe(true)
@@ -1619,7 +1565,7 @@ describe('getKeyInfo', () => {
   })
 
   it('throws on non-OK key response', async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 })
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 401 }))
     await expect(getKeyInfo()).rejects.toMatchObject({
       code: 'ai_provider_configuration_error',
     })

--- a/tests/unit/openrouter-client.test.ts
+++ b/tests/unit/openrouter-client.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  AiProviderError,
   generateChat,
   generateChatStream,
+  getDefaultModel,
   getKeyInfo,
   listModels,
 } from '@/lib/ai/openrouter-client'
@@ -22,7 +24,220 @@ afterEach(() => {
   vi.unstubAllEnvs()
 })
 
+it('uses the built-in model when no public default is configured', () => {
+  vi.stubEnv('NEXT_PUBLIC_DEFAULT_MODEL', '')
+
+  expect(getDefaultModel()).toBe('anthropic/claude-sonnet-4')
+})
+
 describe('generateChat (non-streaming)', () => {
+  it('uses a stable rate-limit error without retaining provider body data', async () => {
+    const providerBody = JSON.stringify({
+      error: {
+        code: 'provider_rate_limit',
+        message:
+          'Echo: create payroll for Ada Lovelace ada@example.test with password=unsafe-secret',
+      },
+    })
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    mockFetch.mockResolvedValueOnce(
+      new Response(providerBody, {
+        headers: {
+          'Content-Type': 'application/json',
+          'x-request-id': 'provider-request-123',
+        },
+        status: 429,
+      }),
+    )
+
+    try {
+      const rejection = generateChat({
+        correlationId: 'correlation-123',
+        messages: [{ content: 'sensitive prompt', role: 'user' }],
+        requestId: 'request-123',
+      })
+
+      await expect(rejection).rejects.toMatchObject({
+        code: 'ai_provider_rate_limited',
+        message: 'AI provider rate limit reached',
+        name: 'AiProviderError',
+      })
+      await rejection.catch(error => {
+        expect(error).toBeInstanceOf(AiProviderError)
+        expect(error).not.toHaveProperty('cause')
+        expect(JSON.stringify(error)).not.toMatch(
+          /Ada Lovelace|ada@example\.test|unsafe-secret|sensitive prompt/,
+        )
+      })
+      expect(JSON.stringify(consoleErrorSpy.mock.calls)).not.toMatch(
+        /Ada Lovelace|ada@example\.test|unsafe-secret|sensitive prompt/,
+      )
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"channel":"ai-provider-observability"'),
+      )
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
+  it('rejects an unexpected success content type without reading its body', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            'Ada ada@example.test password=unsafe-secret',
+          ),
+        )
+        controller.close()
+      },
+    })
+    const getReaderSpy = vi.spyOn(stream, 'getReader')
+    mockFetch.mockResolvedValueOnce(
+      new Response(stream, {
+        headers: { 'Content-Type': 'text/html' },
+        status: 200,
+      }),
+    )
+
+    await expect(generateChat({ messages: [] })).rejects.toMatchObject({
+      code: 'ai_provider_invalid_response',
+    })
+    expect(getReaderSpy).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [400, 'ai_provider_configuration_error'],
+    [401, 'ai_provider_configuration_error'],
+    [403, 'ai_provider_configuration_error'],
+    [408, 'ai_provider_timeout'],
+    [429, 'ai_provider_rate_limited'],
+    [500, 'ai_provider_unavailable'],
+    [504, 'ai_provider_timeout'],
+  ] as const)('maps upstream status %i to %s', async (status, code) => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('body must not be read', {
+        headers: { 'Content-Type': 'text/plain' },
+        status,
+      }),
+    )
+
+    await expect(generateChat({ messages: [] })).rejects.toMatchObject({ code })
+  })
+
+  it('stops reading an oversized provider error body at 16 KiB', async () => {
+    const cancel = vi.fn(() => {
+      throw new Error('cancel failure must be ignored')
+    })
+    const chunk = new TextEncoder().encode('x'.repeat(10 * 1024))
+    let reads = 0
+    const stream = new ReadableStream<Uint8Array>({
+      cancel,
+      pull(controller) {
+        reads += 1
+        controller.enqueue(chunk)
+      },
+    })
+    mockFetch.mockResolvedValueOnce(
+      new Response(stream, {
+        headers: { 'Content-Type': 'application/problem+json' },
+        status: 503,
+      }),
+    )
+
+    await expect(generateChat({ messages: [] })).rejects.toMatchObject({
+      code: 'ai_provider_response_too_large',
+      metadata: { truncated: true },
+    })
+    expect(reads).toBeLessThanOrEqual(3)
+    expect(cancel).toHaveBeenCalledOnce()
+  })
+
+  it('classifies provider body read failures without retaining exception text', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(
+          new Error('Ada ada@example.test password=body-read-secret'),
+        )
+      },
+    })
+    mockFetch.mockResolvedValueOnce(
+      new Response(stream, {
+        headers: { 'Content-Type': 'application/json' },
+        status: 502,
+      }),
+    )
+
+    try {
+      await expect(generateChat({ messages: [] })).rejects.toMatchObject({
+        code: 'ai_provider_response_read_failed',
+      })
+      expect(JSON.stringify(consoleErrorSpy.mock.calls)).not.toMatch(
+        /Ada|ada@example\.test|body-read-secret/,
+      )
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
+  it('stops reading a successful JSON response above 4 MiB', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('x'.repeat(4 * 1024 * 1024 + 1), {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    await expect(generateChat({ messages: [] })).rejects.toMatchObject({
+      code: 'ai_provider_response_too_large',
+    })
+  })
+
+  it('rejects a missing or malformed bounded JSON body', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(null, {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response('{malformed', {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+
+    await expect(generateChat({ messages: [] })).rejects.toMatchObject({
+      code: 'ai_provider_invalid_response',
+    })
+    await expect(generateChat({ messages: [] })).rejects.toMatchObject({
+      code: 'ai_provider_invalid_response',
+    })
+  })
+
+  it('rejects malformed non-streaming response shapes', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ json: async () => null, ok: true })
+      .mockResolvedValueOnce({
+        json: async () => ({ choices: [{ message: { content: 42 } }] }),
+        ok: true,
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({
+          choices: [{ message: { content: '{}' } }],
+          usage: { completion_tokens: 'many' },
+        }),
+        ok: true,
+      })
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await expect(generateChat({ messages: [] })).rejects.toMatchObject({
+        code: 'ai_provider_invalid_response',
+      })
+    }
+  })
   it('sends correct request to OpenRouter', async () => {
     mockFetch.mockResolvedValueOnce({
       json: async () => ({
@@ -155,7 +370,7 @@ describe('generateChat (non-streaming)', () => {
         messages: [{ content: 'Generate', role: 'user' }],
         signal: controller.signal,
       }),
-    ).rejects.toThrow('Aborted')
+    ).rejects.toMatchObject({ name: 'AiProviderCallerCancelledError' })
   })
 
   it('aborts a pending request after the provider timeout', async () => {
@@ -172,7 +387,9 @@ describe('generateChat (non-streaming)', () => {
     const result = generateChat({
       messages: [{ content: 'Generate', role: 'user' }],
     })
-    const rejection = expect(result).rejects.toThrow('Timed out')
+    const rejection = expect(result).rejects.toMatchObject({
+      code: 'ai_provider_timeout',
+    })
     await vi.advanceTimersByTimeAsync(120_000)
 
     await rejection
@@ -195,21 +412,19 @@ describe('generateChat (non-streaming)', () => {
     })
     controller.abort()
 
-    await expect(result).rejects.toThrow('Caller aborted')
+    await expect(result).rejects.toMatchObject({
+      name: 'AiProviderCallerCancelledError',
+    })
   })
 
-  it('uses an empty provider error body when reading the body fails', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 502,
-      text: vi.fn().mockRejectedValue(new Error('body unavailable')),
-    })
+  it('uses a stable provider error when an error body is unavailable', async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 502 }))
 
     await expect(
       generateChat({
         messages: [{ content: 'Generate', role: 'user' }],
       }),
-    ).rejects.toThrow('OpenRouter request failed (502): ')
+    ).rejects.toMatchObject({ code: 'ai_provider_unavailable' })
   })
 
   it('does not duplicate non-streaming reasoning when reasoning_details is also present', async () => {
@@ -348,9 +563,9 @@ describe('generateChat (non-streaming)', () => {
       text: async () => 'Internal error',
     })
 
-    await expect(generateChat({ messages: [] })).rejects.toThrow(
-      'OpenRouter request failed (500)',
-    )
+    await expect(generateChat({ messages: [] })).rejects.toMatchObject({
+      code: 'ai_provider_unavailable',
+    })
   })
 
   it('throws on invalid JSON content', async () => {
@@ -361,17 +576,17 @@ describe('generateChat (non-streaming)', () => {
       ok: true,
     })
 
-    await expect(generateChat({ messages: [] })).rejects.toThrow(
-      'Failed to parse OpenRouter JSON response',
-    )
+    await expect(generateChat({ messages: [] })).rejects.toMatchObject({
+      code: 'ai_provider_invalid_response',
+    })
   })
 
   it('throws when API key is missing', async () => {
     vi.stubEnv('OPENROUTER_API_KEY', '')
 
-    await expect(generateChat({ messages: [] })).rejects.toThrow(
-      'OPENROUTER_API_KEY environment variable is not set',
-    )
+    await expect(generateChat({ messages: [] })).rejects.toMatchObject({
+      code: 'ai_provider_configuration_error',
+    })
   })
 
   it('handles abort signal', async () => {
@@ -387,6 +602,160 @@ describe('generateChat (non-streaming)', () => {
 })
 
 describe('generateChatStream', () => {
+  it('rejects an unexpected stream content type without reading the body', async () => {
+    const stream = new ReadableStream<Uint8Array>()
+    const getReaderSpy = vi.spyOn(stream, 'getReader')
+    mockFetch.mockResolvedValueOnce(
+      new Response(stream, {
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const events = []
+    for await (const event of generateChatStream({ messages: [] })) {
+      events.push(event)
+    }
+
+    expect(events).toEqual([
+      {
+        code: 'ai_provider_invalid_response',
+        message: 'AI provider returned an invalid response',
+        phase: 'error',
+      },
+    ])
+    expect(getReaderSpy).not.toHaveBeenCalled()
+  })
+
+  it('stops reading an SSE frame above 256 KiB', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(`data: ${'x'.repeat(256 * 1024)}\n\n`, {
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+
+    const events = []
+    for await (const event of generateChatStream({ messages: [] })) {
+      events.push(event)
+    }
+
+    expect(events.at(-1)).toMatchObject({
+      code: 'ai_provider_response_too_large',
+      phase: 'error',
+    })
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ phase: 'done' }),
+    )
+  })
+
+  it('stops accumulating model content above 4 MiB', async () => {
+    const content = 'x'.repeat(240 * 1024)
+    const frames = Array.from(
+      { length: 18 },
+      () =>
+        `data: ${JSON.stringify({ choices: [{ delta: { content } }] })}\n\n`,
+    ).join('')
+    mockFetch.mockResolvedValueOnce(
+      new Response(frames, {
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+
+    const events = []
+    for await (const event of generateChatStream({ messages: [] })) {
+      events.push(event)
+    }
+
+    expect(events.at(-1)).toMatchObject({
+      code: 'ai_provider_response_too_large',
+      phase: 'error',
+    })
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ phase: 'done' }),
+    )
+  })
+
+  it('fails closed when an SSE response ends without a DONE frame', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response('data: {"choices":[{"delta":{"content":"partial"}}]}\n\n', {
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    )
+
+    const events = []
+    for await (const event of generateChatStream({ messages: [] })) {
+      events.push(event)
+    }
+
+    expect(events.at(-1)).toMatchObject({
+      code: 'ai_provider_invalid_response',
+      phase: 'error',
+    })
+    expect(events).not.toContainEqual(
+      expect.objectContaining({ phase: 'done' }),
+    )
+  })
+
+  it('rejects malformed SSE JSON and payload shapes', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        body: {
+          getReader: () => ({
+            read: vi.fn().mockResolvedValueOnce({
+              done: false,
+              value: new TextEncoder().encode('data: {malformed\n\n'),
+            }),
+            releaseLock: vi.fn(),
+          }),
+        },
+        ok: true,
+        status: 200,
+      })
+      .mockResolvedValueOnce({
+        body: {
+          getReader: () => ({
+            read: vi.fn().mockResolvedValueOnce({
+              done: false,
+              value: new TextEncoder().encode('data: null\n\n'),
+            }),
+            releaseLock: vi.fn(),
+          }),
+        },
+        ok: true,
+        status: 200,
+      })
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const events = []
+      for await (const event of generateChatStream({ messages: [] })) {
+        events.push(event)
+      }
+      expect(events.at(-1)).toMatchObject({
+        code: 'ai_provider_invalid_response',
+        phase: 'error',
+      })
+    }
+  })
+
+  it('rejects malformed SSE UTF-8', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        Uint8Array.from([0x64, 0x61, 0x74, 0x61, 0x3a, 0x20, 0xff]),
+        {
+          headers: { 'Content-Type': 'text/event-stream' },
+        },
+      ),
+    )
+
+    const events = []
+    for await (const event of generateChatStream({ messages: [] })) {
+      events.push(event)
+    }
+
+    expect(events.at(-1)).toMatchObject({
+      code: 'ai_provider_invalid_response',
+      phase: 'error',
+    })
+  })
   it('yields thinking and generating events', async () => {
     const sseLines = [
       'data: {"choices":[{"delta":{"reasoning":"Let me "}}]}\n\n',
@@ -701,7 +1070,10 @@ describe('generateChatStream', () => {
       value: new TextEncoder().encode(sseLines[2]),
     })
     await waitForRead(4)
-    resolveLine(3, { done: true, value: undefined })
+    resolveLine(3, {
+      done: false,
+      value: new TextEncoder().encode('data: [DONE]\n\n'),
+    })
 
     const events = await eventsPromise
     expect(events.map(event => event.phase)).toEqual([
@@ -751,8 +1123,44 @@ describe('generateChatStream', () => {
     const events = await eventsPromise
     expect(events).toEqual([
       {
-        cause: 'OpenRouter stream idle timeout after 120000 ms',
-        message: 'AI provider is unavailable',
+        code: 'ai_provider_timeout',
+        message: 'AI provider request timed out',
+        phase: 'error',
+      },
+    ])
+  })
+
+  it('times out while reading a stalled provider error body', async () => {
+    vi.useFakeTimers()
+    mockFetch.mockImplementationOnce(async (_url, init) => {
+      const requestSignal = (init as { signal: AbortSignal }).signal
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            requestSignal.addEventListener(
+              'abort',
+              () => controller.error(new DOMException('Aborted', 'AbortError')),
+              { once: true },
+            )
+          },
+        }),
+        { headers: { 'Content-Type': 'application/json' }, status: 503 },
+      )
+    })
+
+    const eventsPromise = (async () => {
+      const events = []
+      for await (const event of generateChatStream({ messages: [] })) {
+        events.push(event)
+      }
+      return events
+    })()
+    await vi.advanceTimersByTimeAsync(120_000)
+
+    await expect(eventsPromise).resolves.toEqual([
+      {
+        code: 'ai_provider_timeout',
+        message: 'AI provider request timed out',
         phase: 'error',
       },
     ])
@@ -779,6 +1187,78 @@ describe('generateChatStream', () => {
     expect(events).toEqual([])
   })
 
+  it('returns quietly without diagnostics when a caller aborts while an error body is being read', async () => {
+    const caller = new AbortController()
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        await new Promise(resolve => setTimeout(resolve, 0))
+        caller.abort()
+        controller.error(
+          new Error('provider body leaked Ada Lovelace ada@example.test'),
+        )
+      },
+    })
+    mockFetch.mockResolvedValueOnce(
+      new Response(stream, {
+        headers: { 'Content-Type': 'application/json' },
+        status: 503,
+      }),
+    )
+
+    try {
+      const events = []
+      for await (const event of generateChatStream({
+        messages: [],
+        signal: caller.signal,
+      })) {
+        events.push(event)
+      }
+
+      expect(events).toEqual([])
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
+  it('returns quietly when a successful stream read and caller abort happen together', async () => {
+    const caller = new AbortController()
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            caller.abort()
+            controller.enqueue(
+              new TextEncoder().encode('data: {provider-secret}\n\n'),
+            )
+          },
+        }),
+        { headers: { 'Content-Type': 'text/event-stream' } },
+      ),
+    )
+
+    try {
+      const events = []
+      for await (const event of generateChatStream({
+        messages: [],
+        signal: caller.signal,
+      })) {
+        events.push(event)
+      }
+
+      expect(events).toEqual([])
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+    } finally {
+      consoleErrorSpy.mockRestore()
+    }
+  })
+
   it('reports non-Error fetch failures without leaking their value', async () => {
     mockFetch.mockRejectedValueOnce('provider-secret')
 
@@ -791,7 +1271,7 @@ describe('generateChatStream', () => {
 
     expect(events).toEqual([
       {
-        cause: 'OpenRouter fetch error: Fetch failed',
+        code: 'ai_provider_unavailable',
         message: 'AI provider is unavailable',
         phase: 'error',
       },
@@ -810,8 +1290,8 @@ describe('generateChatStream', () => {
 
     expect(events).toEqual([
       {
-        cause: 'No response body from OpenRouter',
-        message: 'AI provider is unavailable',
+        code: 'ai_provider_invalid_response',
+        message: 'AI provider returned an invalid response',
         phase: 'error',
       },
     ])
@@ -819,6 +1299,63 @@ describe('generateChatStream', () => {
 })
 
 describe('listModels', () => {
+  it('uses the shared stable error contract for model catalog failures', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            message:
+              'Echo Ada Lovelace ada@example.test password=catalog-secret',
+          },
+        }),
+        {
+          headers: { 'Content-Type': 'application/json' },
+          status: 401,
+        },
+      ),
+    )
+
+    await expect(listModels()).rejects.toMatchObject({
+      code: 'ai_provider_configuration_error',
+      message: 'AI provider configuration is invalid',
+    })
+  })
+
+  it('classifies model catalog network, timeout, and parse failures safely', async () => {
+    mockFetch
+      .mockRejectedValueOnce(
+        new Error('Ada ada@example.test password=network-secret'),
+      )
+      .mockResolvedValueOnce({
+        json: async () => {
+          throw new Error('Ada ada@example.test password=parse-secret')
+        },
+        ok: true,
+        status: 200,
+      })
+
+    await expect(listModels()).rejects.toMatchObject({
+      code: 'ai_provider_unavailable',
+    })
+    await expect(listModels()).rejects.toMatchObject({
+      code: 'ai_provider_invalid_response',
+    })
+
+    const controller = new AbortController()
+    controller.abort()
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, 'timeout')
+      .mockReturnValueOnce(controller.signal)
+    mockFetch.mockRejectedValueOnce(new Error('timeout-secret'))
+    try {
+      await expect(listModels()).rejects.toMatchObject({
+        code: 'ai_provider_timeout',
+      })
+    } finally {
+      timeoutSpy.mockRestore()
+    }
+  })
+
   it('returns models from OpenRouter', async () => {
     mockFetch.mockResolvedValueOnce({
       json: async () => ({
@@ -876,9 +1413,11 @@ describe('listModels', () => {
     ])
   })
 
-  it('returns an empty catalog when the provider omits data', async () => {
+  it('rejects a catalog response when the provider omits data', async () => {
     mockFetch.mockResolvedValueOnce({ json: async () => ({}), ok: true })
-    await expect(listModels()).resolves.toEqual([])
+    await expect(listModels()).rejects.toMatchObject({
+      code: 'ai_provider_invalid_response',
+    })
   })
 
   it('passes supported_parameters filter', async () => {
@@ -897,15 +1436,66 @@ describe('listModels', () => {
     /* cspell:enable */
   })
 
+  it('rejects malformed model entries', async () => {
+    mockFetch.mockResolvedValueOnce({
+      json: async () => ({ data: [{ id: 42, name: 'Invalid model' }] }),
+      ok: true,
+    })
+
+    await expect(listModels()).rejects.toMatchObject({
+      code: 'ai_provider_invalid_response',
+    })
+  })
+
   it('throws on non-OK response', async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 500 })
-    await expect(listModels()).rejects.toThrow(
-      'Failed to list OpenRouter models',
-    )
+    await expect(listModels()).rejects.toMatchObject({
+      code: 'ai_provider_unavailable',
+    })
   })
 })
 
 describe('getKeyInfo', () => {
+  it('keeps optional credit lookup best-effort under the shared error contract', async () => {
+    vi.stubEnv('OPENROUTER_MGMT_API_KEY', 'sk-or-mgmt-test-key')
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              message:
+                'Echo Ada Lovelace ada@example.test password=credit-secret',
+            },
+          }),
+          {
+            headers: { 'Content-Type': 'application/json' },
+            status: 503,
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: {
+              is_free_tier: false,
+              limit: 50,
+              limit_remaining: 40,
+              usage: 10,
+              usage_daily: 1,
+            },
+          }),
+          { headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+
+    await expect(
+      getKeyInfo({
+        correlationId: 'credits-correlation',
+        requestId: 'credits-request',
+      }),
+    ).resolves.toMatchObject({ totalCredits: null, usage: 10 })
+  })
+
   it('returns credit info with org credits when mgmt key is set', async () => {
     vi.stubEnv('OPENROUTER_MGMT_API_KEY', 'sk-or-mgmt-test-key')
     mockFetch
@@ -969,7 +1559,7 @@ describe('getKeyInfo', () => {
     expect(info.managementKeyMissing).toBe(false)
   })
 
-  it('uses safe key and credit defaults for partial provider payloads', async () => {
+  it('rejects a missing primary key envelope and ignores missing optional credit data', async () => {
     vi.stubEnv('OPENROUTER_MGMT_API_KEY', 'sk-or-mgmt-test-key')
     mockFetch
       .mockResolvedValueOnce({
@@ -978,14 +1568,31 @@ describe('getKeyInfo', () => {
       })
       .mockResolvedValueOnce({ json: async () => ({}), ok: true })
 
-    await expect(getKeyInfo()).resolves.toEqual({
-      isFreeTier: false,
-      limit: null,
-      limitRemaining: null,
-      managementKeyMissing: false,
+    await expect(getKeyInfo()).rejects.toMatchObject({
+      code: 'ai_provider_invalid_response',
+    })
+  })
+
+  it('rejects a malformed primary key payload and ignores malformed optional credits', async () => {
+    vi.stubEnv('OPENROUTER_MGMT_API_KEY', 'sk-or-mgmt-test-key')
+    mockFetch
+      .mockResolvedValueOnce({ json: async () => ({ data: [] }), ok: true })
+      .mockResolvedValueOnce({ json: async () => ({ data: [] }), ok: true })
+
+    await expect(getKeyInfo()).rejects.toMatchObject({
+      code: 'ai_provider_invalid_response',
+    })
+
+    mockFetch
+      .mockResolvedValueOnce({ json: async () => ({ data: [] }), ok: true })
+      .mockResolvedValueOnce({
+        json: async () => ({ data: { usage: 1 } }),
+        ok: true,
+      })
+
+    await expect(getKeyInfo()).resolves.toMatchObject({
       totalCredits: null,
-      usage: 0,
-      usageDaily: 0,
+      usage: 1,
     })
   })
 
@@ -1013,8 +1620,8 @@ describe('getKeyInfo', () => {
 
   it('throws on non-OK key response', async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 401 })
-    await expect(getKeyInfo()).rejects.toThrow(
-      'Failed to get OpenRouter key info (401)',
-    )
+    await expect(getKeyInfo()).rejects.toMatchObject({
+      code: 'ai_provider_configuration_error',
+    })
   })
 })

--- a/tests/unit/openrouter-model-catalog.test.ts
+++ b/tests/unit/openrouter-model-catalog.test.ts
@@ -48,8 +48,12 @@ describe('openrouter model catalog', () => {
       supportedParameters: ['vision'],
     })
 
-    expect(mocks.listModels).toHaveBeenNthCalledWith(1, undefined)
-    expect(mocks.listModels).toHaveBeenNthCalledWith(2, ['structured_outputs'])
+    expect(mocks.listModels).toHaveBeenNthCalledWith(1, undefined, undefined)
+    expect(mocks.listModels).toHaveBeenNthCalledWith(
+      2,
+      ['structured_outputs'],
+      undefined,
+    )
     expect(catalog).toEqual([
       expect.objectContaining({
         id: 'openai/gpt-5-vision',


### PR DESCRIPTION
## Description

- Introduces stable, sanitized error codes for all OpenRouter operations and keeps request identifiers in response headers.
- Bounds provider error, JSON, and SSE reads; rejects malformed, oversized, incomplete, and unexpected responses without exposing provider content.
- Adds structured provider diagnostics, silent caller cancellation, typed deadlines, and fail-closed streamed generation behavior.
- Expands route and client coverage and documents the provider failure contract.

## Related Issues

Closes #479

## Reviewer Notes

`npm run check` passes, including 6,585 application tests and 31 HSA support tests. Focused coverage reports 90.27% statement and 87.69% branch coverage.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
AI provider failures now use stable error codes and sanitized response shapes. During rollout, verify any clients, alerts, or support runbooks that rely on the previous error payloads or treated malformed model output as a validation response.

Provider failure diagnostics now use a structured observability channel containing only bounded operational metadata. Confirm that production log routing and dashboards capture this channel without expecting raw provider error text.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/981)
<!-- Reviewable:end -->
