### PR TITLE
Constrain HSA OAuth and lookup destinations

### DIFF
--- a/.github/production-smoke/quadlet/kravhantering-ci-kong.container.template
+++ b/.github/production-smoke/quadlet/kravhantering-ci-kong.container.template
@@ -20,6 +20,7 @@ Environment=KONG_SSL_CERT_KEY=/run/kong-tls/server.key
 Network=kravhantering-single-node-egress.network
 PodmanArgs=--network-alias=kong
 PodmanArgs=--group-add=keep-groups
+Tmpfs=/tmp:rw,size=64M,mode=1777,U,nosuid,nodev,noexec
 Volume=@@BUNDLE_ROOT@@/kong/kong.yml:/kong/declarative/kong.yml:ro
 Volume=@@CONFIG_ROOT@@/kong-tls/kong.crt:/run/kong-tls/server.crt:ro
 Volume=@@CONFIG_ROOT@@/kong-tls/kong.key:/run/kong-tls/server.key:ro

--- a/.github/production-smoke/quadlet/kravhantering-ci-kong.container.template
+++ b/.github/production-smoke/quadlet/kravhantering-ci-kong.container.template
@@ -13,10 +13,14 @@ Environment=KONG_DATABASE=off
 Environment=KONG_DECLARATIVE_CONFIG=/kong/declarative/kong.yml
 Environment=KONG_PROXY_ACCESS_LOG=/dev/stdout
 Environment=KONG_PROXY_ERROR_LOG=/dev/stderr
-Environment=KONG_PROXY_LISTEN=0.0.0.0:8000
+Environment="KONG_PROXY_LISTEN=0.0.0.0:8443 ssl"
+Environment=KONG_SSL_CERT=/run/kong-tls/server.crt
+Environment=KONG_SSL_CERT_KEY=/run/kong-tls/server.key
 Network=kravhantering-single-node-egress.network
 PodmanArgs=--network-alias=kong
 Volume=@@BUNDLE_ROOT@@/kong/kong.yml:/kong/declarative/kong.yml:ro
+Volume=@@CONFIG_ROOT@@/kong-tls/kong.crt:/run/kong-tls/server.crt:ro
+Volume=@@CONFIG_ROOT@@/kong-tls/kong.key:/run/kong-tls/server.key:ro
 NoNewPrivileges=true
 DropCapability=all
 

--- a/.github/production-smoke/quadlet/kravhantering-ci-kong.container.template
+++ b/.github/production-smoke/quadlet/kravhantering-ci-kong.container.template
@@ -18,6 +18,7 @@ Environment=KONG_SSL_CERT=/run/kong-tls/server.crt
 Environment=KONG_SSL_CERT_KEY=/run/kong-tls/server.key
 Network=kravhantering-single-node-egress.network
 PodmanArgs=--network-alias=kong
+PodmanArgs=--group-add=keep-groups
 Volume=@@BUNDLE_ROOT@@/kong/kong.yml:/kong/declarative/kong.yml:ro
 Volume=@@CONFIG_ROOT@@/kong-tls/kong.crt:/run/kong-tls/server.crt:ro
 Volume=@@CONFIG_ROOT@@/kong-tls/kong.key:/run/kong-tls/server.key:ro

--- a/.github/production-smoke/quadlet/kravhantering-ci-kong.container.template
+++ b/.github/production-smoke/quadlet/kravhantering-ci-kong.container.template
@@ -11,6 +11,7 @@ Environment=KONG_ADMIN_ERROR_LOG=/dev/stderr
 Environment=KONG_ADMIN_LISTEN=127.0.0.1:8001
 Environment=KONG_DATABASE=off
 Environment=KONG_DECLARATIVE_CONFIG=/kong/declarative/kong.yml
+Environment=KONG_PREFIX=/tmp/kong
 Environment=KONG_PROXY_ACCESS_LOG=/dev/stdout
 Environment=KONG_PROXY_ERROR_LOG=/dev/stderr
 Environment="KONG_PROXY_LISTEN=0.0.0.0:8443 ssl"

--- a/.github/workflows/container-pr-smoke.yml
+++ b/.github/workflows/container-pr-smoke.yml
@@ -375,10 +375,9 @@ jobs:
         run: scripts/containers/production-smoke.sh evidence || true
 
       - name: Collect container runtime diagnostics
-        if: always()
+        if: ${{ !cancelled() }}
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
+        timeout-minutes: 2
         run: scripts/containers/ci-container-runtime.sh collect
 
       - name: Remove production Quadlet stack

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -339,10 +339,9 @@ jobs:
         run: scripts/containers/production-smoke.sh evidence || true
 
       - name: Collect container runtime diagnostics
-        if: always()
+        if: ${{ !cancelled() }}
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
+        timeout-minutes: 2
         run: scripts/containers/ci-container-runtime.sh collect
 
       - name: Remove production Quadlet stack

--- a/app/api/ready/route.ts
+++ b/app/api/ready/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/database-schema-status'
 import { getRequestSqlServerDataSource } from '@/lib/db'
 import { probeGeneratedOutputTempDirectory } from '@/lib/generated-output/spool'
+import { getHsaPersonLookupConfig } from '@/lib/hsa/person-lookup'
 import { withRestResponsePolicy } from '@/lib/http/response-policy'
 import { resolveRequestCorrelationIds } from '@/lib/observability/request-ids'
 import {
@@ -108,6 +109,7 @@ function failureReason(
 async function checkRuntimeConfig() {
   assertSiteUrlConfigured()
   getAuthConfig()
+  getHsaPersonLookupConfig()
   getSqlServerDatabaseUrl(process.env, false)
 }
 

--- a/app/api/ready/route.ts
+++ b/app/api/ready/route.ts
@@ -6,7 +6,11 @@ import {
 } from '@/lib/database-schema-status'
 import { getRequestSqlServerDataSource } from '@/lib/db'
 import { probeGeneratedOutputTempDirectory } from '@/lib/generated-output/spool'
-import { getHsaPersonLookupConfig } from '@/lib/hsa/person-lookup'
+import {
+  getHsaPersonLookupConfig,
+  type HsaPersonLookupConfigDiagnostic,
+  hsaPersonLookupConfigDiagnostic,
+} from '@/lib/hsa/person-lookup'
 import { withRestResponsePolicy } from '@/lib/http/response-policy'
 import { resolveRequestCorrelationIds } from '@/lib/observability/request-ids'
 import {
@@ -87,7 +91,14 @@ function discoveryUrl(issuerUrl: string): string {
 function readinessDiagnostic(
   check: ReadinessCheckName,
   error: unknown,
-): 'check_failed' | 'sql_server_driver_unavailable' {
+):
+  | 'check_failed'
+  | HsaPersonLookupConfigDiagnostic
+  | 'sql_server_driver_unavailable' {
+  if (check === 'runtime_config') {
+    const hsaDiagnostic = hsaPersonLookupConfigDiagnostic(error)
+    if (hsaDiagnostic) return hsaDiagnostic
+  }
   if (
     check === 'sql_server' &&
     error instanceof Error &&

--- a/containers/app/README.md
+++ b/containers/app/README.md
@@ -114,8 +114,9 @@ Required application values:
 - `AUTH_OIDC_REDIRECT_URI` and `AUTH_OIDC_POST_LOGOUT_REDIRECT_URI` must
   match the Keycloak realm imported for the stack.
 - `AUTH_SESSION_COOKIE_PASSWORD` must be at least 32 characters.
-- `HSA_PERSON_LOOKUP_URL` must point to the server-side Kong or
-  integration-platform REST facade for HSA person lookup.
+- `HSA_PERSON_LOOKUP_URL` must use HTTPS in production and point to the
+  server-side Kong or integration-platform REST facade approved by the
+  environment's egress policy for HSA person lookup.
 
 Optional application values:
 
@@ -141,7 +142,10 @@ Optional application values:
   `HSA_PERSON_LOOKUP_OAUTH_SCOPE`, and
   `HSA_PERSON_LOOKUP_OAUTH_AUDIENCE` enable optional OAuth2 client
   credentials auth. Set either token URL or issuer URL; issuer URL uses OIDC
-  discovery.
+  discovery. Production OAuth URLs must use HTTPS. Discovery must return the
+  configured issuer and a token endpoint on the same origin; configure an
+  explicit HTTPS token URL when the approved token service uses another
+  origin.
 - `OPENROUTER_API_KEY`, `OPENROUTER_MGMT_API_KEY`, and
   `NEXT_PUBLIC_DEFAULT_MODEL` enable optional AI integrations.
 - `KRAVHANTERING_EXPORT_TEMP_DIR` selects an absolute private spool root for

--- a/containers/hsa-person-lookup-adapter/src/server.mjs
+++ b/containers/hsa-person-lookup-adapter/src/server.mjs
@@ -15,6 +15,7 @@ const DEFAULT_TO = 'SE165565594230-1000'
 const HEALTH_PATH = '/health'
 const LOOKUP_PATH = '/hsa/person-records/lookup'
 const MAX_BODY_BYTES = 1024 * 1024
+const SOAP_RESPONSE_MAX_BYTES = 1024 * 1024
 
 class AdapterError extends Error {
   constructor(status, code, message) {
@@ -47,7 +48,7 @@ function readTimeout(env = process.env) {
 }
 
 export function readConfig(env = process.env) {
-  return {
+  const config = {
     caPath: readString('HSA_SOAP_CA_PATH', '/run/hsa-mtls/ca.crt', env),
     certPath: readString(
       'HSA_SOAP_CLIENT_CERT_PATH',
@@ -67,6 +68,23 @@ export function readConfig(env = process.env) {
     serverName: readString('HSA_SOAP_TLS_SERVER_NAME', undefined, env),
     timeoutMs: readTimeout(env),
     to: readString('HSA_SOAP_TO', DEFAULT_TO, env),
+  }
+  validateConfig(config, env)
+  return config
+}
+
+export function validateConfig(config, env = process.env) {
+  let endpoint
+  try {
+    endpoint = new URL(config.endpointUrl)
+  } catch {
+    throw new Error('HSA SOAP endpoint must be a valid URL.')
+  }
+  if (endpoint.protocol !== 'http:' && endpoint.protocol !== 'https:') {
+    throw new Error('HSA SOAP endpoint must use HTTP or HTTPS.')
+  }
+  if (env.NODE_ENV === 'production' && endpoint.protocol !== 'https:') {
+    throw new Error('HSA SOAP endpoint must use HTTPS in production.')
   }
 }
 
@@ -250,7 +268,13 @@ async function tlsOptions(config) {
   }
 }
 
+function isSoapMediaType(value) {
+  const mediaType = value?.split(';', 1)[0]?.trim().toLowerCase()
+  return mediaType === 'text/xml' || mediaType === 'application/soap+xml'
+}
+
 export async function postSoap(xml, config) {
+  validateConfig(config)
   const parsed = new URL(config.endpointUrl)
   const isHttps = parsed.protocol === 'https:'
   if (!isHttps && parsed.protocol !== 'http:') {
@@ -273,25 +297,60 @@ export async function postSoap(xml, config) {
   }
 
   return new Promise((resolve, reject) => {
+    let settled = false
+    const finish = callback => {
+      if (settled) return
+      settled = true
+      callback()
+    }
     const transport = isHttps ? https : http
     const req = transport.request(options, response => {
+      if (!isSoapMediaType(response.headers['content-type'])) {
+        response.destroy()
+        finish(() => reject(new Error('HSA SOAP response must use XML.')))
+        return
+      }
       const chunks = []
+      let totalBytes = 0
+      const declaredLength = Number(response.headers['content-length'])
+      if (
+        Number.isFinite(declaredLength) &&
+        declaredLength > SOAP_RESPONSE_MAX_BYTES
+      ) {
+        response.destroy()
+        finish(() =>
+          reject(new Error('HSA SOAP response exceeds the 1 MiB limit.')),
+        )
+        return
+      }
       response.on('data', chunk => {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+        totalBytes += buffer.byteLength
+        if (totalBytes > SOAP_RESPONSE_MAX_BYTES) {
+          response.destroy()
+          finish(() =>
+            reject(new Error('HSA SOAP response exceeds the 1 MiB limit.')),
+          )
+          return
+        }
+        chunks.push(buffer)
       })
       response.on('end', () => {
-        resolve({
-          body: Buffer.concat(chunks).toString('utf8'),
-          status: response.statusCode ?? 0,
-        })
+        finish(() =>
+          resolve({
+            body: Buffer.concat(chunks).toString('utf8'),
+            status: response.statusCode ?? 0,
+          }),
+        )
       })
+      response.on('error', error => finish(() => reject(error)))
     })
     req.on('timeout', () => {
       req.destroy(
         new AdapterError(504, 'timeout', 'HSA SOAP request timed out.'),
       )
     })
-    req.on('error', reject)
+    req.on('error', error => finish(() => reject(error)))
     req.write(xml)
     req.end()
   })
@@ -394,6 +453,7 @@ async function handleLookup(req, res, config) {
 }
 
 export function createServer(config = readConfig()) {
+  validateConfig(config)
   return http.createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', 'http://hsa-person-lookup-adapter')
     try {

--- a/containers/hsa-person-lookup-adapter/test/server.test.mjs
+++ b/containers/hsa-person-lookup-adapter/test/server.test.mjs
@@ -13,6 +13,7 @@ import {
   createServer,
   mapSoapPeopleToRest,
   parseGetHsaPersonResponse,
+  readConfig,
   soapRequestXml,
 } from '../src/server.mjs'
 
@@ -127,6 +128,17 @@ function successEnvelope(userInformations) {
 }
 
 describe('HSA person lookup adapter SOAP mapping', () => {
+  it('rejects a plaintext production SOAP endpoint during configuration', () => {
+    assert.throws(
+      () =>
+        readConfig({
+          HSA_SOAP_ENDPOINT_URL: 'http://hsa.example.test/soap',
+          NODE_ENV: 'production',
+        }),
+      /must use HTTPS in production/u,
+    )
+  })
+
   it('generates dynamic server SANs and owner-only private key permissions', async () => {
     const customCertDir = await mkdtemp(path.join(tmpdir(), 'hsa-certs-'))
     try {
@@ -309,6 +321,113 @@ describe('HSA person lookup adapter REST facade', () => {
 
       assert.equal(response.status, 503)
       assert.equal(response.body.code, 'service_unavailable')
+    } finally {
+      await stop(adapter)
+      await stop(upstream)
+    }
+  })
+
+  it('rejects a successful SOAP response with a non-XML media type', async () => {
+    const upstream = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' })
+      res.end(
+        successEnvelope(
+          [
+            '<hsa:userInformation>',
+            '<hsa:hsaIdentity>SE5560000001-annaj</hsa:hsaIdentity>',
+            '<hsa:givenName>Anna</hsa:givenName>',
+            '</hsa:userInformation>',
+          ].join(''),
+        ),
+      )
+    })
+    const upstreamBaseUrl = await listen(upstream, 'http')
+    const adapter = createServer({
+      endpointUrl: `${upstreamBaseUrl}${SOAP_URL}`,
+      timeoutMs: 5000,
+      to: 'SE165565594230-1000',
+    })
+    const localAdapterBaseUrl = await listen(adapter, 'http')
+    try {
+      const response = await postLookupAt(
+        localAdapterBaseUrl,
+        'SE5560000001-annaj',
+      )
+
+      assert.equal(response.status, 503)
+      assert.equal(response.body.code, 'service_unavailable')
+    } finally {
+      await stop(adapter)
+      await stop(upstream)
+    }
+  })
+
+  it('rejects a streaming SOAP response as soon as it exceeds 1 MiB', async () => {
+    const upstream = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/xml; charset=utf-8' })
+      res.end(
+        `${successEnvelope(
+          [
+            '<hsa:userInformation>',
+            '<hsa:hsaIdentity>SE5560000001-annaj</hsa:hsaIdentity>',
+            '<hsa:givenName>Anna</hsa:givenName>',
+            '</hsa:userInformation>',
+          ].join(''),
+        )}${' '.repeat(1024 * 1024)}`,
+      )
+    })
+    const upstreamBaseUrl = await listen(upstream, 'http')
+    const adapter = createServer({
+      endpointUrl: `${upstreamBaseUrl}${SOAP_URL}`,
+      timeoutMs: 5000,
+      to: 'SE165565594230-1000',
+    })
+    const localAdapterBaseUrl = await listen(adapter, 'http')
+    try {
+      const response = await postLookupAt(
+        localAdapterBaseUrl,
+        'SE5560000001-annaj',
+      )
+
+      assert.equal(response.status, 503)
+      assert.equal(response.body.code, 'service_unavailable')
+    } finally {
+      await stop(adapter)
+      await stop(upstream)
+    }
+  })
+
+  it('does not follow SOAP redirects', async () => {
+    let redirectTargetRequests = 0
+    const upstream = http.createServer((req, res) => {
+      if (req.url === '/credential-sink') {
+        redirectTargetRequests += 1
+        res.writeHead(200, { 'Content-Type': 'text/xml' })
+        res.end(successEnvelope(''))
+        return
+      }
+      res.writeHead(302, {
+        'Content-Type': 'application/soap+xml; charset=utf-8',
+        Location: '/credential-sink',
+      })
+      res.end('<redirect/>')
+    })
+    const upstreamBaseUrl = await listen(upstream, 'http')
+    const adapter = createServer({
+      endpointUrl: `${upstreamBaseUrl}${SOAP_URL}`,
+      timeoutMs: 5000,
+      to: 'SE165565594230-1000',
+    })
+    const localAdapterBaseUrl = await listen(adapter, 'http')
+    try {
+      const response = await postLookupAt(
+        localAdapterBaseUrl,
+        'SE5560000001-annaj',
+      )
+
+      assert.equal(response.status, 503)
+      assert.equal(response.body.code, 'service_unavailable')
+      assert.equal(redirectTargetRequests, 0)
     } finally {
       await stop(adapter)
       await stop(upstream)

--- a/containers/production/env/app.env.template
+++ b/containers/production/env/app.env.template
@@ -29,6 +29,10 @@ AUTH_SESSION_TTL_SECONDS=28800
 MCP_CLIENT_ID=kravhantering-mcp
 
 HSA_PERSON_LOOKUP_TIMEOUT_MS=5000
+# Production lookup, issuer, and token URLs must use HTTPS. OIDC discovery may
+# only return a token endpoint on the configured issuer origin. Site-specific
+# firewall, egress-proxy, DNS, route, and upstream ACL policy must allow only
+# the approved destinations.
 HSA_PERSON_LOOKUP_URL=https://kong.example.internal/hsa/person-records/lookup
 # Optional app-to-external-integrationsplattform auth. Leave blank for the
 # internal same-stack Kong route.

--- a/docs/integrations/hsa-person-lookup-integration.md
+++ b/docs/integrations/hsa-person-lookup-integration.md
@@ -59,6 +59,15 @@ Production environments should point at the approved environment-specific
 Kong route or integration-platform REST facade. The browser must never receive
 this endpoint or call it directly.
 
+Production lookup, OAuth issuer, explicit token, and adapter SOAP endpoints
+must use HTTPS. Explicit HTTP fixtures remain available only outside
+production. Application readiness validates configured HSA settings without
+contacting lookup, discovery, token, or SOAP services; absent optional app HSA
+configuration remains ready. The app and adapter repeat endpoint validation
+immediately before outbound requests. Invalid static configuration therefore
+fails before certificate files, client credentials, or cached bearer tokens
+can be used.
+
 `HSA_PERSON_LOOKUP_TIMEOUT_MS` controls the app-side timeout. Keep the default
 unless the approved integration path for an environment requires a different
 timeout.
@@ -77,6 +86,26 @@ changing the URL knob. Set `HSA_PERSON_LOOKUP_CLIENT_CERT_PATH` and
 `HSA_PERSON_LOOKUP_OAUTH_SCOPE` and `HSA_PERSON_LOOKUP_OAUTH_AUDIENCE` are
 sent to the token endpoint when configured. Supplying both mTLS and OAuth2
 enables mixed mode.
+
+OIDC discovery must return an issuer equal to the normalized configured issuer
+and a token endpoint on that issuer's origin. If the approved token service is
+on another origin, configure its HTTPS URL explicitly instead of using the
+discovered endpoint. Lookup, discovery, token, and SOAP transports never follow
+redirects.
+
+The app accepts `application/json` and `application/*+json` responses.
+Discovery responses are limited to 256 KiB; token and REST lookup responses
+are limited to 64 KiB. The adapter accepts `text/xml` and
+`application/soap+xml` responses up to 1 MiB. Media type and streaming byte
+limits apply to successful and error responses, and an over-limit stream is
+aborted before parsing.
+
+The application does not implement site-specific origin allowlists, IP or CIDR
+classification, DNS pinning, or route filtering. Production operators must
+enforce the approved lookup, issuer, explicit token, and SOAP destinations with
+the host firewall, approved egress proxy, controlled DNS, route policy, and
+upstream ACLs. Those controls own loopback, link-local, private-address, DNS
+rebinding, and destination-change protection for each deployed environment.
 
 ## Verify route
 

--- a/docs/operations/rhel10-production-deploy.md
+++ b/docs/operations/rhel10-production-deploy.md
@@ -670,7 +670,10 @@ lookup endpoint. The browser must not call the HSA integration directly; the
 app calls this internal Kong or integration-platform REST facade only when an
 editable HSA-id needs lookup or refresh. Keep
 `HSA_PERSON_LOOKUP_TIMEOUT_MS=5000` unless the approved integration path needs
-another timeout.
+another timeout. Production lookup, OAuth issuer, and explicit token URLs must
+use HTTPS. OIDC discovery accepts only the configured issuer and a token
+endpoint on the same origin; use an explicit approved HTTPS token URL when the
+token service uses another origin.
 
 Leave the optional `HSA_PERSON_LOOKUP_*` authentication values blank for an
 internal same-stack route. When the approved external route requires mTLS, set
@@ -685,6 +688,12 @@ and either `HSA_PERSON_LOOKUP_OAUTH_TOKEN_URL` or
 when the token endpoint requires them. Supplying both mTLS and OAuth2 enables
 mixed mode. The canonical flow is described in
 [HSA person lookup integration](../integrations/hsa-person-lookup-integration.md).
+
+Before rollout, allow only the approved lookup, issuer, explicit token, and
+adapter SOAP destinations through the host firewall, approved egress proxy,
+controlled DNS and routes, and upstream ACLs. These infrastructure controls
+own IP, CIDR, loopback, link-local, private-address, DNS-rebinding, and route
+allowlisting; the application does not duplicate them.
 
 Ownership for the optional MCP service-token client is split by responsibility:
 

--- a/docs/operations/rhel10-production-single-node-self-contained-deploy.md
+++ b/docs/operations/rhel10-production-single-node-self-contained-deploy.md
@@ -1045,7 +1045,10 @@ lookup endpoint. The browser must not call the HSA integration directly; the
 app calls this internal Kong or integration-platform REST facade only when an
 editable HSA-id needs lookup or refresh. Keep
 `HSA_PERSON_LOOKUP_TIMEOUT_MS=5000` unless the approved integration path needs
-another timeout.
+another timeout. Production lookup, OAuth issuer, and explicit token URLs must
+use HTTPS. OIDC discovery accepts only the configured issuer and a token
+endpoint on the same origin; use an explicit approved HTTPS token URL when the
+token service uses another origin.
 
 Leave the optional `HSA_PERSON_LOOKUP_*` authentication values blank for an
 internal same-stack route. When the approved external route requires mTLS, set
@@ -1060,6 +1063,12 @@ and either `HSA_PERSON_LOOKUP_OAUTH_TOKEN_URL` or
 when the token endpoint requires them. Supplying both mTLS and OAuth2 enables
 mixed mode. The canonical flow is described in
 [HSA person lookup integration](../integrations/hsa-person-lookup-integration.md).
+
+Before rollout, allow only the approved lookup, issuer, explicit token, and
+adapter SOAP destinations through the host firewall, approved egress proxy,
+controlled DNS and routes, and upstream ACLs. These infrastructure controls
+own IP, CIDR, loopback, link-local, private-address, DNS-rebinding, and route
+allowlisting; the application does not duplicate them.
 
 Leave `NEXT_PUBLIC_DEFAULT_MODEL`, `OPENROUTER_API_KEY` and
 `OPENROUTER_MGMT_API_KEY` empty unless AI requirement generation is approved

--- a/lib/hsa/person-lookup.ts
+++ b/lib/hsa/person-lookup.ts
@@ -492,6 +492,9 @@ function executeHttpRequest(input: HttpRequestInput): Promise<HttpResponse> {
             )
             return
           }
+          response.on('error', error => {
+            finish(() => reject(error))
+          })
           response.on('data', chunk => {
             const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
             totalBytes += buffer.byteLength
@@ -564,10 +567,14 @@ async function resolveTokenUrl(
     throw new Error('OAuth issuer URL or token URL is required.')
   }
   const issuer = oauth.issuerUrl.replace(/\/+$/u, '')
-  validateEndpointUrl(issuer, 'HSA person lookup OAuth issuer URL', {
-    mtls: Boolean(config.mtls),
-    production: process.env.NODE_ENV === 'production',
-  })
+  const issuerUrl = validateEndpointUrl(
+    issuer,
+    'HSA person lookup OAuth issuer URL',
+    {
+      mtls: Boolean(config.mtls),
+      production: process.env.NODE_ENV === 'production',
+    },
+  )
   const response = await requestImpl({
     headers: { Accept: 'application/json' },
     method: 'GET',
@@ -577,10 +584,10 @@ async function resolveTokenUrl(
     timeoutMs: config.timeoutMs,
     url: `${issuer}/.well-known/openid-configuration`,
   })
-  const payload = parseJsonHttpResponse(response, DISCOVERY_RESPONSE_MAX_BYTES)
   if (response.status < 200 || response.status >= 300) {
     throw new Error(`OIDC discovery failed with ${response.status}.`)
   }
+  const payload = parseJsonHttpResponse(response, DISCOVERY_RESPONSE_MAX_BYTES)
   const discoveredIssuer =
     payload && typeof payload === 'object'
       ? stringField((payload as Record<string, unknown>).issuer)
@@ -589,11 +596,7 @@ async function resolveTokenUrl(
     payload && typeof payload === 'object'
       ? stringField((payload as Record<string, unknown>).token_endpoint)
       : null
-  const normalizedIssuer = oauth.issuerUrl.replace(/\/+$/u, '')
-  if (
-    !discoveredIssuer ||
-    discoveredIssuer.replace(/\/+$/u, '') !== normalizedIssuer
-  ) {
+  if (!discoveredIssuer || discoveredIssuer.replace(/\/+$/u, '') !== issuer) {
     throw new Error(
       'OIDC discovery response issuer did not match configuration.',
     )
@@ -605,11 +608,6 @@ async function resolveTokenUrl(
     mtls: Boolean(config.mtls),
     production: process.env.NODE_ENV === 'production',
   }
-  const issuerUrl = validateEndpointUrl(
-    normalizedIssuer,
-    'HSA person lookup OAuth issuer URL',
-    validationOptions,
-  )
   const tokenUrl = validateEndpointUrl(
     tokenEndpoint,
     'Discovered HSA person lookup OAuth token URL',

--- a/lib/hsa/person-lookup.ts
+++ b/lib/hsa/person-lookup.ts
@@ -82,36 +82,96 @@ interface CachedTlsFile {
   mtimeMs: number
 }
 
+const ENDPOINT_CONFIG_DIAGNOSTICS = {
+  discoveredToken: {
+    httpsRequired: 'hsa_oauth_discovered_token_url_https_required',
+    invalid: 'hsa_oauth_discovered_token_url_invalid',
+    mtlsHttpsRequired: 'hsa_oauth_discovered_token_url_mtls_https_required',
+    protocolInvalid: 'hsa_oauth_discovered_token_url_protocol_invalid',
+  },
+  issuer: {
+    httpsRequired: 'hsa_oauth_issuer_url_https_required',
+    invalid: 'hsa_oauth_issuer_url_invalid',
+    mtlsHttpsRequired: 'hsa_oauth_issuer_url_mtls_https_required',
+    protocolInvalid: 'hsa_oauth_issuer_url_protocol_invalid',
+  },
+  lookup: {
+    httpsRequired: 'hsa_lookup_url_https_required',
+    invalid: 'hsa_lookup_url_invalid',
+    mtlsHttpsRequired: 'hsa_lookup_url_mtls_https_required',
+    protocolInvalid: 'hsa_lookup_url_protocol_invalid',
+  },
+  token: {
+    httpsRequired: 'hsa_oauth_token_url_https_required',
+    invalid: 'hsa_oauth_token_url_invalid',
+    mtlsHttpsRequired: 'hsa_oauth_token_url_mtls_https_required',
+    protocolInvalid: 'hsa_oauth_token_url_protocol_invalid',
+  },
+} as const
+
+type EndpointConfigDiagnostics =
+  (typeof ENDPOINT_CONFIG_DIAGNOSTICS)[keyof typeof ENDPOINT_CONFIG_DIAGNOSTICS]
+
+export type HsaPersonLookupConfigDiagnostic =
+  | EndpointConfigDiagnostics[keyof EndpointConfigDiagnostics]
+  | 'hsa_lookup_auth_requires_url'
+  | 'hsa_lookup_mtls_incomplete'
+  | 'hsa_lookup_oauth_incomplete'
+  | 'hsa_lookup_timeout_invalid'
+
 class HsaPersonLookupConfigError extends Error {
-  constructor(message: string) {
+  readonly diagnostic: HsaPersonLookupConfigDiagnostic
+
+  constructor(diagnostic: HsaPersonLookupConfigDiagnostic, message: string) {
     super(message)
     this.name = 'HsaPersonLookupConfigError'
+    this.diagnostic = diagnostic
   }
+}
+
+export function hsaPersonLookupConfigDiagnostic(
+  error: unknown,
+): HsaPersonLookupConfigDiagnostic | null {
+  return error instanceof HsaPersonLookupConfigError ? error.diagnostic : null
 }
 
 function validateEndpointUrl(
   value: string,
   label: string,
-  { mtls, production }: { mtls: boolean; production: boolean },
+  {
+    diagnostics,
+    mtls,
+    production,
+  }: {
+    diagnostics: EndpointConfigDiagnostics
+    mtls: boolean
+    production: boolean
+  },
 ): URL {
   let parsed: URL
   try {
     parsed = new URL(value)
   } catch {
-    throw new HsaPersonLookupConfigError(`${label} must be a valid URL.`)
+    throw new HsaPersonLookupConfigError(
+      diagnostics.invalid,
+      `${label} must be a valid URL.`,
+    )
   }
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new HsaPersonLookupConfigError(
+      diagnostics.protocolInvalid,
       `${label} must use the HTTP or HTTPS protocol.`,
     )
   }
   if (production && parsed.protocol !== 'https:') {
     throw new HsaPersonLookupConfigError(
+      diagnostics.httpsRequired,
       `${label} must use HTTPS in production.`,
     )
   }
   if (mtls && parsed.protocol !== 'https:') {
     throw new HsaPersonLookupConfigError(
+      diagnostics.mtlsHttpsRequired,
       `${label} must use HTTPS when mTLS is configured.`,
     )
   }
@@ -128,6 +188,7 @@ export function validateHsaPersonLookupConfig(
     config.timeoutMs > 30_000
   ) {
     throw new HsaPersonLookupConfigError(
+      'hsa_lookup_timeout_invalid',
       'HSA person lookup timeout must be an integer from 1 through 30000 milliseconds.',
     )
   }
@@ -136,6 +197,7 @@ export function validateHsaPersonLookupConfig(
     (!stringField(config.mtls.certPath) || !stringField(config.mtls.keyPath))
   ) {
     throw new HsaPersonLookupConfigError(
+      'hsa_lookup_mtls_incomplete',
       'HSA lookup mTLS configuration requires both client certificate and client key paths.',
     )
   }
@@ -147,6 +209,7 @@ export function validateHsaPersonLookupConfig(
         !stringField(config.oauth.issuerUrl)))
   ) {
     throw new HsaPersonLookupConfigError(
+      'hsa_lookup_oauth_incomplete',
       'HSA lookup OAuth2 configuration requires client id, client secret, and token URL or issuer URL.',
     )
   }
@@ -154,19 +217,28 @@ export function validateHsaPersonLookupConfig(
     mtls: Boolean(config.mtls),
     production: env.NODE_ENV === 'production',
   }
-  validateEndpointUrl(config.url, 'HSA person lookup URL', validationOptions)
+  validateEndpointUrl(config.url, 'HSA person lookup URL', {
+    ...validationOptions,
+    diagnostics: ENDPOINT_CONFIG_DIAGNOSTICS.lookup,
+  })
   if (config.oauth?.issuerUrl) {
     validateEndpointUrl(
       config.oauth.issuerUrl,
       'HSA person lookup OAuth issuer URL',
-      validationOptions,
+      {
+        ...validationOptions,
+        diagnostics: ENDPOINT_CONFIG_DIAGNOSTICS.issuer,
+      },
     )
   }
   if (config.oauth?.tokenUrl) {
     validateEndpointUrl(
       config.oauth.tokenUrl,
       'HSA person lookup OAuth token URL',
-      validationOptions,
+      {
+        ...validationOptions,
+        diagnostics: ENDPOINT_CONFIG_DIAGNOSTICS.token,
+      },
     )
   }
 }
@@ -179,6 +251,7 @@ function parseTimeout(value: string | undefined): number {
   const parsed = Number(value)
   if (!Number.isInteger(parsed) || parsed < 1 || parsed > 30_000) {
     throw new HsaPersonLookupConfigError(
+      'hsa_lookup_timeout_invalid',
       'HSA person lookup timeout must be an integer from 1 through 30000 milliseconds.',
     )
   }
@@ -204,6 +277,7 @@ function oauthConfigFromEnv(
   if (!anyOAuth) return undefined
   if (!clientId || !clientSecret || (!tokenUrl && !issuerUrl)) {
     throw new HsaPersonLookupConfigError(
+      'hsa_lookup_oauth_incomplete',
       'HSA lookup OAuth2 configuration requires client id, client secret, and token URL or issuer URL.',
     )
   }
@@ -229,6 +303,7 @@ function mtlsConfigFromEnv(
   if (!anyMtls) return undefined
   if (!certPath || !keyPath) {
     throw new HsaPersonLookupConfigError(
+      'hsa_lookup_mtls_incomplete',
       'HSA lookup mTLS configuration requires both client certificate and client key paths.',
     )
   }
@@ -250,6 +325,7 @@ export function getHsaPersonLookupConfig(
   if (!url) {
     if (mtls || oauth) {
       throw new HsaPersonLookupConfigError(
+        'hsa_lookup_auth_requires_url',
         'HSA lookup authentication configuration requires HSA_PERSON_LOOKUP_URL.',
       )
     }
@@ -571,6 +647,7 @@ async function resolveTokenUrl(
     issuer,
     'HSA person lookup OAuth issuer URL',
     {
+      diagnostics: ENDPOINT_CONFIG_DIAGNOSTICS.issuer,
       mtls: Boolean(config.mtls),
       production: process.env.NODE_ENV === 'production',
     },
@@ -611,7 +688,10 @@ async function resolveTokenUrl(
   const tokenUrl = validateEndpointUrl(
     tokenEndpoint,
     'Discovered HSA person lookup OAuth token URL',
-    validationOptions,
+    {
+      ...validationOptions,
+      diagnostics: ENDPOINT_CONFIG_DIAGNOSTICS.discoveredToken,
+    },
   )
   if (tokenUrl.origin !== issuerUrl.origin) {
     throw new Error('OIDC discovery token endpoint must match issuer origin.')
@@ -636,6 +716,7 @@ async function getOAuthAccessToken(
 
   const tokenUrl = await resolveTokenUrl(oauth, requestImpl, config, signal)
   validateEndpointUrl(tokenUrl, 'HSA person lookup OAuth token URL', {
+    diagnostics: ENDPOINT_CONFIG_DIAGNOSTICS.token,
     mtls: Boolean(config.mtls),
     production: process.env.NODE_ENV === 'production',
   })

--- a/lib/hsa/person-lookup.ts
+++ b/lib/hsa/person-lookup.ts
@@ -11,7 +11,10 @@ import {
 import type { RequirementResponsibilityPersonRecord } from '@/lib/requirements/responsibility-person'
 
 const DEFAULT_TIMEOUT_MS = 5000
+const DISCOVERY_RESPONSE_MAX_BYTES = 256 * 1024
+const LOOKUP_RESPONSE_MAX_BYTES = 64 * 1024
 const OAUTH_CACHE_SKEW_MS = 60_000
+const TOKEN_RESPONSE_MAX_BYTES = 64 * 1024
 const LOOKUP_REASON = {
   conflict: 'hsa_lookup_conflict',
   invalidResponse: 'hsa_lookup_invalid_response',
@@ -47,6 +50,7 @@ export interface HsaPersonLookupConfig {
 interface HttpRequestInput {
   body?: string
   headers?: Record<string, string>
+  maxResponseBytes: number
   method: string
   mtls?: HsaPersonLookupMtlsConfig
   signal?: AbortSignal
@@ -85,14 +89,100 @@ class HsaPersonLookupConfigError extends Error {
   }
 }
 
+function validateEndpointUrl(
+  value: string,
+  label: string,
+  { mtls, production }: { mtls: boolean; production: boolean },
+): URL {
+  let parsed: URL
+  try {
+    parsed = new URL(value)
+  } catch {
+    throw new HsaPersonLookupConfigError(`${label} must be a valid URL.`)
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new HsaPersonLookupConfigError(
+      `${label} must use the HTTP or HTTPS protocol.`,
+    )
+  }
+  if (production && parsed.protocol !== 'https:') {
+    throw new HsaPersonLookupConfigError(
+      `${label} must use HTTPS in production.`,
+    )
+  }
+  if (mtls && parsed.protocol !== 'https:') {
+    throw new HsaPersonLookupConfigError(
+      `${label} must use HTTPS when mTLS is configured.`,
+    )
+  }
+  return parsed
+}
+
+export function validateHsaPersonLookupConfig(
+  config: HsaPersonLookupConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (
+    !Number.isInteger(config.timeoutMs) ||
+    config.timeoutMs < 1 ||
+    config.timeoutMs > 30_000
+  ) {
+    throw new HsaPersonLookupConfigError(
+      'HSA person lookup timeout must be an integer from 1 through 30000 milliseconds.',
+    )
+  }
+  if (
+    config.mtls &&
+    (!stringField(config.mtls.certPath) || !stringField(config.mtls.keyPath))
+  ) {
+    throw new HsaPersonLookupConfigError(
+      'HSA lookup mTLS configuration requires both client certificate and client key paths.',
+    )
+  }
+  if (
+    config.oauth &&
+    (!stringField(config.oauth.clientId) ||
+      !stringField(config.oauth.clientSecret) ||
+      (!stringField(config.oauth.tokenUrl) &&
+        !stringField(config.oauth.issuerUrl)))
+  ) {
+    throw new HsaPersonLookupConfigError(
+      'HSA lookup OAuth2 configuration requires client id, client secret, and token URL or issuer URL.',
+    )
+  }
+  const validationOptions = {
+    mtls: Boolean(config.mtls),
+    production: env.NODE_ENV === 'production',
+  }
+  validateEndpointUrl(config.url, 'HSA person lookup URL', validationOptions)
+  if (config.oauth?.issuerUrl) {
+    validateEndpointUrl(
+      config.oauth.issuerUrl,
+      'HSA person lookup OAuth issuer URL',
+      validationOptions,
+    )
+  }
+  if (config.oauth?.tokenUrl) {
+    validateEndpointUrl(
+      config.oauth.tokenUrl,
+      'HSA person lookup OAuth token URL',
+      validationOptions,
+    )
+  }
+}
+
 const oauthTokenCache = new Map<string, CachedOAuthToken>()
 const tlsFileCache = new Map<string, CachedTlsFile>()
 
 function parseTimeout(value: string | undefined): number {
   if (!value) return DEFAULT_TIMEOUT_MS
   const parsed = Number(value)
-  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_TIMEOUT_MS
-  return Math.min(Math.trunc(parsed), 30_000)
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 30_000) {
+    throw new HsaPersonLookupConfigError(
+      'HSA person lookup timeout must be an integer from 1 through 30000 milliseconds.',
+    )
+  }
+  return parsed
 }
 
 function envString(env: NodeJS.ProcessEnv, name: string): string | undefined {
@@ -134,7 +224,8 @@ function mtlsConfigFromEnv(
   const certPath = envString(env, 'HSA_PERSON_LOOKUP_CLIENT_CERT_PATH')
   const keyPath = envString(env, 'HSA_PERSON_LOOKUP_CLIENT_KEY_PATH')
   const caPath = envString(env, 'HSA_PERSON_LOOKUP_CA_PATH')
-  const anyMtls = certPath || keyPath || caPath
+  const serverName = envString(env, 'HSA_PERSON_LOOKUP_TLS_SERVER_NAME')
+  const anyMtls = certPath || keyPath || caPath || serverName
   if (!anyMtls) return undefined
   if (!certPath || !keyPath) {
     throw new HsaPersonLookupConfigError(
@@ -142,7 +233,6 @@ function mtlsConfigFromEnv(
     )
   }
 
-  const serverName = envString(env, 'HSA_PERSON_LOOKUP_TLS_SERVER_NAME')
   return {
     ...(caPath ? { caPath } : {}),
     certPath,
@@ -154,16 +244,25 @@ function mtlsConfigFromEnv(
 export function getHsaPersonLookupConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): HsaPersonLookupConfig | null {
-  const url = env.HSA_PERSON_LOOKUP_URL?.trim()
-  if (!url) return null
   const mtls = mtlsConfigFromEnv(env)
   const oauth = oauthConfigFromEnv(env)
-  return {
+  const url = envString(env, 'HSA_PERSON_LOOKUP_URL')
+  if (!url) {
+    if (mtls || oauth) {
+      throw new HsaPersonLookupConfigError(
+        'HSA lookup authentication configuration requires HSA_PERSON_LOOKUP_URL.',
+      )
+    }
+    return null
+  }
+  const config: HsaPersonLookupConfig = {
     ...(mtls ? { mtls } : {}),
     ...(oauth ? { oauth } : {}),
     timeoutMs: parseTimeout(env.HSA_PERSON_LOOKUP_TIMEOUT_MS),
     url,
   }
+  validateHsaPersonLookupConfig(config, env)
+  return config
 }
 
 function stringField(value: unknown): string | null {
@@ -180,9 +279,56 @@ function booleanField(value: unknown): boolean {
   return value === true
 }
 
-async function readJson(response: Response): Promise<unknown> {
-  const text = await response.text()
-  return parseJsonText(text)
+function isJsonMediaType(value: string | null | undefined): boolean {
+  const mediaType = value?.split(';', 1)[0]?.trim().toLowerCase()
+  return (
+    mediaType === 'application/json' ||
+    Boolean(
+      mediaType?.startsWith('application/') && mediaType.endsWith('+json'),
+    )
+  )
+}
+
+async function readBoundedResponseBody(
+  response: Response,
+  maxBytes: number,
+): Promise<string> {
+  const declaredLength = Number(response.headers.get('content-length'))
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    await response.body?.cancel()
+    throw new Error('HSA response body exceeds the configured byte limit.')
+  }
+  if (!response.body) return ''
+
+  const reader = response.body.getReader()
+  const chunks: Buffer[] = []
+  let totalBytes = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      totalBytes += value.byteLength
+      if (totalBytes > maxBytes) {
+        await reader.cancel()
+        throw new Error('HSA response body exceeds the configured byte limit.')
+      }
+      chunks.push(Buffer.from(value))
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+async function readJson(
+  response: Response,
+  maxBytes: number,
+): Promise<unknown> {
+  if (!isJsonMediaType(response.headers.get('content-type'))) {
+    await response.body?.cancel()
+    throw new Error('HSA response must use a JSON media type.')
+  }
+  return parseJsonText(await readBoundedResponseBody(response, maxBytes))
 }
 
 function parseJsonText(text: string): unknown {
@@ -330,8 +476,37 @@ function executeHttpRequest(input: HttpRequestInput): Promise<HttpResponse> {
         const transport = isHttps ? https : http
         const req = transport.request(requestOptions, response => {
           const chunks: Buffer[] = []
+          let totalBytes = 0
+          const declaredLength = Number(response.headers['content-length'])
+          if (
+            Number.isFinite(declaredLength) &&
+            declaredLength > input.maxResponseBytes
+          ) {
+            response.destroy()
+            finish(() =>
+              reject(
+                new Error(
+                  'HSA response body exceeds the configured byte limit.',
+                ),
+              ),
+            )
+            return
+          }
           response.on('data', chunk => {
-            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+            const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+            totalBytes += buffer.byteLength
+            if (totalBytes > input.maxResponseBytes) {
+              response.destroy()
+              finish(() =>
+                reject(
+                  new Error(
+                    'HSA response body exceeds the configured byte limit.',
+                  ),
+                ),
+              )
+              return
+            }
+            chunks.push(buffer)
           })
           response.on('end', () => {
             finish(() =>
@@ -357,6 +532,27 @@ function executeHttpRequest(input: HttpRequestInput): Promise<HttpResponse> {
   })
 }
 
+function responseHeader(
+  headers: http.IncomingHttpHeaders,
+  name: string,
+): string | undefined {
+  const value = headers[name]
+  return Array.isArray(value) ? value[0] : value
+}
+
+function parseJsonHttpResponse(
+  response: HttpResponse,
+  maxBytes: number,
+): unknown {
+  if (!isJsonMediaType(responseHeader(response.headers, 'content-type'))) {
+    throw new Error('HSA response must use a JSON media type.')
+  }
+  if (Buffer.byteLength(response.body) > maxBytes) {
+    throw new Error('HSA response body exceeds the configured byte limit.')
+  }
+  return parseJsonText(response.body)
+}
+
 async function resolveTokenUrl(
   oauth: HsaPersonLookupOAuthConfig,
   requestImpl: HttpRequestImpl,
@@ -368,24 +564,59 @@ async function resolveTokenUrl(
     throw new Error('OAuth issuer URL or token URL is required.')
   }
   const issuer = oauth.issuerUrl.replace(/\/+$/u, '')
+  validateEndpointUrl(issuer, 'HSA person lookup OAuth issuer URL', {
+    mtls: Boolean(config.mtls),
+    production: process.env.NODE_ENV === 'production',
+  })
   const response = await requestImpl({
     headers: { Accept: 'application/json' },
     method: 'GET',
+    maxResponseBytes: DISCOVERY_RESPONSE_MAX_BYTES,
     mtls: config.mtls,
     signal,
     timeoutMs: config.timeoutMs,
     url: `${issuer}/.well-known/openid-configuration`,
   })
+  const payload = parseJsonHttpResponse(response, DISCOVERY_RESPONSE_MAX_BYTES)
   if (response.status < 200 || response.status >= 300) {
     throw new Error(`OIDC discovery failed with ${response.status}.`)
   }
-  const payload = parseJsonText(response.body)
+  const discoveredIssuer =
+    payload && typeof payload === 'object'
+      ? stringField((payload as Record<string, unknown>).issuer)
+      : null
   const tokenEndpoint =
     payload && typeof payload === 'object'
       ? stringField((payload as Record<string, unknown>).token_endpoint)
       : null
+  const normalizedIssuer = oauth.issuerUrl.replace(/\/+$/u, '')
+  if (
+    !discoveredIssuer ||
+    discoveredIssuer.replace(/\/+$/u, '') !== normalizedIssuer
+  ) {
+    throw new Error(
+      'OIDC discovery response issuer did not match configuration.',
+    )
+  }
   if (!tokenEndpoint) {
     throw new Error('OIDC discovery response did not include token_endpoint.')
+  }
+  const validationOptions = {
+    mtls: Boolean(config.mtls),
+    production: process.env.NODE_ENV === 'production',
+  }
+  const issuerUrl = validateEndpointUrl(
+    normalizedIssuer,
+    'HSA person lookup OAuth issuer URL',
+    validationOptions,
+  )
+  const tokenUrl = validateEndpointUrl(
+    tokenEndpoint,
+    'Discovered HSA person lookup OAuth token URL',
+    validationOptions,
+  )
+  if (tokenUrl.origin !== issuerUrl.origin) {
+    throw new Error('OIDC discovery token endpoint must match issuer origin.')
   }
   return tokenEndpoint
 }
@@ -406,6 +637,10 @@ async function getOAuthAccessToken(
   }
 
   const tokenUrl = await resolveTokenUrl(oauth, requestImpl, config, signal)
+  validateEndpointUrl(tokenUrl, 'HSA person lookup OAuth token URL', {
+    mtls: Boolean(config.mtls),
+    production: process.env.NODE_ENV === 'production',
+  })
   const form = new URLSearchParams()
   form.set('grant_type', 'client_credentials')
   if (oauth.scope) form.set('scope', oauth.scope)
@@ -419,15 +654,16 @@ async function getOAuthAccessToken(
       'Content-Type': 'application/x-www-form-urlencoded',
     },
     method: 'POST',
+    maxResponseBytes: TOKEN_RESPONSE_MAX_BYTES,
     mtls: config.mtls,
     signal,
     timeoutMs: config.timeoutMs,
     url: tokenUrl,
   })
+  const payload = parseJsonHttpResponse(response, TOKEN_RESPONSE_MAX_BYTES)
   if (response.status < 200 || response.status >= 300) {
     throw new Error(`OAuth token request failed with ${response.status}.`)
   }
-  const payload = parseJsonText(response.body)
   const accessToken =
     payload && typeof payload === 'object'
       ? stringField((payload as Record<string, unknown>).access_token)
@@ -456,7 +692,9 @@ async function postLookupWithHttpRequest(
   requestImpl: HttpRequestImpl,
   signal: AbortSignal,
 ): Promise<{ ok: boolean; payload: unknown; status: number }> {
+  validateHsaPersonLookupConfig(config)
   const accessToken = await getOAuthAccessToken(config, requestImpl, signal)
+  validateHsaPersonLookupConfig(config)
   const response = await requestImpl({
     body: JSON.stringify({ hsaId }),
     headers: {
@@ -465,6 +703,7 @@ async function postLookupWithHttpRequest(
       'Content-Type': 'application/json',
     },
     method: 'POST',
+    maxResponseBytes: LOOKUP_RESPONSE_MAX_BYTES,
     mtls: config.mtls,
     signal,
     timeoutMs: config.timeoutMs,
@@ -472,7 +711,7 @@ async function postLookupWithHttpRequest(
   })
   return {
     ok: response.status >= 200 && response.status < 300,
-    payload: parseJsonText(response.body),
+    payload: parseJsonHttpResponse(response, LOOKUP_RESPONSE_MAX_BYTES),
     status: response.status,
   }
 }
@@ -496,6 +735,7 @@ export async function lookupHsaPerson(
         reason: LOOKUP_REASON.missingConfig,
       })
     }
+    validateHsaPersonLookupConfig(config)
     timeout = setTimeout(() => controller.abort(), config.timeoutMs)
     const response =
       config.mtls || config.oauth
@@ -512,12 +752,13 @@ export async function lookupHsaPerson(
                 body: JSON.stringify({ hsaId }),
                 headers: { 'Content-Type': 'application/json' },
                 method: 'POST',
+                redirect: 'manual',
                 signal: controller.signal,
               },
             )
             return {
               ok: fetchResponse.ok,
-              payload: await readJson(fetchResponse),
+              payload: await readJson(fetchResponse, LOOKUP_RESPONSE_MAX_BYTES),
               status: fetchResponse.status,
             }
           })()

--- a/scripts/__tests__/ci-container-runtime.test.mjs
+++ b/scripts/__tests__/ci-container-runtime.test.mjs
@@ -21,21 +21,22 @@ const CLASSIFIER_PATH = path.resolve(
 )
 const temporaryDirectories = []
 
-function createToolchainFixture() {
+function createToolchainFixture({ toolchain = 'package' } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kh-ci-runtime-'))
   temporaryDirectories.push(root)
   const systemPrefix = path.join(root, 'usr')
   const localPrefix = path.join(root, 'usr-local')
-  const binDir = path.join(systemPrefix, 'bin')
-  const libexecDir = path.join(systemPrefix, 'libexec', 'podman')
+  const toolchainPrefix = toolchain === 'static' ? localPrefix : systemPrefix
+  const binDir = path.join(toolchainPrefix, 'bin')
+  const libexecDir = path.join(toolchainPrefix, 'libexec', 'podman')
   const userGeneratorDir = path.join(
-    systemPrefix,
+    toolchainPrefix,
     'lib',
     'systemd',
     'user-generators',
   )
   const systemGeneratorDir = path.join(
-    systemPrefix,
+    toolchainPrefix,
     'lib',
     'systemd',
     'system-generators',
@@ -49,13 +50,17 @@ function createToolchainFixture() {
     'containers.conf.d',
     '00-fix-runtime.conf',
   )
+  const conmonPath =
+    toolchain === 'static'
+      ? path.join(localPrefix, 'lib', 'podman', 'conmon')
+      : path.join(binDir, 'conmon')
   fs.mkdirSync(binDir, { recursive: true })
   fs.mkdirSync(libexecDir, { recursive: true })
+  fs.mkdirSync(path.dirname(conmonPath), { recursive: true })
   fs.mkdirSync(userGeneratorDir, { recursive: true })
   fs.mkdirSync(systemGeneratorDir, { recursive: true })
 
   const podmanPath = path.join(binDir, 'podman')
-  const conmonPath = path.join(binDir, 'conmon')
   const crunPath = path.join(binDir, 'crun')
   const generatorPath = path.join(libexecDir, 'quadlet')
   fs.writeFileSync(
@@ -248,6 +253,32 @@ describe('CI container runtime', () => {
     )
     expect(commands.includes('skopeo')).toBe(usesSkopeo)
   })
+
+  it.each([
+    ['pr', false],
+    ['release', true],
+  ])(
+    'keeps a coherent static runner %s profile instead of downgrading it',
+    (profile, usesSkopeo) => {
+      const fixture = createToolchainFixture({ toolchain: 'static' })
+
+      const result = runRuntimeScript(['bootstrap', profile], fixture)
+
+      expect(result.status).toBe(0)
+      expect(result.stdout).toContain('coherent static toolchain: verified')
+      const podmanCommands = fs.readFileSync(fixture.commandLog, 'utf8')
+      expect(podmanCommands).toContain('--log-level=debug info --format json')
+      expect(podmanCommands).not.toContain('system reset')
+      const sudoCommands = fs.readFileSync(fixture.sudoLog, 'utf8')
+      expect(sudoCommands).toContain(
+        'apt-get install -y --no-install-recommends --reinstall jq libnss3-tools',
+      )
+      expect(sudoCommands.includes('skopeo')).toBe(usesSkopeo)
+      expect(sudoCommands).not.toContain(' podman')
+      expect(sudoCommands).not.toContain(' conmon')
+      expect(sudoCommands).not.toContain(' crun')
+    },
+  )
 
   it('aborts bootstrap before replacing binaries when Podman reset fails', () => {
     const fixture = createToolchainFixture()

--- a/scripts/__tests__/ci-container-runtime.test.mjs
+++ b/scripts/__tests__/ci-container-runtime.test.mjs
@@ -63,6 +63,7 @@ function createToolchainFixture() {
     [
       '#!/usr/bin/env bash',
       'printf \'%s\\n\' "$*" >>"$CI_FAKE_PODMAN_LOG"',
+      '[[ "$1" == "--log-level=debug" ]] && shift',
       'case "$1" in',
       "  --version) printf 'podman version 4.9.3\\n' ;;",
       '  info)',
@@ -309,6 +310,9 @@ describe('CI container runtime', () => {
     expect(result.status).not.toBe(0)
     expect(result.stderr).toContain(
       'cannot inspect the selected Podman runtime toolchain (exit 124)',
+    )
+    expect(fs.readFileSync(fixture.commandLog, 'utf8')).toContain(
+      '--log-level=debug info --format json',
     )
   })
 

--- a/scripts/__tests__/ci-container-runtime.test.mjs
+++ b/scripts/__tests__/ci-container-runtime.test.mjs
@@ -70,7 +70,7 @@ function createToolchainFixture() {
       '    printf \'{"host":{"conmon":{"path":"%s"},"ociRuntime":{"path":"%s"}}}\\n\' "$CI_FAKE_CONMON_PATH" "$CI_FAKE_CRUN_PATH"',
       '    ;;',
       `  run) exit "\${CI_FAKE_RUN_STATUS:-0}" ;;`,
-      `  system) [[ "$2" == migrate ]] && exit "\${CI_FAKE_MIGRATE_STATUS:-0}" ;;`,
+      `  system) [[ "$2 $3" == "reset --force" ]] && exit "\${CI_FAKE_RESET_STATUS:-0}" ;;`,
       'esac',
       '',
     ].join('\n'),
@@ -130,6 +130,7 @@ function createToolchainFixture() {
     env: {
       ...process.env,
       GH_TOKEN: '',
+      GITHUB_ACTIONS: 'true',
       GITHUB_REPOSITORY: '',
       GITHUB_RUN_ID: '',
       CI_FAKE_CONMON_PATH: conmonPath,
@@ -235,10 +236,10 @@ describe('CI container runtime', () => {
     expect(fs.existsSync(fixture.containersConfigPath)).toBe(false)
     expect(fs.existsSync(fixture.runtimeDropInPath)).toBe(false)
     expect(fs.readFileSync(fixture.commandLog, 'utf8')).toContain(
-      'system migrate',
+      'system reset --force',
     )
     expect(result.stdout).toContain(
-      'existing rootless Podman runtime state: stopped',
+      'existing rootless Podman runtime state: reset',
     )
     const commands = fs.readFileSync(fixture.sudoLog, 'utf8')
     expect(commands).toContain(
@@ -247,7 +248,7 @@ describe('CI container runtime', () => {
     expect(commands.includes('skopeo')).toBe(usesSkopeo)
   })
 
-  it('aborts bootstrap before replacing binaries when Podman migration fails', () => {
+  it('aborts bootstrap before replacing binaries when Podman reset fails', () => {
     const fixture = createToolchainFixture()
     const preinstalledPath = path.join(
       fixture.localPrefix,
@@ -259,14 +260,37 @@ describe('CI container runtime', () => {
     fs.writeFileSync(preinstalledPath, 'foreign toolchain')
 
     const result = runRuntimeScript(['bootstrap', 'pr'], fixture, {
-      CI_FAKE_MIGRATE_STATUS: '42',
+      CI_FAKE_RESET_STATUS: '42',
     })
 
     expect(result.status).not.toBe(0)
     expect(result.stderr).toContain(
-      'cannot stop the existing rootless Podman runtime state (exit 42)',
+      'cannot reset the existing rootless Podman runtime state (exit 42)',
     )
     expect(fs.existsSync(preinstalledPath)).toBe(true)
+    expect(
+      fs.existsSync(fixture.sudoLog)
+        ? fs.readFileSync(fixture.sudoLog, 'utf8')
+        : '',
+    ).not.toContain('apt-get')
+  })
+
+  it('refuses to reset Podman state outside an ephemeral GitHub Actions runner', () => {
+    const fixture = createToolchainFixture()
+
+    const result = runRuntimeScript(['bootstrap', 'pr'], fixture, {
+      GITHUB_ACTIONS: '',
+    })
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain(
+      'refusing to reset rootless Podman state outside GitHub Actions',
+    )
+    expect(
+      fs.existsSync(fixture.commandLog)
+        ? fs.readFileSync(fixture.commandLog, 'utf8')
+        : '',
+    ).not.toContain('system reset')
     expect(
       fs.existsSync(fixture.sudoLog)
         ? fs.readFileSync(fixture.sudoLog, 'utf8')

--- a/scripts/__tests__/ci-container-runtime.test.mjs
+++ b/scripts/__tests__/ci-container-runtime.test.mjs
@@ -354,6 +354,59 @@ describe('CI container runtime', () => {
     expect(completeEvidence).not.toContain(secret)
   })
 
+  it('bounds Podman inspection while collecting runtime evidence', () => {
+    const fixture = createToolchainFixture()
+    const evidenceDirectory = path.join(fixture.root, 'evidence')
+
+    const result = runRuntimeScript(['collect'], fixture, {
+      CI_FAKE_INFO_DELAY_SECONDS: '2',
+      CI_RUNTIME_COMMAND_TIMEOUT_SECONDS: '1',
+      CI_RUNTIME_EVIDENCE_DIR: evidenceDirectory,
+    })
+
+    expect(result.status).toBe(0)
+    expect(
+      fs.readFileSync(path.join(evidenceDirectory, 'podman-info.json'), 'utf8'),
+    ).not.toContain('ociRuntime')
+    expect(
+      fs.readFileSync(
+        path.join(evidenceDirectory, 'classification.txt'),
+        'utf8',
+      ),
+    ).toContain('unknown')
+  })
+
+  it('defers current-job runner metadata until the job has completed', () => {
+    const fixture = createToolchainFixture()
+    const evidenceDirectory = path.join(fixture.root, 'evidence')
+    const ghCallLog = path.join(fixture.root, 'gh-calls.log')
+    const ghPath = path.join(fixture.root, 'usr', 'bin', 'gh')
+    fs.writeFileSync(
+      ghPath,
+      [
+        '#!/usr/bin/env bash',
+        'printf \'%s\\n\' "$*" >>"$CI_FAKE_GH_CALL_LOG"',
+        'exit 99',
+        '',
+      ].join('\n'),
+      { mode: 0o755 },
+    )
+
+    const result = runRuntimeScript(['collect'], fixture, {
+      CI_FAKE_GH_CALL_LOG: ghCallLog,
+      CI_RUNTIME_EVIDENCE_DIR: evidenceDirectory,
+      GH_TOKEN: 'test-token',
+      GITHUB_REPOSITORY: 'viscalyx/Kravhantering',
+      GITHUB_RUN_ID: '12345',
+    })
+
+    expect(result.status).toBe(0)
+    expect(fs.existsSync(ghCallLog)).toBe(false)
+    expect(
+      fs.existsSync(path.join(evidenceDirectory, 'github-runner-metadata.txt')),
+    ).toBe(false)
+  })
+
   it('records provenance for runtime paths selected outside the package toolchain', () => {
     const fixture = createToolchainFixture()
     const evidenceDirectory = path.join(fixture.root, 'evidence')

--- a/scripts/__tests__/production-smoke-output.test.mjs
+++ b/scripts/__tests__/production-smoke-output.test.mjs
@@ -245,6 +245,7 @@ describe('production smoke output', () => {
     expect(kongUnit).toContain(
       `Volume=${configRoot}/kong-tls/kong.crt:/run/kong-tls/server.crt:ro`,
     )
+    expect(kongUnit).toContain('Environment=KONG_PREFIX=/tmp/kong')
     expect(kongUnit).toContain('PodmanArgs=--group-add=keep-groups')
     expect(kongUnit).not.toContain('@@CONFIG_ROOT@@')
   })

--- a/scripts/__tests__/production-smoke-output.test.mjs
+++ b/scripts/__tests__/production-smoke-output.test.mjs
@@ -245,6 +245,7 @@ describe('production smoke output', () => {
     expect(kongUnit).toContain(
       `Volume=${configRoot}/kong-tls/kong.crt:/run/kong-tls/server.crt:ro`,
     )
+    expect(kongUnit).toContain('PodmanArgs=--group-add=keep-groups')
     expect(kongUnit).not.toContain('@@CONFIG_ROOT@@')
   })
 

--- a/scripts/__tests__/production-smoke-output.test.mjs
+++ b/scripts/__tests__/production-smoke-output.test.mjs
@@ -169,7 +169,85 @@ function runCaTrust(updateStatus) {
   })
 }
 
+function renderHsaSmokeConfiguration() {
+  const temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'kh-hsa-smoke-config-'),
+  )
+  temporaryDirectories.push(temporaryDirectory)
+  const appEnvPath = path.join(temporaryDirectory, 'app.env')
+  const serviceHome = path.join(temporaryDirectory, 'service-home')
+  const configRoot = path.join(temporaryDirectory, 'config')
+  fs.writeFileSync(
+    appEnvPath,
+    [
+      'AUTH_OIDC_ISSUER_URL=https://kravhantering.test/auth/realms/kravhantering-test',
+      'HSA_PERSON_LOOKUP_URL=http://localhost:8000/hsa/person-records/lookup',
+      'DB_TRUST_SERVER_CERTIFICATE=true',
+      '',
+    ].join('\n'),
+  )
+
+  const shell = `
+    source "$1"
+    SERVICE_HOME="$2"
+    CONFIG_ROOT="$3"
+    INSTALL_ROOT=/opt/kravhantering
+    HSA_DIRECTORY_MOCK_IMAGE_REF=test/hsa-directory-mock:latest
+    HSA_PERSON_LOOKUP_ADAPTER_IMAGE_REF=test/hsa-person-lookup-adapter:latest
+    KONG_IMAGE_REF=test/kong:latest
+    configure_smoke_app_env "$4"
+    as_service() { "$@"; }
+    render_ci_overlay
+  `
+  const result = childProcess.spawnSync(
+    'bash',
+    [
+      '-c',
+      shell,
+      'bash',
+      PRODUCTION_SMOKE_PATH,
+      serviceHome,
+      configRoot,
+      appEnvPath,
+    ],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  )
+  const kongUnitPath = path.join(
+    serviceHome,
+    '.config/containers/systemd/kravhantering-ci-kong.container',
+  )
+  return {
+    appEnv: fs.readFileSync(appEnvPath, 'utf8'),
+    configRoot,
+    kongUnit: fs.existsSync(kongUnitPath)
+      ? fs.readFileSync(kongUnitPath, 'utf8')
+      : '',
+    result,
+  }
+}
+
 describe('production smoke output', () => {
+  it('renders the CI-only HSA route with verified HTTPS', () => {
+    const { appEnv, configRoot, kongUnit, result } =
+      renderHsaSmokeConfiguration()
+
+    expect(result.stderr).toBe('')
+    expect(result.status).toBe(0)
+    expect(appEnv).toContain(
+      'HSA_PERSON_LOOKUP_URL=https://kong:8443/hsa/person-records/lookup',
+    )
+    expect(kongUnit).toContain(
+      'Environment="KONG_PROXY_LISTEN=0.0.0.0:8443 ssl"',
+    )
+    expect(kongUnit).toContain(
+      'Environment=KONG_SSL_CERT=/run/kong-tls/server.crt',
+    )
+    expect(kongUnit).toContain(
+      `Volume=${configRoot}/kong-tls/kong.crt:/run/kong-tls/server.crt:ro`,
+    )
+    expect(kongUnit).not.toContain('@@CONFIG_ROOT@@')
+  })
+
   it('summarizes expected readiness retries with lifecycle context', () => {
     const { countPath, result } = runReadinessProbe(12)
 

--- a/scripts/__tests__/production-smoke-output.test.mjs
+++ b/scripts/__tests__/production-smoke-output.test.mjs
@@ -247,6 +247,9 @@ describe('production smoke output', () => {
     )
     expect(kongUnit).toContain('Environment=KONG_PREFIX=/tmp/kong')
     expect(kongUnit).toContain('PodmanArgs=--group-add=keep-groups')
+    expect(kongUnit).toContain(
+      'Tmpfs=/tmp:rw,size=64M,mode=1777,U,nosuid,nodev,noexec',
+    )
     expect(kongUnit).not.toContain('@@CONFIG_ROOT@@')
   })
 

--- a/scripts/containers/ci-container-runtime.sh
+++ b/scripts/containers/ci-container-runtime.sh
@@ -4,10 +4,20 @@ set -euo pipefail
 
 SYSTEM_PREFIX="${CI_RUNTIME_SYSTEM_PREFIX:-/usr}"
 LOCAL_PREFIX="${CI_RUNTIME_LOCAL_PREFIX:-/usr/local}"
-PODMAN_BIN="${CI_RUNTIME_PODMAN_BIN:-$SYSTEM_PREFIX/bin/podman}"
-CONMON_BIN="${CI_RUNTIME_CONMON_BIN:-$SYSTEM_PREFIX/bin/conmon}"
-CRUN_BIN="${CI_RUNTIME_CRUN_BIN:-$SYSTEM_PREFIX/bin/crun}"
-QUADLET_GENERATOR="${CI_RUNTIME_QUADLET_GENERATOR:-$SYSTEM_PREFIX/libexec/podman/quadlet}"
+PACKAGE_PODMAN_BIN="$SYSTEM_PREFIX/bin/podman"
+PACKAGE_CONMON_BIN="$SYSTEM_PREFIX/bin/conmon"
+PACKAGE_CRUN_BIN="$SYSTEM_PREFIX/bin/crun"
+PACKAGE_QUADLET_GENERATOR="$SYSTEM_PREFIX/libexec/podman/quadlet"
+STATIC_PODMAN_BIN="$LOCAL_PREFIX/bin/podman"
+STATIC_CONMON_BIN="$LOCAL_PREFIX/lib/podman/conmon"
+STATIC_CRUN_BIN="$LOCAL_PREFIX/bin/crun"
+STATIC_QUADLET_GENERATOR="$LOCAL_PREFIX/libexec/podman/quadlet"
+PODMAN_BIN="${CI_RUNTIME_PODMAN_BIN:-$(command -v podman 2>/dev/null || true)}"
+PODMAN_BIN="${PODMAN_BIN:-$PACKAGE_PODMAN_BIN}"
+CONMON_BIN=''
+CRUN_BIN=''
+QUADLET_GENERATOR=''
+TOOLCHAIN_PROFILE=''
 DPKG_QUERY_BIN="${CI_RUNTIME_DPKG_QUERY_BIN:-dpkg-query}"
 SUDO_BIN="${CI_RUNTIME_SUDO_BIN:-sudo}"
 APT_GET_BIN="${CI_RUNTIME_APT_GET_BIN:-apt-get}"
@@ -25,6 +35,24 @@ fail() {
 
 canonical_path() {
   realpath -m -- "$1"
+}
+
+select_toolchain() {
+  local resolved_podman
+  resolved_podman="$(canonical_path "$PODMAN_BIN")"
+  if [[ "$resolved_podman" == "$(canonical_path "$STATIC_PODMAN_BIN")" ]]; then
+    TOOLCHAIN_PROFILE=static
+    CONMON_BIN="${CI_RUNTIME_CONMON_BIN:-$STATIC_CONMON_BIN}"
+    CRUN_BIN="${CI_RUNTIME_CRUN_BIN:-$STATIC_CRUN_BIN}"
+    QUADLET_GENERATOR="${CI_RUNTIME_QUADLET_GENERATOR:-$STATIC_QUADLET_GENERATOR}"
+  elif [[ "$resolved_podman" == "$(canonical_path "$PACKAGE_PODMAN_BIN")" ]]; then
+    TOOLCHAIN_PROFILE=package
+    CONMON_BIN="${CI_RUNTIME_CONMON_BIN:-$PACKAGE_CONMON_BIN}"
+    CRUN_BIN="${CI_RUNTIME_CRUN_BIN:-$PACKAGE_CRUN_BIN}"
+    QUADLET_GENERATOR="${CI_RUNTIME_QUADLET_GENERATOR:-$PACKAGE_QUADLET_GENERATOR}"
+  else
+    fail "Podman resolves outside the supported runner toolchains: $PODMAN_BIN"
+  fi
 }
 
 run_bounded() {
@@ -122,13 +150,16 @@ resolved_generator() {
 
 verify_toolchain() {
   local generator podman_info selected_conmon selected_runtime status
+  select_toolchain
   assert_executable "$PODMAN_BIN"
   assert_executable "$CONMON_BIN"
   assert_executable "$CRUN_BIN"
   assert_executable "$QUADLET_GENERATOR"
   verify_command_resolution podman "$PODMAN_BIN"
-  verify_command_resolution conmon "$CONMON_BIN"
   verify_command_resolution crun "$CRUN_BIN"
+  if [[ "$TOOLCHAIN_PROFILE" == package ]]; then
+    verify_command_resolution conmon "$CONMON_BIN"
+  fi
 
   generator="$(resolved_generator)"
   [[ "$generator" == "$(canonical_path "$QUADLET_GENERATOR")" ]] ||
@@ -151,16 +182,18 @@ verify_toolchain() {
   [[ "$(canonical_path "$selected_runtime")" == "$(canonical_path "$CRUN_BIN")" ]] ||
     fail "Podman selected unexpected OCI runtime: $selected_runtime"
 
-  assert_package_owner "$PODMAN_BIN" podman
-  assert_package_owner "$CONMON_BIN" conmon
-  assert_package_owner "$CRUN_BIN" crun
-  assert_package_owner "$QUADLET_GENERATOR" podman
+  if [[ "$TOOLCHAIN_PROFILE" == package ]]; then
+    assert_package_owner "$PODMAN_BIN" podman
+    assert_package_owner "$CONMON_BIN" conmon
+    assert_package_owner "$CRUN_BIN" crun
+    assert_package_owner "$QUADLET_GENERATOR" podman
+  fi
 
   "$PODMAN_BIN" --version
   "$CONMON_BIN" --version
   "$CRUN_BIN" --version
   "$QUADLET_GENERATOR" --version
-  printf '%s\n' 'coherent package toolchain: verified'
+  printf 'coherent %s toolchain: verified\n' "$TOOLCHAIN_PROFILE"
 }
 
 bootstrap_toolchain() {
@@ -169,6 +202,17 @@ bootstrap_toolchain() {
   [[ "$profile" == pr || "$profile" == release ]] ||
     fail 'bootstrap expects the pr or release profile'
   [[ "$profile" == release ]] && packages+=(skopeo)
+
+  select_toolchain
+  if [[ "$TOOLCHAIN_PROFILE" == static ]]; then
+    packages=(jq libnss3-tools)
+    [[ "$profile" == release ]] && packages+=(skopeo)
+    "$SUDO_BIN" "$APT_GET_BIN" update
+    "$SUDO_BIN" "$APT_GET_BIN" install -y --no-install-recommends \
+      --reinstall "${packages[@]}"
+    verify_toolchain
+    return 0
+  fi
 
   reset_existing_rootless_runtime
   remove_runner_static_configuration
@@ -358,6 +402,7 @@ collect_component_evidence() {
   local directory name podman_command podman_info selected_conmon selected_runtime
   local -a directories
   local search_path="${CI_RUNTIME_GENERATOR_SEARCH_PATH:-/run/systemd/user-generators:/etc/systemd/user-generators:$LOCAL_PREFIX/lib/systemd/user-generators:$SYSTEM_PREFIX/lib/systemd/user-generators:/lib/systemd/user-generators}"
+  select_toolchain
   : >"$EVIDENCE_DIR/runtime-components.txt"
 
   append_component_evidence expected-podman "$PODMAN_BIN"

--- a/scripts/containers/ci-container-runtime.sh
+++ b/scripts/containers/ci-container-runtime.sh
@@ -134,7 +134,9 @@ verify_toolchain() {
   [[ "$generator" == "$(canonical_path "$QUADLET_GENERATOR")" ]] ||
     fail "systemd selected unexpected Quadlet generator: $generator"
 
-  if podman_info="$(run_bounded "$PODMAN_BIN" info --format json)"; then
+  if podman_info="$(
+    run_bounded "$PODMAN_BIN" --log-level=debug info --format json
+  )"; then
     :
   else
     status="$?"
@@ -377,7 +379,7 @@ collect_component_evidence() {
 
   podman_command="$(command -v podman 2>/dev/null || true)"
   [[ -n "$podman_command" ]] || podman_command="$PODMAN_BIN"
-  run_bounded "$podman_command" info --format json \
+  run_bounded "$podman_command" --log-level=debug info --format json \
     >"$EVIDENCE_DIR/podman-info.json" 2>&1 || true
   podman_info="$(<"$EVIDENCE_DIR/podman-info.json")"
   selected_conmon="$(jq -er '.host.conmon.path' <<<"$podman_info" 2>/dev/null || true)"

--- a/scripts/containers/ci-container-runtime.sh
+++ b/scripts/containers/ci-container-runtime.sh
@@ -60,16 +60,21 @@ remove_runner_static_configuration() {
   fi
 }
 
-stop_existing_rootless_runtime() {
+reset_existing_rootless_runtime() {
   local existing_podman status
   existing_podman="$(command -v podman 2>/dev/null || true)"
   [[ -n "$existing_podman" ]] || return 0
-  printf '%s\n' 'Stopping existing rootless Podman runtime state before replacing the toolchain.'
-  if run_bounded "$existing_podman" system migrate; then
-    printf '%s\n' 'existing rootless Podman runtime state: stopped'
+  [[ "${GITHUB_ACTIONS:-}" == true ]] ||
+    fail 'refusing to reset rootless Podman state outside GitHub Actions'
+  printf '%s\n' 'Resetting existing rootless Podman runtime state before replacing the toolchain.'
+  # Hosted runners are disposable and have no workflow-owned Podman resources yet.
+  # A migration writes state for the preinstalled version, which can be newer than
+  # Ubuntu's package version and therefore unsafe to reuse after the downgrade.
+  if run_bounded "$existing_podman" system reset --force; then
+    printf '%s\n' 'existing rootless Podman runtime state: reset'
   else
     status="$?"
-    fail "cannot stop the existing rootless Podman runtime state (exit $status)"
+    fail "cannot reset the existing rootless Podman runtime state (exit $status)"
   fi
 }
 
@@ -163,7 +168,7 @@ bootstrap_toolchain() {
     fail 'bootstrap expects the pr or release profile'
   [[ "$profile" == release ]] && packages+=(skopeo)
 
-  stop_existing_rootless_runtime
+  reset_existing_rootless_runtime
   remove_runner_static_configuration
   "$SUDO_BIN" rm -rf -- \
     "$LOCAL_PREFIX/lib/podman" \

--- a/scripts/containers/ci-container-runtime.sh
+++ b/scripts/containers/ci-container-runtime.sh
@@ -372,7 +372,8 @@ collect_component_evidence() {
 
   podman_command="$(command -v podman 2>/dev/null || true)"
   [[ -n "$podman_command" ]] || podman_command="$PODMAN_BIN"
-  "$podman_command" info --format json >"$EVIDENCE_DIR/podman-info.json" 2>&1 || true
+  run_bounded "$podman_command" info --format json \
+    >"$EVIDENCE_DIR/podman-info.json" 2>&1 || true
   podman_info="$(<"$EVIDENCE_DIR/podman-info.json")"
   selected_conmon="$(jq -er '.host.conmon.path' <<<"$podman_info" 2>/dev/null || true)"
   selected_runtime="$(jq -er '.host.ociRuntime.path' <<<"$podman_info" 2>/dev/null || true)"
@@ -415,7 +416,6 @@ collect_diagnostics() {
   [[ -n "$EVIDENCE_DIR" ]] || fail 'collect requires CI_RUNTIME_EVIDENCE_DIR'
   mkdir -p -- "$EVIDENCE_DIR"
   write_runner_metadata "$EVIDENCE_DIR/runner.json"
-  collect_github_runner_metadata
   {
     uname -a
     cat /etc/os-release

--- a/scripts/containers/production-smoke.sh
+++ b/scripts/containers/production-smoke.sh
@@ -168,14 +168,19 @@ install_archive() {
   sudo ln -sfn "$release_root" "$INSTALL_ROOT/current"
 }
 
+configure_smoke_app_env() {
+  local app_env="$1"
+  sed -i \
+    -e 's#/realms/kravhantering-test#/realms/kravhantering-production#' \
+    -e 's#^HSA_PERSON_LOOKUP_URL=.*#HSA_PERSON_LOOKUP_URL=https://kong:8443/hsa/person-records/lookup#' \
+    -e 's#^DB_TRUST_SERVER_CERTIFICATE=.*#DB_TRUST_SERVER_CERTIFICATE=false#' \
+    "$app_env"
+}
+
 render_runtime_configuration() {
   CONFIG_TEMP_DIR="$(mktemp -d)"
   cp containers/app/.env.app.local "$CONFIG_TEMP_DIR/app.env"
-  sed -i \
-    -e 's#/realms/kravhantering-test#/realms/kravhantering-production#' \
-    -e 's#^HSA_PERSON_LOOKUP_URL=.*#HSA_PERSON_LOOKUP_URL=http://kong:8000/hsa/person-records/lookup#' \
-    -e 's#^DB_TRUST_SERVER_CERTIFICATE=.*#DB_TRUST_SERVER_CERTIFICATE=false#' \
-    "$CONFIG_TEMP_DIR/app.env"
+  configure_smoke_app_env "$CONFIG_TEMP_DIR/app.env"
   cp containers/db-job/.env.db-job.local "$CONFIG_TEMP_DIR/db-job.env"
   sed -i \
     -e 's#^DB_TRUST_SERVER_CERTIFICATE=.*#DB_TRUST_SERVER_CERTIFICATE=false#' \
@@ -242,9 +247,16 @@ render_runtime_configuration() {
     'allow ::1/128;' \
     >"$CONFIG_TEMP_DIR/nginx-readiness-probes.conf"
 
+  node scripts/containers/generate-tls.mjs \
+    --hostname kong \
+    --output-dir "$CONFIG_TEMP_DIR/kong-tls" \
+    --ca-cert tmp/container-tls/ca.crt \
+    --ca-key tmp/container-tls/ca.key
+
   sudo install -d -o root -g "$SERVICE_USER" -m 0750 \
     "$CONFIG_ROOT" "$CONFIG_ROOT/keycloak" "$CONFIG_ROOT/sqlserver-tls" \
-    "$CONFIG_ROOT/tls" "$CONFIG_ROOT/keycloak-management-tls"
+    "$CONFIG_ROOT/tls" "$CONFIG_ROOT/keycloak-management-tls" \
+    "$CONFIG_ROOT/kong-tls"
   for file in app.env db-job.env keycloak.env release.env sqlserver.env; do
     sudo install -o root -g "$SERVICE_USER" -m 0640 \
       "$CONFIG_TEMP_DIR/$file" "$CONFIG_ROOT/$file"
@@ -261,6 +273,10 @@ render_runtime_configuration() {
     tmp/container-tls/kravhantering.test.key "$CONFIG_ROOT/tls/privkey.pem"
   sudo install -o root -g "$SERVICE_USER" -m 0644 \
     tmp/container-tls/ca.crt "$CONFIG_ROOT/tls/ca.crt"
+  sudo install -o root -g "$SERVICE_USER" -m 0644 \
+    "$CONFIG_TEMP_DIR/kong-tls/kong.crt" "$CONFIG_ROOT/kong-tls/kong.crt"
+  sudo install -o root -g "$SERVICE_USER" -m 0640 \
+    "$CONFIG_TEMP_DIR/kong-tls/kong.key" "$CONFIG_ROOT/kong-tls/kong.key"
   sudo install -o root -g "$SERVICE_USER" -m 0644 \
     tmp/container-tls/sqlserver.crt \
     "$CONFIG_ROOT/sqlserver-tls/server.crt"
@@ -339,6 +355,7 @@ render_ci_overlay() {
     fi
     sed \
       -e "s#@@BUNDLE_ROOT@@#$INSTALL_ROOT/current#g" \
+      -e "s#@@CONFIG_ROOT@@#$CONFIG_ROOT#g" \
       -e "s#@@HSA_DIRECTORY_MOCK_IMAGE_REF@@#$HSA_DIRECTORY_MOCK_IMAGE_REF#g" \
       -e "s#@@HSA_PERSON_LOOKUP_ADAPTER_IMAGE_REF@@#$HSA_PERSON_LOOKUP_ADAPTER_IMAGE_REF#g" \
       -e "s#@@KONG_IMAGE_REF@@#$KONG_IMAGE_REF#g" \

--- a/tests/release-smoke/release-smoke.md
+++ b/tests/release-smoke/release-smoke.md
@@ -75,7 +75,8 @@ flowchart TD
   production realm.
 - The CI-only Quadlet overlay starts Kong, the HSA person lookup adapter and
   the HSA directory mock. The app runtime receives
-  `HSA_PERSON_LOOKUP_URL=http://kong:8000/hsa/person-records/lookup`.
+  `HSA_PERSON_LOOKUP_URL=https://kong:8443/hsa/person-records/lookup`; Kong's
+  CI-only certificate is issued by the same disposable CA trusted by the app.
 - The config adds same-origin and `X-Requested-With` headers so API mutations
   exercise the same CSRF path as the browser UI.
 

--- a/tests/unit/github-actions-workflow-security.test.ts
+++ b/tests/unit/github-actions-workflow-security.test.ts
@@ -773,7 +773,7 @@ describe('GitHub Actions workflow security', () => {
     }
   })
 
-  it('keeps container runtime diagnostics best-effort with job-scoped permissions', () => {
+  it('keeps container runtime diagnostics bounded and cancellation-safe', () => {
     const cases = [
       {
         fileName: 'container-pr-smoke.yml',
@@ -804,9 +804,11 @@ describe('GitHub Actions workflow security', () => {
       expect(job?.permissions).toEqual(permissions)
       expect(diagnostics).toMatchObject({
         'continue-on-error': true,
-        if: 'always()',
+        if: ['${{', '!cancelled()', '}}'].join(' '),
         run: 'scripts/containers/ci-container-runtime.sh collect',
+        'timeout-minutes': 2,
       })
+      expect(diagnostics?.env).toBeUndefined()
     }
 
     const prWorkflow = readWorkflowYaml('container-pr-smoke.yml')

--- a/tests/unit/hsa-person-lookup.test.ts
+++ b/tests/unit/hsa-person-lookup.test.ts
@@ -392,6 +392,47 @@ describe('HSA person lookup', () => {
     }
   })
 
+  it('rejects when the native HTTP response stream errors', async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, {
+        'Content-Length': '100',
+        'Content-Type': 'application/json',
+      })
+      response.write('{"access_token":"partial')
+      setImmediate(() => response.socket?.destroy())
+    })
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') throw new Error('No port')
+      const origin = `http://127.0.0.1:${address.port}`
+
+      await expect(
+        lookupHsaPerson(HSA_ID, {
+          config: {
+            oauth: {
+              clientId: 'client-id',
+              clientSecret: 'client-secret',
+              tokenUrl: `${origin}/token`,
+            },
+            timeoutMs: 5000,
+            url: `${origin}/lookup`,
+          },
+        }),
+      ).rejects.toSatisfy(error => {
+        expectRequirementsError(error, 'service_unavailable')
+        if (isRequirementsServiceError(error)) {
+          expect(error.details?.reason).toBe('hsa_lookup_unavailable')
+        }
+        return true
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close(error => (error ? reject(error) : resolve())),
+      )
+    }
+  })
+
   it('does not follow token or bearer-authenticated lookup redirects', async () => {
     let redirectTargetRequests = 0
     const server = createServer((request, response) => {
@@ -844,21 +885,9 @@ describe('HSA person lookup', () => {
     )
   })
 
-  it('does not acquire or forward a cached bearer token after lookup destination validation fails', async () => {
+  it('does not forward an acquired bearer token after lookup destination validation fails', async () => {
     vi.stubEnv('NODE_ENV', 'production')
     try {
-      const httpRequestImpl = vi
-        .fn()
-        .mockResolvedValueOnce({
-          body: JSON.stringify({ access_token: 'token-1', expires_in: 3600 }),
-          headers: { 'content-type': 'application/json' },
-          status: 200,
-        })
-        .mockResolvedValueOnce({
-          body: JSON.stringify({ givenName: 'Kalle', hsaId: HSA_ID }),
-          headers: { 'content-type': 'application/json' },
-          status: 200,
-        })
       const config = {
         oauth: {
           clientId: 'client-id',
@@ -868,9 +897,14 @@ describe('HSA person lookup', () => {
         timeoutMs: 5000,
         url: 'https://lookup.example.test/person',
       }
-
-      await lookupHsaPerson(HSA_ID, { config, httpRequestImpl })
-      config.url = 'http://unapproved.example.test/person'
+      const httpRequestImpl = vi.fn().mockImplementationOnce(async () => {
+        config.url = 'http://unapproved.example.test/person'
+        return {
+          body: JSON.stringify({ access_token: 'token-1', expires_in: 3600 }),
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        }
+      })
 
       await expect(
         lookupHsaPerson(HSA_ID, { config, httpRequestImpl }),
@@ -878,7 +912,7 @@ describe('HSA person lookup', () => {
         expectRequirementsError(error, 'service_unavailable')
         return true
       })
-      expect(httpRequestImpl).toHaveBeenCalledTimes(2)
+      expect(httpRequestImpl).toHaveBeenCalledOnce()
     } finally {
       vi.unstubAllEnvs()
     }

--- a/tests/unit/hsa-person-lookup.test.ts
+++ b/tests/unit/hsa-person-lookup.test.ts
@@ -25,7 +25,7 @@ describe('HSA person lookup', () => {
     resetHsaPersonLookupAuthCacheForTests()
   })
 
-  it('reads lookup URL and clamps timeout from environment', () => {
+  it('reads lookup URL and validates timeout from environment', () => {
     expect(
       getHsaPersonLookupConfig({
         HSA_PERSON_LOOKUP_TIMEOUT_MS: '750',
@@ -36,19 +36,14 @@ describe('HSA person lookup', () => {
       url: 'http://kong:8000/hsa/person-records/lookup',
     })
 
-    expect(
-      getHsaPersonLookupConfig({
-        HSA_PERSON_LOOKUP_TIMEOUT_MS: 'not-a-timeout',
-        HSA_PERSON_LOOKUP_URL: 'http://kong:8000/hsa/person-records/lookup',
-      } as unknown as NodeJS.ProcessEnv),
-    ).toMatchObject({ timeoutMs: 5000 })
-
-    expect(
-      getHsaPersonLookupConfig({
-        HSA_PERSON_LOOKUP_TIMEOUT_MS: '0',
-        HSA_PERSON_LOOKUP_URL: 'http://kong:8000/hsa/person-records/lookup',
-      } as unknown as NodeJS.ProcessEnv),
-    ).toMatchObject({ timeoutMs: 5000 })
+    for (const timeout of ['not-a-timeout', '0', '-1', '30001']) {
+      expect(() =>
+        getHsaPersonLookupConfig({
+          HSA_PERSON_LOOKUP_TIMEOUT_MS: timeout,
+          HSA_PERSON_LOOKUP_URL: 'http://kong:8000/hsa/person-records/lookup',
+        } as unknown as NodeJS.ProcessEnv),
+      ).toThrow(/timeout must be an integer/u)
+    }
   })
 
   it('reads optional mTLS and OAuth2 lookup auth from environment', () => {
@@ -104,6 +99,12 @@ describe('HSA person lookup', () => {
   it('rejects incomplete app-to-platform auth configuration', () => {
     expect(() =>
       getHsaPersonLookupConfig({
+        HSA_PERSON_LOOKUP_OAUTH_CLIENT_ID: 'client-id',
+      } as unknown as NodeJS.ProcessEnv),
+    ).toThrow(/OAuth2 configuration/u)
+
+    expect(() =>
+      getHsaPersonLookupConfig({
         HSA_PERSON_LOOKUP_CLIENT_CERT_PATH: '/certs/client.crt',
         HSA_PERSON_LOOKUP_URL:
           'https://kong.example.internal/hsa/person-records/lookup',
@@ -135,6 +136,34 @@ describe('HSA person lookup', () => {
     ).toThrow(/OAuth2 configuration/u)
   })
 
+  it.each([
+    {
+      HSA_PERSON_LOOKUP_URL: 'http://lookup.example.test/person',
+      label: 'lookup',
+    },
+    {
+      HSA_PERSON_LOOKUP_OAUTH_CLIENT_ID: 'client-id',
+      HSA_PERSON_LOOKUP_OAUTH_CLIENT_SECRET: 'client-secret',
+      HSA_PERSON_LOOKUP_OAUTH_ISSUER_URL: 'http://issuer.example.test',
+      HSA_PERSON_LOOKUP_URL: 'https://lookup.example.test/person',
+      label: 'issuer',
+    },
+    {
+      HSA_PERSON_LOOKUP_OAUTH_CLIENT_ID: 'client-id',
+      HSA_PERSON_LOOKUP_OAUTH_CLIENT_SECRET: 'client-secret',
+      HSA_PERSON_LOOKUP_OAUTH_TOKEN_URL: 'http://issuer.example.test/token',
+      HSA_PERSON_LOOKUP_URL: 'https://lookup.example.test/person',
+      label: 'token',
+    },
+  ])('rejects a plaintext production $label endpoint', config => {
+    expect(() =>
+      getHsaPersonLookupConfig({
+        ...config,
+        NODE_ENV: 'production',
+      } as unknown as NodeJS.ProcessEnv),
+    ).toThrow(/must use HTTPS in production/u)
+  })
+
   it('posts HSA-id as JSON and maps split person fields', async () => {
     const fetchImpl = vi.fn(
       async () =>
@@ -146,7 +175,12 @@ describe('HSA person lookup', () => {
             middleName: 'Bertil',
             surname: 'Svensson',
           }),
-          { status: 200 },
+          {
+            headers: {
+              'Content-Type': 'application/vnd.hsa-person+json; charset=utf-8',
+            },
+            status: 200,
+          },
         ),
     ) as unknown as typeof fetch
 
@@ -164,6 +198,7 @@ describe('HSA person lookup', () => {
         body: JSON.stringify({ hsaId: HSA_ID }),
         headers: { 'Content-Type': 'application/json' },
         method: 'POST',
+        redirect: 'manual',
       }),
     )
     expect(person).toEqual({
@@ -174,6 +209,126 @@ describe('HSA person lookup', () => {
       middleName: 'Bertil',
       surname: 'Svensson',
     })
+  })
+
+  it.each([
+    {
+      body: JSON.stringify({ givenName: 'Kalle', hsaId: HSA_ID }),
+      status: 200,
+    },
+    { body: JSON.stringify({ code: 'not_found' }), status: 404 },
+  ])(
+    'rejects a non-JSON lookup response before mapping HTTP $status',
+    async ({ body, status }) => {
+      const fetchImpl = vi.fn(
+        async () =>
+          new Response(body, {
+            headers: { 'Content-Type': 'text/plain' },
+            status,
+          }),
+      )
+
+      await expect(
+        lookupHsaPerson(HSA_ID, {
+          config: { timeoutMs: 5000, url: 'http://kong/lookup' },
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+        }),
+      ).rejects.toSatisfy(error => {
+        expectRequirementsError(error, 'service_unavailable')
+        return true
+      })
+    },
+  )
+
+  it('cancels a streaming lookup response as soon as it exceeds 64 KiB', async () => {
+    let cancelled = false
+    const oversizedPayload = `${JSON.stringify({
+      givenName: 'Kalle',
+      hsaId: HSA_ID,
+    })}${' '.repeat(64 * 1024)}`
+    const body = new ReadableStream<Uint8Array>({
+      cancel: () => {
+        cancelled = true
+      },
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(oversizedPayload))
+      },
+    })
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(body, {
+          headers: { 'Content-Type': 'application/json' },
+          status: 200,
+        }),
+    )
+
+    await expect(
+      lookupHsaPerson(HSA_ID, {
+        config: { timeoutMs: 5000, url: 'http://kong/lookup' },
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toSatisfy(error => {
+      expectRequirementsError(error, 'service_unavailable')
+      return true
+    })
+    expect(cancelled).toBe(true)
+  })
+
+  it.each([
+    {
+      body: JSON.stringify({
+        issuer: 'https://issuer.example.test',
+        token_endpoint: 'https://issuer.example.test/token',
+      }),
+      contentType: 'text/plain',
+      stage: 'discovery media type',
+    },
+    {
+      body: `${JSON.stringify({
+        issuer: 'https://issuer.example.test',
+        token_endpoint: 'https://issuer.example.test/token',
+      })}${' '.repeat(256 * 1024)}`,
+      contentType: 'application/json',
+      stage: 'discovery byte limit',
+    },
+    {
+      body: JSON.stringify({ access_token: 'token' }),
+      contentType: 'text/plain',
+      stage: 'token media type',
+    },
+    {
+      body: `${JSON.stringify({ access_token: 'token' })}${' '.repeat(64 * 1024)}`,
+      contentType: 'application/problem+json; charset=utf-8',
+      stage: 'token byte limit',
+    },
+  ])('fails closed for an invalid OAuth $stage', async testCase => {
+    const discovery = testCase.stage.startsWith('discovery')
+    const httpRequestImpl = vi.fn(async (_input: unknown) => ({
+      body: testCase.body,
+      headers: { 'content-type': testCase.contentType },
+      status: 200,
+    }))
+
+    await expect(
+      lookupHsaPerson(HSA_ID, {
+        config: {
+          oauth: {
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+            ...(discovery
+              ? { issuerUrl: 'https://issuer.example.test' }
+              : { tokenUrl: 'https://issuer.example.test/token' }),
+          },
+          timeoutMs: 5000,
+          url: 'https://lookup.example.test/person',
+        },
+        httpRequestImpl,
+      }),
+    ).rejects.toSatisfy(error => {
+      expectRequirementsError(error, 'service_unavailable')
+      return true
+    })
+    expect(httpRequestImpl).toHaveBeenCalledOnce()
   })
 
   it('uses the native HTTP transport for OAuth token and lookup requests', async () => {
@@ -230,6 +385,60 @@ describe('HSA person lookup', () => {
           path: '/lookup?source=test',
         }),
       ])
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        server.close(error => (error ? reject(error) : resolve())),
+      )
+    }
+  })
+
+  it('does not follow token or bearer-authenticated lookup redirects', async () => {
+    let redirectTargetRequests = 0
+    const server = createServer((request, response) => {
+      response.setHeader('Content-Type', 'application/json')
+      if (request.url === '/token-redirect') {
+        response.writeHead(302, { Location: '/credential-sink' })
+        response.end('{}')
+        return
+      }
+      if (request.url === '/token') {
+        response.end(JSON.stringify({ access_token: 'redirect-test-token' }))
+        return
+      }
+      if (request.url === '/lookup') {
+        response.writeHead(302, { Location: '/credential-sink' })
+        response.end('{}')
+        return
+      }
+      redirectTargetRequests += 1
+      response.end('{}')
+    })
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') throw new Error('No port')
+      const origin = `http://127.0.0.1:${address.port}`
+
+      for (const tokenPath of ['/token-redirect', '/token']) {
+        await expect(
+          lookupHsaPerson(HSA_ID, {
+            config: {
+              oauth: {
+                clientId: `client-${tokenPath}`,
+                clientSecret: 'client-secret',
+                tokenUrl: `${origin}${tokenPath}`,
+              },
+              timeoutMs: 5000,
+              url: `${origin}/lookup`,
+            },
+          }),
+        ).rejects.toSatisfy(error => {
+          expectRequirementsError(error, 'service_unavailable')
+          return true
+        })
+      }
+
+      expect(redirectTargetRequests).toBe(0)
     } finally {
       await new Promise<void>((resolve, reject) =>
         server.close(error => (error ? reject(error) : resolve())),
@@ -325,7 +534,10 @@ describe('HSA person lookup', () => {
             middleName: null,
             surname: 'Person',
           }),
-          { status: 200 },
+          {
+            headers: { 'Content-Type': 'application/json' },
+            status: 200,
+          },
         ),
     ) as unknown as typeof fetch
 
@@ -385,7 +597,10 @@ describe('HSA person lookup', () => {
   it('maps catalog not found and conflict responses to domain errors', async () => {
     const notFoundFetch = vi.fn(
       async () =>
-        new Response(JSON.stringify({ code: 'not_found' }), { status: 404 }),
+        new Response(JSON.stringify({ code: 'not_found' }), {
+          headers: { 'Content-Type': 'application/json' },
+          status: 404,
+        }),
     )
     await expect(
       lookupHsaPerson(HSA_ID, {
@@ -397,7 +612,13 @@ describe('HSA person lookup', () => {
       return true
     })
 
-    const conflictFetch = vi.fn(async () => new Response('{}', { status: 409 }))
+    const conflictFetch = vi.fn(
+      async () =>
+        new Response('{}', {
+          headers: { 'Content-Type': 'application/json' },
+          status: 409,
+        }),
+    )
     await expect(
       lookupHsaPerson(HSA_ID, {
         config: { timeoutMs: 5000, url: 'http://kong/lookup' },
@@ -413,7 +634,10 @@ describe('HSA person lookup', () => {
     for (const status of [401, 403]) {
       const fetchImpl = vi.fn(
         async () =>
-          new Response(JSON.stringify({ code: 'auth_failed' }), { status }),
+          new Response(JSON.stringify({ code: 'auth_failed' }), {
+            headers: { 'Content-Type': 'application/json' },
+            status,
+          }),
       )
 
       await expect(
@@ -432,6 +656,7 @@ describe('HSA person lookup', () => {
     const fetchImpl = vi.fn(
       async () =>
         new Response(JSON.stringify({ message: 'no Route matched' }), {
+          headers: { 'Content-Type': 'application/json' },
           status: 404,
         }),
     )
@@ -479,7 +704,7 @@ describe('HSA person lookup', () => {
         middleName: null,
         surname: 'Svensson',
       }),
-      headers: {},
+      headers: { 'content-type': 'application/json' },
       status: 200,
     }))
 
@@ -559,7 +784,7 @@ describe('HSA person lookup', () => {
           access_token: 'token-1',
           expires_in: 3600,
         }),
-        headers: {},
+        headers: { 'content-type': 'application/json' },
         status: 200,
       })
       .mockResolvedValue({
@@ -571,7 +796,7 @@ describe('HSA person lookup', () => {
           middleName: null,
           surname: 'Svensson',
         }),
-        headers: {},
+        headers: { 'content-type': 'application/json' },
         status: 200,
       })
 
@@ -619,6 +844,97 @@ describe('HSA person lookup', () => {
     )
   })
 
+  it('does not acquire or forward a cached bearer token after lookup destination validation fails', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    try {
+      const httpRequestImpl = vi
+        .fn()
+        .mockResolvedValueOnce({
+          body: JSON.stringify({ access_token: 'token-1', expires_in: 3600 }),
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        })
+        .mockResolvedValueOnce({
+          body: JSON.stringify({ givenName: 'Kalle', hsaId: HSA_ID }),
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        })
+      const config = {
+        oauth: {
+          clientId: 'client-id',
+          clientSecret: 'client-secret',
+          tokenUrl: 'https://issuer.example.test/token',
+        },
+        timeoutMs: 5000,
+        url: 'https://lookup.example.test/person',
+      }
+
+      await lookupHsaPerson(HSA_ID, { config, httpRequestImpl })
+      config.url = 'http://unapproved.example.test/person'
+
+      await expect(
+        lookupHsaPerson(HSA_ID, { config, httpRequestImpl }),
+      ).rejects.toSatisfy(error => {
+        expectRequirementsError(error, 'service_unavailable')
+        return true
+      })
+      expect(httpRequestImpl).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('does not send Basic credentials to an invalid explicit token endpoint', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    try {
+      const httpRequestImpl = vi.fn()
+
+      await expect(
+        lookupHsaPerson(HSA_ID, {
+          config: {
+            oauth: {
+              clientId: 'client-id',
+              clientSecret: 'client-secret',
+              tokenUrl: 'http://issuer.example.test/token',
+            },
+            timeoutMs: 5000,
+            url: 'https://lookup.example.test/person',
+          },
+          httpRequestImpl,
+        }),
+      ).rejects.toSatisfy(error => {
+        expectRequirementsError(error, 'service_unavailable')
+        return true
+      })
+      expect(httpRequestImpl).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('rejects an invalid runtime timeout before any outbound request', async () => {
+    const httpRequestImpl = vi.fn()
+
+    await expect(
+      lookupHsaPerson(HSA_ID, {
+        config: {
+          oauth: {
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+            tokenUrl: 'https://issuer.example.test/token',
+          },
+          timeoutMs: 0,
+          url: 'https://lookup.example.test/person',
+        },
+        httpRequestImpl,
+      }),
+    ).rejects.toSatisfy(error => {
+      expectRequirementsError(error, 'service_unavailable')
+      return true
+    })
+    expect(httpRequestImpl).not.toHaveBeenCalled()
+  })
+
   it('supports OIDC discovery and combined mTLS plus OAuth2 mode', async () => {
     const mtls = {
       certPath: '/certs/client.crt',
@@ -628,14 +944,15 @@ describe('HSA person lookup', () => {
       .fn()
       .mockResolvedValueOnce({
         body: JSON.stringify({
+          issuer: 'https://issuer.example.test',
           token_endpoint: 'https://issuer.example.test/oauth/token',
         }),
-        headers: {},
+        headers: { 'content-type': 'application/json' },
         status: 200,
       })
       .mockResolvedValueOnce({
         body: JSON.stringify({ access_token: 'token-2', expires_in: 300 }),
-        headers: {},
+        headers: { 'content-type': 'application/json' },
         status: 200,
       })
       .mockResolvedValueOnce({
@@ -647,7 +964,7 @@ describe('HSA person lookup', () => {
           middleName: null,
           surname: 'Svensson',
         }),
-        headers: {},
+        headers: { 'content-type': 'application/json' },
         status: 200,
       })
 
@@ -692,6 +1009,62 @@ describe('HSA person lookup', () => {
   })
 
   it.each([
+    {
+      metadata: {
+        token_endpoint: 'https://issuer.example.test/oauth/token',
+      },
+      reason: 'missing issuer',
+    },
+    {
+      metadata: {
+        issuer: 'https://other-issuer.example.test',
+        token_endpoint: 'https://issuer.example.test/oauth/token',
+      },
+      reason: 'mismatched issuer',
+    },
+    {
+      metadata: {
+        issuer: 'https://issuer.example.test',
+        token_endpoint: 'https://tokens.example.test/oauth/token',
+      },
+      reason: 'cross-origin token endpoint',
+    },
+  ])(
+    'does not send client credentials after discovery reports a $reason',
+    async ({ metadata }) => {
+      const httpRequestImpl = vi.fn(async (_input: unknown) => ({
+        body: JSON.stringify(metadata),
+        headers: { 'content-type': 'application/json' },
+        status: 200,
+      }))
+
+      await expect(
+        lookupHsaPerson(HSA_ID, {
+          config: {
+            oauth: {
+              clientId: 'client-id',
+              clientSecret: 'client-secret',
+              issuerUrl: 'https://issuer.example.test/',
+            },
+            timeoutMs: 5000,
+            url: 'https://lookup.example.test/person',
+          },
+          httpRequestImpl,
+        }),
+      ).rejects.toSatisfy(error => {
+        expectRequirementsError(error, 'service_unavailable')
+        return true
+      })
+
+      expect(httpRequestImpl).toHaveBeenCalledOnce()
+      const firstRequest = httpRequestImpl.mock.calls[0]?.[0] as
+        | { headers?: Record<string, string> }
+        | undefined
+      expect(firstRequest?.headers).not.toHaveProperty('Authorization')
+    },
+  )
+
+  it.each([
     { body: '', status: 200 },
     { body: '{invalid', status: 200 },
     { body: JSON.stringify({ givenName: 'Kalle', hsaId: '' }), status: 200 },
@@ -709,7 +1082,7 @@ describe('HSA person lookup', () => {
         config: { timeoutMs: 5000, url: 'https://kong/lookup' },
         httpRequestImpl: vi.fn(async () => ({
           body: response.body,
-          headers: {},
+          headers: { 'content-type': 'application/json' },
           status: response.status,
         })),
       }),
@@ -721,29 +1094,49 @@ describe('HSA person lookup', () => {
 
   it.each([
     {
-      responses: [{ body: '{}', headers: {}, status: 500 }],
-    },
-    {
-      responses: [{ body: '{}', headers: {}, status: 200 }],
+      responses: [
+        {
+          body: '{}',
+          headers: { 'content-type': 'application/json' },
+          status: 500,
+        },
+      ],
     },
     {
       responses: [
         {
-          body: JSON.stringify({ token_endpoint: 'https://idp/token' }),
-          headers: {},
+          body: '{}',
+          headers: { 'content-type': 'application/json' },
           status: 200,
         },
-        { body: '{}', headers: {}, status: 401 },
       ],
     },
     {
       responses: [
         {
           body: JSON.stringify({ token_endpoint: 'https://idp/token' }),
-          headers: {},
+          headers: { 'content-type': 'application/json' },
           status: 200,
         },
-        { body: '{}', headers: {}, status: 200 },
+        {
+          body: '{}',
+          headers: { 'content-type': 'application/json' },
+          status: 401,
+        },
+      ],
+    },
+    {
+      responses: [
+        {
+          body: JSON.stringify({ token_endpoint: 'https://idp/token' }),
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        },
+        {
+          body: '{}',
+          headers: { 'content-type': 'application/json' },
+          status: 200,
+        },
       ],
     },
   ])(
@@ -781,12 +1174,12 @@ describe('HSA person lookup', () => {
           access_token: 'token-default',
           expires_in: 'invalid',
         }),
-        headers: {},
+        headers: { 'content-type': 'application/json' },
         status: 200,
       })
       .mockResolvedValueOnce({
         body: JSON.stringify({ givenName: 'Kalle', hsaId: HSA_ID }),
-        headers: {},
+        headers: { 'content-type': 'application/json' },
         status: 200,
       })
     await lookupHsaPerson(HSA_ID, {

--- a/tests/unit/hsa-person-lookup.test.ts
+++ b/tests/unit/hsa-person-lookup.test.ts
@@ -8,6 +8,7 @@ import {
   lookupHsaPerson,
   readHsaPersonLookupTlsFileForTests,
   resetHsaPersonLookupAuthCacheForTests,
+  validateHsaPersonLookupConfig,
 } from '@/lib/hsa/person-lookup'
 import { isRequirementsServiceError } from '@/lib/requirements/errors'
 
@@ -134,6 +135,45 @@ describe('HSA person lookup', () => {
           'https://kong.example.internal/hsa/person-records/lookup',
       } as unknown as NodeJS.ProcessEnv),
     ).toThrow(/OAuth2 configuration/u)
+
+    expect(() =>
+      getHsaPersonLookupConfig({
+        HSA_PERSON_LOOKUP_OAUTH_CLIENT_ID: 'client-id',
+        HSA_PERSON_LOOKUP_OAUTH_CLIENT_SECRET: 'client-secret',
+        HSA_PERSON_LOOKUP_OAUTH_TOKEN_URL: 'https://idp.example.test/token',
+      } as unknown as NodeJS.ProcessEnv),
+    ).toThrow(/requires HSA_PERSON_LOOKUP_URL/u)
+  })
+
+  it.each([
+    {
+      config: { timeoutMs: 5000, url: 'not a URL' },
+      message: /must be a valid URL/u,
+    },
+    {
+      config: {
+        mtls: { certPath: ' ', keyPath: '/certs/client.key' },
+        timeoutMs: 5000,
+        url: 'https://lookup.example.test/person',
+      },
+      message: /mTLS configuration/u,
+    },
+    {
+      config: {
+        oauth: {
+          clientId: ' ',
+          clientSecret: 'client-secret',
+          tokenUrl: 'https://idp.example.test/token',
+        },
+        timeoutMs: 5000,
+        url: 'https://lookup.example.test/person',
+      },
+      message: /OAuth2 configuration/u,
+    },
+  ])('validates programmatic lookup config %#', ({ config, message }) => {
+    expect(() => validateHsaPersonLookupConfig(config as never)).toThrow(
+      message,
+    )
   })
 
   it.each([
@@ -272,6 +312,52 @@ describe('HSA person lookup', () => {
       return true
     })
     expect(cancelled).toBe(true)
+  })
+
+  it('rejects a lookup response whose declared length exceeds 64 KiB', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response('{}', {
+          headers: {
+            'Content-Length': String(64 * 1024 + 1),
+            'Content-Type': 'application/json',
+          },
+          status: 200,
+        }),
+    )
+
+    await expect(
+      lookupHsaPerson(HSA_ID, {
+        config: { timeoutMs: 5000, url: 'http://kong/lookup' },
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toSatisfy(error => {
+      expectRequirementsError(error, 'service_unavailable')
+      return true
+    })
+  })
+
+  it('rejects an empty successful lookup response as invalid', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(null, {
+          headers: { 'Content-Type': 'application/json' },
+          status: 200,
+        }),
+    )
+
+    await expect(
+      lookupHsaPerson(HSA_ID, {
+        config: { timeoutMs: 5000, url: 'http://kong/lookup' },
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).rejects.toSatisfy(error => {
+      expectRequirementsError(error, 'service_unavailable')
+      if (isRequirementsServiceError(error)) {
+        expect(error.details?.reason).toBe('hsa_lookup_invalid_response')
+      }
+      return true
+    })
   })
 
   it.each([
@@ -432,6 +518,47 @@ describe('HSA person lookup', () => {
       )
     }
   })
+
+  it.each(['declared', 'streamed'])(
+    'rejects an oversized native HTTP response with a %s length',
+    async responseMode => {
+      const oversizedBody = 'x'.repeat(64 * 1024 + 1)
+      const server = createServer((_request, response) => {
+        response.setHeader('Content-Type', 'application/json')
+        if (responseMode === 'declared') {
+          response.setHeader('Content-Length', String(oversizedBody.length))
+        }
+        response.end(oversizedBody)
+      })
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+      try {
+        const address = server.address()
+        if (!address || typeof address === 'string') throw new Error('No port')
+        const origin = `http://127.0.0.1:${address.port}`
+
+        await expect(
+          lookupHsaPerson(HSA_ID, {
+            config: {
+              oauth: {
+                clientId: 'client-id',
+                clientSecret: 'client-secret',
+                tokenUrl: `${origin}/token`,
+              },
+              timeoutMs: 5000,
+              url: `${origin}/lookup`,
+            },
+          }),
+        ).rejects.toSatisfy(error => {
+          expectRequirementsError(error, 'service_unavailable')
+          return true
+        })
+      } finally {
+        await new Promise<void>((resolve, reject) =>
+          server.close(error => (error ? reject(error) : resolve())),
+        )
+      }
+    },
+  )
 
   it('does not follow token or bearer-authenticated lookup redirects', async () => {
     let redirectTargetRequests = 0
@@ -715,7 +842,9 @@ describe('HSA person lookup', () => {
 
   it('maps aborts to service unavailable timeout', async () => {
     const fetchImpl = vi.fn(async () => {
-      throw new DOMException('timeout', 'AbortError')
+      const error = new Error('timeout')
+      error.name = 'AbortError'
+      throw error
     })
 
     await expect(
@@ -725,6 +854,9 @@ describe('HSA person lookup', () => {
       }),
     ).rejects.toSatisfy(error => {
       expectRequirementsError(error, 'service_unavailable')
+      if (isRequirementsServiceError(error)) {
+        expect(error.details?.reason).toBe('hsa_lookup_timeout')
+      }
       return true
     })
   })
@@ -1063,6 +1195,12 @@ describe('HSA person lookup', () => {
       },
       reason: 'cross-origin token endpoint',
     },
+    {
+      metadata: {
+        issuer: 'https://issuer.example.test',
+      },
+      reason: 'missing token endpoint',
+    },
   ])(
     'does not send client credentials after discovery reports a $reason',
     async ({ metadata }) => {
@@ -1099,29 +1237,42 @@ describe('HSA person lookup', () => {
   )
 
   it.each([
-    { body: '', status: 200 },
-    { body: '{invalid', status: 200 },
-    { body: JSON.stringify({ givenName: 'Kalle', hsaId: '' }), status: 200 },
+    { body: '', code: 'service_unavailable', status: 200 },
+    { body: '{invalid', code: 'service_unavailable', status: 200 },
+    {
+      body: JSON.stringify({ givenName: 'Kalle', hsaId: '' }),
+      code: 'service_unavailable',
+      status: 200,
+    },
     {
       body: JSON.stringify({
         givenName: 'Kalle',
         hsaId: 'SE5560000001-other1',
       }),
+      code: 'conflict',
       status: 200,
     },
-    { body: JSON.stringify({ code: 'conflict' }), status: 422 },
+    {
+      body: JSON.stringify({ code: 'conflict' }),
+      code: 'conflict',
+      status: 422,
+    },
   ])('rejects invalid or conflicting lookup payload %#', async response => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(response.body, {
+          headers: { 'Content-Type': 'application/json' },
+          status: response.status,
+        }),
+    )
+
     await expect(
       lookupHsaPerson(HSA_ID, {
-        config: { timeoutMs: 5000, url: 'https://kong/lookup' },
-        httpRequestImpl: vi.fn(async () => ({
-          body: response.body,
-          headers: { 'content-type': 'application/json' },
-          status: response.status,
-        })),
+        config: { timeoutMs: 5000, url: 'http://kong/lookup' },
+        fetchImpl: fetchImpl as unknown as typeof fetch,
       }),
     ).rejects.toSatisfy(error => {
-      expect(isRequirementsServiceError(error)).toBe(true)
+      expectRequirementsError(error, response.code)
       return true
     })
   })
@@ -1148,7 +1299,10 @@ describe('HSA person lookup', () => {
     {
       responses: [
         {
-          body: JSON.stringify({ token_endpoint: 'https://idp/token' }),
+          body: JSON.stringify({
+            issuer: 'https://issuer.example.test',
+            token_endpoint: 'https://issuer.example.test/token',
+          }),
           headers: { 'content-type': 'application/json' },
           status: 200,
         },
@@ -1162,7 +1316,10 @@ describe('HSA person lookup', () => {
     {
       responses: [
         {
-          body: JSON.stringify({ token_endpoint: 'https://idp/token' }),
+          body: JSON.stringify({
+            issuer: 'https://issuer.example.test',
+            token_endpoint: 'https://issuer.example.test/token',
+          }),
           headers: { 'content-type': 'application/json' },
           status: 200,
         },

--- a/tests/unit/hsa-person-lookup.test.ts
+++ b/tests/unit/hsa-person-lookup.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   getHsaPersonLookupConfig,
+  hsaPersonLookupConfigDiagnostic,
   lookupHsaPerson,
   readHsaPersonLookupTlsFileForTests,
   resetHsaPersonLookupAuthCacheForTests,
@@ -196,12 +197,31 @@ describe('HSA person lookup', () => {
       label: 'token',
     },
   ])('rejects a plaintext production $label endpoint', config => {
-    expect(() =>
+    let error: unknown
+    try {
       getHsaPersonLookupConfig({
         ...config,
         NODE_ENV: 'production',
-      } as unknown as NodeJS.ProcessEnv),
-    ).toThrow(/must use HTTPS in production/u)
+      } as unknown as NodeJS.ProcessEnv)
+    } catch (caught) {
+      error = caught
+    }
+
+    expect(error).toHaveProperty(
+      'message',
+      expect.stringMatching(/must use HTTPS in production/u),
+    )
+    expect(hsaPersonLookupConfigDiagnostic(error)).toBe(
+      config.label === 'lookup'
+        ? 'hsa_lookup_url_https_required'
+        : `hsa_oauth_${config.label}_url_https_required`,
+    )
+  })
+
+  it('does not expose diagnostics for unrelated errors', () => {
+    expect(
+      hsaPersonLookupConfigDiagnostic(new Error('secret value')),
+    ).toBeNull()
   })
 
   it('posts HSA-id as JSON and maps split person fields', async () => {
@@ -527,8 +547,11 @@ describe('HSA person lookup', () => {
         response.setHeader('Content-Type', 'application/json')
         if (responseMode === 'declared') {
           response.setHeader('Content-Length', String(oversizedBody.length))
+          response.end(oversizedBody)
+          return
         }
-        response.end(oversizedBody)
+        response.write(oversizedBody.slice(0, 64 * 1024))
+        response.end(oversizedBody.slice(64 * 1024))
       })
       await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
       try {

--- a/tests/unit/ready-route.test.ts
+++ b/tests/unit/ready-route.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const routeState = vi.hoisted(() => ({
   getAuthConfig: vi.fn(),
+  getHsaPersonLookupConfig: vi.fn(),
   getRequestSqlServerDataSource: vi.fn(),
   getSqlServerDatabaseUrl: vi.fn(),
   probeGeneratedOutputTempDirectory: vi.fn(),
@@ -14,6 +15,10 @@ vi.mock('@/lib/auth/config', () => ({
 
 vi.mock('@/lib/db', () => ({
   getRequestSqlServerDataSource: routeState.getRequestSqlServerDataSource,
+}))
+
+vi.mock('@/lib/hsa/person-lookup', () => ({
+  getHsaPersonLookupConfig: routeState.getHsaPersonLookupConfig,
 }))
 
 vi.mock('@/lib/build-metadata', () => ({
@@ -52,6 +57,7 @@ function setReadyDefaults() {
   routeState.getAuthConfig.mockReturnValue({
     issuerUrl: 'https://issuer.example.com/realms/test',
   })
+  routeState.getHsaPersonLookupConfig.mockReturnValue(null)
   routeState.readBuildMetadata.mockReturnValue({
     builtAt: '2026-05-21T19:00:00.000Z',
     commitSha: 'abc123',
@@ -130,6 +136,28 @@ describe('GET /api/ready', () => {
     expect(response.status).toBe(503)
     expect(JSON.parse(body)).toEqual({ status: 'not_ready' })
     expect(body).not.toContain('NEXT_PUBLIC_SITE_URL')
+    expect(routeState.getRequestSqlServerDataSource).not.toHaveBeenCalled()
+    expect(fetch).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(
+      '[readiness] check failed',
+      expect.objectContaining({ check: 'runtime_config' }),
+    )
+    warn.mockRestore()
+  })
+
+  it('returns not_ready for invalid optional HSA configuration without making a network call', async () => {
+    setReadyDefaults()
+    routeState.getHsaPersonLookupConfig.mockImplementation(() => {
+      throw new Error('HSA_PERSON_LOOKUP_URL contains a private endpoint')
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const response = await route.GET(request())
+    const body = await response.text()
+
+    expect(response.status).toBe(503)
+    expect(JSON.parse(body)).toEqual({ status: 'not_ready' })
+    expect(body).not.toContain('HSA_PERSON_LOOKUP_URL')
     expect(routeState.getRequestSqlServerDataSource).not.toHaveBeenCalled()
     expect(fetch).not.toHaveBeenCalled()
     expect(warn).toHaveBeenCalledWith(

--- a/tests/unit/ready-route.test.ts
+++ b/tests/unit/ready-route.test.ts
@@ -5,6 +5,7 @@ const routeState = vi.hoisted(() => ({
   getHsaPersonLookupConfig: vi.fn(),
   getRequestSqlServerDataSource: vi.fn(),
   getSqlServerDatabaseUrl: vi.fn(),
+  hsaPersonLookupConfigDiagnostic: vi.fn(),
   probeGeneratedOutputTempDirectory: vi.fn(),
   readBuildMetadata: vi.fn(),
 }))
@@ -19,6 +20,7 @@ vi.mock('@/lib/db', () => ({
 
 vi.mock('@/lib/hsa/person-lookup', () => ({
   getHsaPersonLookupConfig: routeState.getHsaPersonLookupConfig,
+  hsaPersonLookupConfigDiagnostic: routeState.hsaPersonLookupConfigDiagnostic,
 }))
 
 vi.mock('@/lib/build-metadata', () => ({
@@ -58,6 +60,7 @@ function setReadyDefaults() {
     issuerUrl: 'https://issuer.example.com/realms/test',
   })
   routeState.getHsaPersonLookupConfig.mockReturnValue(null)
+  routeState.hsaPersonLookupConfigDiagnostic.mockReturnValue(null)
   routeState.readBuildMetadata.mockReturnValue({
     builtAt: '2026-05-21T19:00:00.000Z',
     commitSha: 'abc123',
@@ -147,9 +150,15 @@ describe('GET /api/ready', () => {
 
   it('returns not_ready for invalid optional HSA configuration without making a network call', async () => {
     setReadyDefaults()
+    const configError = new Error(
+      'HSA_PERSON_LOOKUP_URL=https://private.example contains a private endpoint',
+    )
     routeState.getHsaPersonLookupConfig.mockImplementation(() => {
-      throw new Error('HSA_PERSON_LOOKUP_URL contains a private endpoint')
+      throw configError
     })
+    routeState.hsaPersonLookupConfigDiagnostic.mockReturnValue(
+      'hsa_lookup_url_https_required',
+    )
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const response = await route.GET(request())
@@ -162,8 +171,15 @@ describe('GET /api/ready', () => {
     expect(fetch).not.toHaveBeenCalled()
     expect(warn).toHaveBeenCalledWith(
       '[readiness] check failed',
-      expect.objectContaining({ check: 'runtime_config' }),
+      expect.objectContaining({
+        check: 'runtime_config',
+        diagnostic: 'hsa_lookup_url_https_required',
+      }),
     )
+    expect(routeState.hsaPersonLookupConfigDiagnostic).toHaveBeenCalledWith(
+      configError,
+    )
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('private.example')
     warn.mockRestore()
   })
 


### PR DESCRIPTION
## Description

Harden HSA person lookup and REST-to-SOAP outbound transports so production fails closed before credentials or bearer tokens can reach invalid destinations.

- Require HTTPS for production lookup, OAuth issuer/token, and SOAP endpoints.
- Validate discovery issuer and token endpoint origin, disable redirects, and bound accepted response types and sizes.
- Include static HSA configuration validation in readiness and document infrastructure egress allowlisting.

## Related Issues

Fixes #476

## Reviewer Notes

- Validation: `npm run check`
- No visible UI changes; screenshots and developer-mode verification are not applicable.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
Before rollout, verify every production HSA lookup, OAuth, and SOAP endpoint uses HTTPS and that discovery returns a token endpoint on the configured issuer's origin. Confirm host firewall, approved egress proxy, DNS, routing, and upstream ACL rules allow only approved HSA destinations.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/989)
<!-- Reviewable:end -->
