### PR TITLE
docs: persist operator upgrade notes from #987

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -146,6 +146,11 @@ forwarding values. Inventory and restrict those copies, apply the approved
 incident, privacy, and retention process, and rotate any credential that
 remains usable.
 <!-- operator-upgrade:source pr-984 end -->
+
+<!-- operator-upgrade:source pr-987 start -->
+Before upgrading, create a site-specific readiness probe boundary containing the approved IPv4 and IPv6 monitoring source networks and configure the deployment to use it. The upgrade will refuse to render or install if the boundary is absent or invalid.
+After rollout, verify readiness from an allowed monitoring source, confirm other sources receive an empty denial, and confirm liveness and normal application traffic remain available. Update monitoring expectations for one request per second with a burst of five and generic rate-limit/not-ready responses.
+<!-- operator-upgrade:source pr-987 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #987
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/31610788663

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/988)
<!-- Reviewable:end -->
