### PR TITLE
Make HSA verification privacy-preserving and assignment-atomic

### DIFF
--- a/app/[locale]/requirement-areas/requirement-areas-client.tsx
+++ b/app/[locale]/requirement-areas/requirement-areas-client.tsx
@@ -93,6 +93,8 @@ const toCreatePayload = (form: AreaForm) => ({
   name: form.name,
   ownerHsaId: form.ownerHsaId,
   prefix: form.prefix,
+  verificationEvidence:
+    form.ownerPersonVerification?.verificationEvidence ?? '',
 })
 
 const toUpdatePayload = (form: AreaForm) => ({
@@ -137,13 +139,17 @@ export default function RequirementAreasClient() {
 
   const submitOwnerChange = async (
     nextOwnerHsaId: string,
+    person: HsaPersonVerification | null,
   ): Promise<HsaPersonChangeSubmitResult> => {
     if (!ownerChange) return { ok: false }
     try {
       const response = await apiFetch(
         `/api/requirement-areas/${ownerChange.areaId}`,
         {
-          body: JSON.stringify({ ownerHsaId: nextOwnerHsaId }),
+          body: JSON.stringify({
+            ownerHsaId: nextOwnerHsaId,
+            verificationEvidence: person?.verificationEvidence ?? '',
+          }),
           headers: { 'Content-Type': 'application/json' },
           method: 'PUT',
         },

--- a/app/[locale]/requirement-areas/requirement-areas-client.tsx
+++ b/app/[locale]/requirement-areas/requirement-areas-client.tsx
@@ -88,14 +88,24 @@ const toForm = (area: Area): AreaForm => ({
   prefix: area.prefix,
 })
 
-const toCreatePayload = (form: AreaForm) => ({
-  description: form.description,
-  name: form.name,
-  ownerHsaId: form.ownerHsaId,
-  prefix: form.prefix,
-  verificationEvidence:
-    form.ownerPersonVerification?.verificationEvidence ?? '',
-})
+function matchingOwnerVerificationEvidence(form: AreaForm): string | null {
+  const verification = form.ownerPersonVerification
+  const evidence = verification?.verificationEvidence.trim()
+  return verification?.hsaId === form.ownerHsaId.trim() && evidence
+    ? evidence
+    : null
+}
+
+const toCreatePayload = (form: AreaForm) => {
+  const verificationEvidence = matchingOwnerVerificationEvidence(form)
+  return {
+    description: form.description,
+    name: form.name,
+    ownerHsaId: form.ownerHsaId,
+    prefix: form.prefix,
+    ...(verificationEvidence ? { verificationEvidence } : {}),
+  }
+}
 
 const toUpdatePayload = (form: AreaForm) => ({
   description: form.description,
@@ -240,6 +250,10 @@ export default function RequirementAreasClient() {
       }
       formMaxWidthClassName="max-w-2xl"
       formPresentation="modal"
+      formSubmitDisabled={
+        controller.editId === null &&
+        matchingOwnerVerificationEvidence(controller.form) === null
+      }
       formTitle={mode => (mode === 'create' ? t('newArea') : t('editArea'))}
       formTitleId="requirement-area-form-title"
       renderFormFields={({

--- a/app/[locale]/requirement-packages/requirement-packages-client.tsx
+++ b/app/[locale]/requirement-packages/requirement-packages-client.tsx
@@ -477,7 +477,10 @@ export default function RequirementPackagesClient() {
       const response = await apiFetch(
         `/api/requirement-packages/${leadChange.packageId}`,
         {
-          body: JSON.stringify({ leadHsaId: nextLeadHsaId }),
+          body: JSON.stringify({
+            leadHsaId: nextLeadHsaId,
+            verificationEvidence: person?.verificationEvidence ?? '',
+          }),
           headers: { 'Content-Type': 'application/json' },
           method: 'PUT',
         },

--- a/app/[locale]/specifications/specification-form-modal.tsx
+++ b/app/[locale]/specifications/specification-form-modal.tsx
@@ -456,7 +456,10 @@ export default function SpecificationFormModal({
       const response = await apiFetch(
         `/api/requirements-specifications/${editSpecificationId}/responsible`,
         {
-          body: JSON.stringify({ responsibleHsaId: nextResponsibleHsaId }),
+          body: JSON.stringify({
+            responsibleHsaId: nextResponsibleHsaId,
+            verificationEvidence: person?.verificationEvidence ?? '',
+          }),
           headers: { 'Content-Type': 'application/json' },
           method: 'PUT',
         },

--- a/app/api/requirement-areas/[id]/co-authors/route.ts
+++ b/app/api/requirement-areas/[id]/co-authors/route.ts
@@ -12,14 +12,21 @@ import {
   customMutationPolicy,
   secureMutationRoute,
 } from '@/lib/http/secure-mutation-route'
-import { idParamSchema, parseRouteParams } from '@/lib/http/validation'
+import {
+  ARRAY_INPUT_MAX_ITEMS,
+  idParamSchema,
+  parseRouteParams,
+} from '@/lib/http/validation'
 import {
   createRequestContext,
   type RequestContext,
 } from '@/lib/requirements/auth'
 import { forbiddenError } from '@/lib/requirements/errors'
 import { toHttpErrorPayload } from '@/lib/requirements/http-errors'
-import { resolveVerifiedRequirementResponsibilityPeople } from '@/lib/requirements/responsibility-person-verification'
+import {
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH,
+  resolveVerifiedRequirementResponsibilityPeople,
+} from '@/lib/requirements/responsibility-person-verification'
 
 export const dynamic = 'force-dynamic'
 
@@ -30,7 +37,17 @@ const hsaIdSchema = z.string().trim().max(HSA_ID_MAX_LENGTH).refine(isHsaId, {
 
 const updateRequirementAreaCoAuthorsSchema = z
   .object({
-    coAuthorHsaIds: z.array(hsaIdSchema),
+    coAuthorHsaIds: z.array(hsaIdSchema).max(ARRAY_INPUT_MAX_ITEMS),
+    verificationEvidence: z
+      .array(
+        z
+          .string()
+          .min(1)
+          .max(
+            REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH,
+          ),
+      )
+      .max(ARRAY_INPUT_MAX_ITEMS),
   })
   .strict()
 
@@ -115,9 +132,14 @@ export const PUT = secureMutationRoute({
     const area = await getAreaById(db, params.id)
     if (!area) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
-    const coAuthorPeople = await resolveVerifiedRequirementResponsibilityPeople(
-      db,
-      body.coAuthorHsaIds,
+    const coAuthorPeople = resolveVerifiedRequirementResponsibilityPeople(
+      body.verificationEvidence,
+      {
+        actor: context.actor,
+        hsaIds: body.coAuthorHsaIds,
+        purpose: 'requirement_area_co_author',
+        scopeId: params.id,
+      },
     )
     const result = await replaceRequirementAreaCoAuthors(db, params.id, {
       changedBy: assignmentActor(context),

--- a/app/api/requirement-areas/[id]/route.ts
+++ b/app/api/requirement-areas/[id]/route.ts
@@ -27,7 +27,10 @@ import {
 } from '@/lib/http/validation'
 import { createRequestContext } from '@/lib/requirements/auth'
 import { forbiddenError } from '@/lib/requirements/errors'
-import { resolveVerifiedRequirementResponsibilityPerson } from '@/lib/requirements/responsibility-person-verification'
+import {
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH,
+  resolveVerifiedRequirementResponsibilityPerson,
+} from '@/lib/requirements/responsibility-person-verification'
 
 export const dynamic = 'force-dynamic'
 
@@ -44,8 +47,29 @@ const updateAreaSchema = z
     name: boundedDbStringSchema.optional(),
     ownerHsaId: hsaIdSchema.optional(),
     prefix: boundedDbStringSchema.optional(),
+    verificationEvidence: z
+      .string()
+      .min(1)
+      .max(REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH)
+      .optional(),
   })
   .strict()
+  .superRefine((body, context) => {
+    if (body.ownerHsaId !== undefined && !body.verificationEvidence) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Verification evidence is required when changing owner',
+        path: ['verificationEvidence'],
+      })
+    }
+    if (body.ownerHsaId === undefined && body.verificationEvidence) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Verification evidence is only accepted when changing owner',
+        path: ['verificationEvidence'],
+      })
+    }
+  })
 
 function isAdmin(roles: readonly string[]): boolean {
   return roles.includes('Admin')
@@ -110,22 +134,28 @@ export const PUT = secureMutationRoute({
   ),
   handler: async ({ body, context, params }) => {
     const db = await getRequestSqlServerDataSource()
+    const ownerPerson =
+      body.ownerHsaId === undefined
+        ? undefined
+        : resolveVerifiedRequirementResponsibilityPerson(
+            body.verificationEvidence ?? '',
+            {
+              actor: context.actor,
+              hsaId: body.ownerHsaId,
+              purpose: 'requirement_area_owner',
+              scopeId: params.id,
+            },
+          )
+    const { verificationEvidence: _verificationEvidence, ...areaUpdate } = body
     const area = await updateAreaWithOwnerCheck(db, params.id, {
-      ...body,
-      resolveOwnerPerson:
-        body.ownerHsaId === undefined
-          ? undefined
-          : (executor, ownerHsaId) =>
-              resolveVerifiedRequirementResponsibilityPerson(
-                executor,
-                ownerHsaId,
-              ),
+      ...areaUpdate,
+      ownerPerson,
     })
     if (!area) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
     const auditDetail = {
-      changedFields: Object.keys(body),
+      changedFields: Object.keys(areaUpdate),
       operation: 'update',
       resourceId: params.id,
       resourceType: 'requirement_area',

--- a/app/api/requirement-areas/route.ts
+++ b/app/api/requirement-areas/route.ts
@@ -17,7 +17,10 @@ import {
   optionalBusinessTextSchema,
 } from '@/lib/http/validation'
 import { createRequestContext } from '@/lib/requirements/auth'
-import { resolveVerifiedRequirementResponsibilityPerson } from '@/lib/requirements/responsibility-person-verification'
+import {
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH,
+  resolveVerifiedRequirementResponsibilityPerson,
+} from '@/lib/requirements/responsibility-person-verification'
 
 const hsaIdSchema = boundedDbStringSchema.refine(isHsaId, {
   message:
@@ -30,6 +33,10 @@ const createAreaSchema = z
     name: boundedDbStringSchema,
     ownerHsaId: hsaIdSchema,
     prefix: boundedDbStringSchema,
+    verificationEvidence: z
+      .string()
+      .min(1)
+      .max(REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH),
   })
   .strict()
 
@@ -58,13 +65,18 @@ export const POST = secureMutationRoute({
   policy: adminMutationPolicy(),
   handler: async ({ body, context }) => {
     const db = await getRequestSqlServerDataSource()
-    const ownerPerson = await resolveVerifiedRequirementResponsibilityPerson(
-      db,
-      body.ownerHsaId,
+    const ownerPerson = resolveVerifiedRequirementResponsibilityPerson(
+      body.verificationEvidence,
+      {
+        actor: context.actor,
+        hsaId: body.ownerHsaId,
+        purpose: 'requirement_area_owner',
+      },
     )
-    const area = await createArea(db, { ...body, ownerPerson })
+    const { verificationEvidence: _verificationEvidence, ...areaInput } = body
+    const area = await createArea(db, { ...areaInput, ownerPerson })
     await recordAdminPrivilegedActionSucceeded(context, {
-      changedFields: Object.keys(body),
+      changedFields: Object.keys(areaInput),
       operation: 'create',
       resourceId: area.id,
       resourceType: 'requirement_area',

--- a/app/api/requirement-packages/[id]/co-authors/route.ts
+++ b/app/api/requirement-packages/[id]/co-authors/route.ts
@@ -23,7 +23,10 @@ import {
 } from '@/lib/requirements/auth'
 import { toHttpErrorPayload } from '@/lib/requirements/http-errors'
 import { requireRequirementPackageLeadOrAdmin } from '@/lib/requirements/requirement-package-permissions'
-import { resolveVerifiedRequirementResponsibilityPeople } from '@/lib/requirements/responsibility-person-verification'
+import {
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH,
+  resolveVerifiedRequirementResponsibilityPeople,
+} from '@/lib/requirements/responsibility-person-verification'
 
 export const dynamic = 'force-dynamic'
 
@@ -40,6 +43,16 @@ const updateRequirementPackageCoAuthorsSchema = z
       .refine(values => new Set(values).size === values.length, {
         message: 'Co-author HSA-ids must be unique',
       }),
+    verificationEvidence: z
+      .array(
+        z
+          .string()
+          .min(1)
+          .max(
+            REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH,
+          ),
+      )
+      .max(ARRAY_INPUT_MAX_ITEMS),
   })
   .strict()
 
@@ -114,9 +127,14 @@ export const PUT = secureMutationRoute({
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
 
-    const coAuthorPeople = await resolveVerifiedRequirementResponsibilityPeople(
-      db,
-      body.coAuthorHsaIds,
+    const coAuthorPeople = resolveVerifiedRequirementResponsibilityPeople(
+      body.verificationEvidence,
+      {
+        actor: context.actor,
+        hsaIds: body.coAuthorHsaIds,
+        purpose: 'requirement_package_co_author',
+        scopeId: params.id,
+      },
     )
     const result = await replaceRequirementPackageCoAuthors(db, params.id, {
       changedBy: assignmentActor(context),

--- a/app/api/requirement-packages/[id]/route.ts
+++ b/app/api/requirement-packages/[id]/route.ts
@@ -27,7 +27,10 @@ import {
   requireRequirementPackageLeadOrAdmin,
   requireRequirementPackagePermission,
 } from '@/lib/requirements/requirement-package-permissions'
-import { resolveVerifiedRequirementResponsibilityPerson } from '@/lib/requirements/responsibility-person-verification'
+import {
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH,
+  resolveVerifiedRequirementResponsibilityPerson,
+} from '@/lib/requirements/responsibility-person-verification'
 
 export const dynamic = 'force-dynamic'
 
@@ -42,6 +45,11 @@ const updateRequirementPackageSchema = z
     leadHsaId: hsaIdSchema.optional(),
     name: boundedDbStringSchema.optional(),
     purposeAndScope: optionalBusinessTextSchema,
+    verificationEvidence: z
+      .string()
+      .min(1)
+      .max(REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH)
+      .optional(),
   })
   .strict()
   .refine(
@@ -51,6 +59,22 @@ const updateRequirementPackageSchema = z
       ),
     { message: 'At least one field must be provided for update' },
   )
+  .superRefine((body, context) => {
+    if (body.leadHsaId !== undefined && !body.verificationEvidence) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Verification evidence is required when changing lead',
+        path: ['verificationEvidence'],
+      })
+    }
+    if (body.leadHsaId === undefined && body.verificationEvidence) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Verification evidence is only accepted when changing lead',
+        path: ['verificationEvidence'],
+      })
+    }
+  })
 
 export async function GET(
   _request: NextRequest,
@@ -109,12 +133,19 @@ export const PUT = secureMutationRoute({
     const leadPerson =
       body.leadHsaId === undefined
         ? undefined
-        : await resolveVerifiedRequirementResponsibilityPerson(
-            db,
-            body.leadHsaId,
+        : resolveVerifiedRequirementResponsibilityPerson(
+            body.verificationEvidence ?? '',
+            {
+              actor: context.actor,
+              hsaId: body.leadHsaId,
+              purpose: 'requirement_package_lead',
+              scopeId: params.id,
+            },
           )
+    const { verificationEvidence: _verificationEvidence, ...packageUpdate } =
+      body
     const requirementPackage = await updateRequirementPackage(db, params.id, {
-      ...body,
+      ...packageUpdate,
       leadPerson,
     })
     if (!requirementPackage) {

--- a/app/api/requirement-packages/[id]/route.ts
+++ b/app/api/requirement-packages/[id]/route.ts
@@ -153,7 +153,7 @@ export const PUT = secureMutationRoute({
     }
     await recordAllowedActionAuditEvent(db, context, {
       action: 'requirement_package.update',
-      details: { changedFields: Object.keys(body) },
+      details: { changedFields: Object.keys(packageUpdate) },
       targetId: params.id,
       targetKind: 'requirement_package',
     })

--- a/app/api/requirement-packages/route.ts
+++ b/app/api/requirement-packages/route.ts
@@ -24,7 +24,7 @@ import {
   requireHumanActorSnapshot,
 } from '@/lib/requirements/auth'
 import { requireRequirementPackageCreatePermission } from '@/lib/requirements/requirement-package-permissions'
-import { resolveVerifiedRequirementResponsibilityPerson } from '@/lib/requirements/responsibility-person-verification'
+import { requirementResponsibilityPersonFromActor } from '@/lib/requirements/responsibility-person-verification'
 
 const requirementPackageSchema = z
   .object({
@@ -79,10 +79,7 @@ export const POST = secureMutationRoute({
   handler: async ({ body, context }) => {
     const db = await getRequestSqlServerDataSource()
     const actor = requireHumanActorSnapshot(context)
-    const leadPerson = await resolveVerifiedRequirementResponsibilityPerson(
-      db,
-      actor.hsaId,
-    )
+    const leadPerson = requirementResponsibilityPersonFromActor(context.actor)
     const requirementPackage = await db.transaction(async manager => {
       const createdRequirementPackage = await createRequirementPackage(
         manager,

--- a/app/api/requirement-responsibility-people/verify/route.ts
+++ b/app/api/requirement-responsibility-people/verify/route.ts
@@ -6,6 +6,7 @@ import { isHsaId } from '@/lib/auth/hsa-id'
 import { canManageAreaCoAuthors } from '@/lib/dal/requirement-areas'
 import { canManageSpecificationAssignments } from '@/lib/dal/requirements-specifications'
 import { getRequestSqlServerDataSource } from '@/lib/db'
+import { logSanitizedError } from '@/lib/http/safe-errors'
 import {
   customMutationPolicy,
   secureMutationRoute,
@@ -192,32 +193,13 @@ export const POST = secureMutationRoute({
     },
   ),
   handler: async ({ body, context, request }) => {
-    const db = await getRequestSqlServerDataSource()
     const targetFingerprint = requirementResponsibilityPersonTargetFingerprint(
       body.hsaId,
     )
     const actorFingerprint = requirementResponsibilityPersonActorFingerprint(
       context.actor,
     )
-    const actorThrottle = checkInMemoryThrottle({
-      key: `hsa.verify:actor:${actorFingerprint}`,
-      limit: ACTOR_RATE_LIMIT,
-      windowMs: RATE_LIMIT_WINDOW_MS,
-    })
-    const actorTargetThrottle = checkInMemoryThrottle({
-      key: `hsa.verify:actor-target:${actorFingerprint}:${targetFingerprint}`,
-      limit: ACTOR_TARGET_RATE_LIMIT,
-      windowMs: RATE_LIMIT_WINDOW_MS,
-    })
-    const targetThrottle = checkInMemoryThrottle({
-      key: `hsa.verify:target:${targetFingerprint}`,
-      limit: TARGET_RATE_LIMIT,
-      windowMs: RATE_LIMIT_WINDOW_MS,
-    })
-
-    const recordOutcome = async (
-      outcome: VerificationAuditOutcome,
-    ): Promise<void> => {
+    const recordSecurityOutcome = (outcome: VerificationAuditOutcome) => {
       const details = {
         mode: body.mode,
         outcome,
@@ -235,38 +217,11 @@ export const POST = secureMutationRoute({
         outcome: outcome === 'success' ? 'success' : 'failure',
         request,
       })
-      await recordActionAuditEvent(db, {
-        action: 'requirement_responsibility_person.verify',
-        actorClientId: actorFingerprint,
-        actorDisplayName: null,
-        actorHsaId: null,
-        actorKind:
-          context.source === 'mcp' || context.actor.source === 'mcp'
-            ? 'mcp_client'
-            : context.actor.isAuthenticated
-              ? 'user'
-              : 'system',
-        clientIp: context.request?.ip ?? null,
-        correlationId: context.correlationId,
-        decision: 'allowed',
-        details,
-        requestId: context.requestId,
-        targetId: targetFingerprint,
-        targetKind: 'requirement_responsibility_person_verification',
-      })
+      return details
     }
 
-    if (
-      !actorThrottle.allowed ||
-      !actorTargetThrottle.allowed ||
-      !targetThrottle.allowed
-    ) {
-      const retryAfterSeconds = Math.max(
-        actorThrottle.retryAfterSeconds,
-        actorTargetThrottle.retryAfterSeconds,
-        targetThrottle.retryAfterSeconds,
-      )
-      await recordOutcome('throttled')
+    const throttledResponse = (retryAfterSeconds: number) => {
+      recordSecurityOutcome('throttled')
       return NextResponse.json(
         { ...THROTTLED_ERROR, retryAfterSeconds },
         {
@@ -274,6 +229,66 @@ export const POST = secureMutationRoute({
           status: 429,
         },
       )
+    }
+
+    const actorThrottle = checkInMemoryThrottle({
+      key: `hsa.verify:actor:${actorFingerprint}`,
+      limit: ACTOR_RATE_LIMIT,
+      windowMs: RATE_LIMIT_WINDOW_MS,
+    })
+    if (!actorThrottle.allowed) {
+      return throttledResponse(actorThrottle.retryAfterSeconds)
+    }
+
+    const actorTargetThrottle = checkInMemoryThrottle({
+      key: `hsa.verify:actor-target:${actorFingerprint}:${targetFingerprint}`,
+      limit: ACTOR_TARGET_RATE_LIMIT,
+      windowMs: RATE_LIMIT_WINDOW_MS,
+    })
+    if (!actorTargetThrottle.allowed) {
+      return throttledResponse(actorTargetThrottle.retryAfterSeconds)
+    }
+
+    const targetThrottle = checkInMemoryThrottle({
+      key: `hsa.verify:target:${targetFingerprint}`,
+      limit: TARGET_RATE_LIMIT,
+      windowMs: RATE_LIMIT_WINDOW_MS,
+    })
+    if (!targetThrottle.allowed) {
+      return throttledResponse(targetThrottle.retryAfterSeconds)
+    }
+
+    const db = await getRequestSqlServerDataSource()
+    const recordOutcome = async (
+      outcome: VerificationAuditOutcome,
+    ): Promise<void> => {
+      const details = recordSecurityOutcome(outcome)
+      try {
+        await recordActionAuditEvent(db, {
+          action: 'requirement_responsibility_person.verify',
+          actorClientId: actorFingerprint,
+          actorDisplayName: null,
+          actorHsaId: null,
+          actorKind:
+            context.source === 'mcp' || context.actor.source === 'mcp'
+              ? 'mcp_client'
+              : context.actor.isAuthenticated
+                ? 'user'
+                : 'system',
+          clientIp: context.request?.ip ?? null,
+          correlationId: context.correlationId,
+          decision: 'allowed',
+          details,
+          requestId: context.requestId,
+          targetId: targetFingerprint,
+          targetKind: 'requirement_responsibility_person_verification',
+        })
+      } catch (error) {
+        logSanitizedError(
+          'Failed to record requirement responsibility person verification action audit event',
+          error,
+        )
+      }
     }
 
     let person: Awaited<

--- a/app/api/requirement-responsibility-people/verify/route.ts
+++ b/app/api/requirement-responsibility-people/verify/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
+import { recordActionAuditEvent } from '@/lib/audit/action-audit'
+import { recordSecurityEvent } from '@/lib/auth/audit'
 import { isHsaId } from '@/lib/auth/hsa-id'
 import { canManageAreaCoAuthors } from '@/lib/dal/requirement-areas'
 import { canManageSpecificationAssignments } from '@/lib/dal/requirements-specifications'
@@ -12,24 +14,43 @@ import {
   boundedDbStringSchema,
   positiveIntegerSchema,
 } from '@/lib/http/validation'
-import { forbiddenError } from '@/lib/requirements/errors'
+import { checkInMemoryThrottle } from '@/lib/observability/throttle'
+import {
+  forbiddenError,
+  isRequirementsServiceError,
+} from '@/lib/requirements/errors'
 import {
   requireRequirementPackageCreatePermission,
   requireRequirementPackageLeadOrAdmin,
 } from '@/lib/requirements/requirement-package-permissions'
 import {
+  createRequirementResponsibilityPersonVerificationEvidence,
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_PURPOSES,
+  requirementResponsibilityPersonActorFingerprint,
+  requirementResponsibilityPersonTargetFingerprint,
   toRequirementResponsibilityPersonVerificationPayload,
   verifyRequirementResponsibilityPerson,
 } from '@/lib/requirements/responsibility-person-verification'
 
-const verifyPurposeSchema = z.enum([
-  'requirement_area_owner',
-  'requirement_area_co_author',
-  'requirement_package_co_author',
-  'requirement_package_lead',
-  'requirements_specification_responsible',
-  'requirements_specification_co_author',
-])
+const ACTOR_RATE_LIMIT = 50
+const ACTOR_TARGET_RATE_LIMIT = 10
+const TARGET_RATE_LIMIT = 10
+const RATE_LIMIT_WINDOW_MS = 60_000
+const THROTTLED_ERROR = {
+  code: 'hsa_verification_throttled',
+  error: 'Too many HSA verification requests.',
+} as const
+
+type VerificationAuditOutcome =
+  | 'conflict'
+  | 'not_found'
+  | 'provider_failure'
+  | 'success'
+  | 'throttled'
+
+const verifyPurposeSchema = z.enum(
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_PURPOSES,
+)
 
 const verifyModeSchema = z.enum(['reuse_local', 'refresh'])
 
@@ -46,6 +67,13 @@ const verifySchema = z
 
 function isAdmin(roles: string[]): boolean {
   return roles.includes('Admin')
+}
+
+function verificationOutcome(error: unknown): VerificationAuditOutcome {
+  if (!isRequirementsServiceError(error)) return 'provider_failure'
+  if (error.details?.reason === 'hsa_lookup_not_found') return 'not_found'
+  if (error.code === 'conflict') return 'conflict'
+  return 'provider_failure'
 }
 
 export const POST = secureMutationRoute({
@@ -114,11 +142,19 @@ export const POST = secureMutationRoute({
             body.scopeId,
             'requirement_package.update',
           )
-        } else {
+        } else if (
+          body.purpose === 'requirement_package_lead' &&
+          context.actor.hsaId?.trim().toLowerCase() ===
+            body.hsaId.trim().toLowerCase()
+        ) {
           await requireRequirementPackageCreatePermission(
             await getDb(),
             context,
           )
+        } else {
+          throw forbiddenError('Requirement package scope is required', {
+            reason: 'scope_required',
+          })
         }
       }
 
@@ -130,7 +166,8 @@ export const POST = secureMutationRoute({
           body.purpose === 'requirements_specification_responsible' &&
           !body.scopeId &&
           context.actor.hsaId &&
-          body.hsaId === context.actor.hsaId
+          body.hsaId.trim().toLowerCase() ===
+            context.actor.hsaId.trim().toLowerCase()
         ) {
           return
         }
@@ -154,14 +191,114 @@ export const POST = secureMutationRoute({
       }
     },
   ),
-  handler: async ({ body }) => {
+  handler: async ({ body, context, request }) => {
     const db = await getRequestSqlServerDataSource()
-    const person = await verifyRequirementResponsibilityPerson(
-      db,
+    const targetFingerprint = requirementResponsibilityPersonTargetFingerprint(
       body.hsaId,
-      body.mode,
     )
+    const actorFingerprint = requirementResponsibilityPersonActorFingerprint(
+      context.actor,
+    )
+    const actorThrottle = checkInMemoryThrottle({
+      key: `hsa.verify:actor:${actorFingerprint}`,
+      limit: ACTOR_RATE_LIMIT,
+      windowMs: RATE_LIMIT_WINDOW_MS,
+    })
+    const actorTargetThrottle = checkInMemoryThrottle({
+      key: `hsa.verify:actor-target:${actorFingerprint}:${targetFingerprint}`,
+      limit: ACTOR_TARGET_RATE_LIMIT,
+      windowMs: RATE_LIMIT_WINDOW_MS,
+    })
+    const targetThrottle = checkInMemoryThrottle({
+      key: `hsa.verify:target:${targetFingerprint}`,
+      limit: TARGET_RATE_LIMIT,
+      windowMs: RATE_LIMIT_WINDOW_MS,
+    })
+
+    const recordOutcome = async (
+      outcome: VerificationAuditOutcome,
+    ): Promise<void> => {
+      const details = {
+        mode: body.mode,
+        outcome,
+        purpose: body.purpose,
+        ...(body.scopeId === undefined ? {} : { scopeId: body.scopeId }),
+        targetFingerprint,
+      }
+      recordSecurityEvent({
+        actor: {
+          source: context.actor.source,
+          sub: actorFingerprint,
+        },
+        detail: details,
+        event: 'requirements.hsa_verification.completed',
+        outcome: outcome === 'success' ? 'success' : 'failure',
+        request,
+      })
+      await recordActionAuditEvent(db, {
+        action: 'requirement_responsibility_person.verify',
+        actorClientId: actorFingerprint,
+        actorDisplayName: null,
+        actorHsaId: null,
+        actorKind:
+          context.source === 'mcp' || context.actor.source === 'mcp'
+            ? 'mcp_client'
+            : context.actor.isAuthenticated
+              ? 'user'
+              : 'system',
+        clientIp: context.request?.ip ?? null,
+        correlationId: context.correlationId,
+        decision: 'allowed',
+        details,
+        requestId: context.requestId,
+        targetId: targetFingerprint,
+        targetKind: 'requirement_responsibility_person_verification',
+      })
+    }
+
+    if (
+      !actorThrottle.allowed ||
+      !actorTargetThrottle.allowed ||
+      !targetThrottle.allowed
+    ) {
+      const retryAfterSeconds = Math.max(
+        actorThrottle.retryAfterSeconds,
+        actorTargetThrottle.retryAfterSeconds,
+        targetThrottle.retryAfterSeconds,
+      )
+      await recordOutcome('throttled')
+      return NextResponse.json(
+        { ...THROTTLED_ERROR, retryAfterSeconds },
+        {
+          headers: { 'Retry-After': String(retryAfterSeconds) },
+          status: 429,
+        },
+      )
+    }
+
+    let person: Awaited<
+      ReturnType<typeof verifyRequirementResponsibilityPerson>
+    >
+    try {
+      person = await verifyRequirementResponsibilityPerson(
+        db,
+        body.hsaId,
+        body.mode,
+      )
+    } catch (error) {
+      await recordOutcome(verificationOutcome(error))
+      throw error
+    }
+    const verification =
+      createRequirementResponsibilityPersonVerificationEvidence({
+        actor: context.actor,
+        person,
+        purpose: body.purpose,
+        scopeId: body.scopeId,
+      })
+    await recordOutcome('success')
     return NextResponse.json({
+      ...verification,
       person: toRequirementResponsibilityPersonVerificationPayload(person),
     })
   },

--- a/app/api/requirements-specifications/[id]/co-authors/route.ts
+++ b/app/api/requirements-specifications/[id]/co-authors/route.ts
@@ -12,14 +12,21 @@ import {
   customMutationPolicy,
   secureMutationRoute,
 } from '@/lib/http/secure-mutation-route'
-import { idParamSchema, parseRouteParams } from '@/lib/http/validation'
+import {
+  ARRAY_INPUT_MAX_ITEMS,
+  idParamSchema,
+  parseRouteParams,
+} from '@/lib/http/validation'
 import {
   createRequestContext,
   type RequestContext,
 } from '@/lib/requirements/auth'
 import { forbiddenError } from '@/lib/requirements/errors'
 import { toHttpErrorPayload } from '@/lib/requirements/http-errors'
-import { resolveVerifiedRequirementResponsibilityPeople } from '@/lib/requirements/responsibility-person-verification'
+import {
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH,
+  resolveVerifiedRequirementResponsibilityPeople,
+} from '@/lib/requirements/responsibility-person-verification'
 
 export const dynamic = 'force-dynamic'
 
@@ -32,7 +39,17 @@ const hsaIdSchema = z.string().trim().max(HSA_ID_MAX_LENGTH).refine(isHsaId, {
 
 const updateSpecificationCoAuthorsSchema = z
   .object({
-    coAuthorHsaIds: z.array(hsaIdSchema),
+    coAuthorHsaIds: z.array(hsaIdSchema).max(ARRAY_INPUT_MAX_ITEMS),
+    verificationEvidence: z
+      .array(
+        z
+          .string()
+          .min(1)
+          .max(
+            REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH,
+          ),
+      )
+      .max(ARRAY_INPUT_MAX_ITEMS),
   })
   .strict()
 
@@ -117,9 +134,14 @@ export const PUT = secureMutationRoute({
     const spec = await getSpecificationById(db, params.id)
     if (!spec) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
-    const coAuthorPeople = await resolveVerifiedRequirementResponsibilityPeople(
-      db,
-      body.coAuthorHsaIds,
+    const coAuthorPeople = resolveVerifiedRequirementResponsibilityPeople(
+      body.verificationEvidence,
+      {
+        actor: context.actor,
+        hsaIds: body.coAuthorHsaIds,
+        purpose: 'requirements_specification_co_author',
+        scopeId: params.id,
+      },
     )
     const result = await replaceSpecificationCoAuthors(db, spec.id, {
       changedBy: assignmentActor(context),

--- a/app/api/requirements-specifications/[id]/responsible/route.ts
+++ b/app/api/requirements-specifications/[id]/responsible/route.ts
@@ -13,7 +13,10 @@ import {
 } from '@/lib/http/secure-mutation-route'
 import { idParamSchema } from '@/lib/http/validation'
 import { forbiddenError } from '@/lib/requirements/errors'
-import { resolveVerifiedRequirementResponsibilityPerson } from '@/lib/requirements/responsibility-person-verification'
+import {
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH,
+  resolveVerifiedRequirementResponsibilityPerson,
+} from '@/lib/requirements/responsibility-person-verification'
 
 export const dynamic = 'force-dynamic'
 
@@ -27,6 +30,10 @@ const hsaIdSchema = z.string().trim().max(HSA_ID_MAX_LENGTH).refine(isHsaId, {
 const updateSpecificationResponsibleSchema = z
   .object({
     responsibleHsaId: hsaIdSchema,
+    verificationEvidence: z
+      .string()
+      .min(1)
+      .max(REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH),
   })
   .strict()
 
@@ -59,16 +66,20 @@ export const PUT = secureMutationRoute({
       }
     },
   ),
-  handler: async ({ body, params }) => {
+  handler: async ({ body, context, params }) => {
     const db = await getRequestSqlServerDataSource()
     const spec = await getSpecificationById(db, params.id)
     if (!spec) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
-    const responsiblePerson =
-      await resolveVerifiedRequirementResponsibilityPerson(
-        db,
-        body.responsibleHsaId,
-      )
+    const responsiblePerson = resolveVerifiedRequirementResponsibilityPerson(
+      body.verificationEvidence,
+      {
+        actor: context.actor,
+        hsaId: body.responsibleHsaId,
+        purpose: 'requirements_specification_responsible',
+        scopeId: params.id,
+      },
+    )
     const updated = await updateSpecificationResponsible(db, spec.id, {
       responsibleHsaId: body.responsibleHsaId,
       responsiblePerson,

--- a/app/api/requirements-specifications/route.ts
+++ b/app/api/requirements-specifications/route.ts
@@ -9,7 +9,7 @@ import {
 import { requireHumanActorSnapshot } from '@/lib/requirements/auth'
 import { forbiddenError, validationError } from '@/lib/requirements/errors'
 import { toHttpErrorPayload } from '@/lib/requirements/http-errors'
-import { resolveVerifiedRequirementResponsibilityPerson } from '@/lib/requirements/responsibility-person-verification'
+import { requirementResponsibilityPersonFromActor } from '@/lib/requirements/responsibility-person-verification'
 import { createRequirementsRestRuntime } from '@/lib/requirements/server'
 import { createSpecificationWithAudit } from '@/lib/requirements/specification-mutations'
 import { canCreateSpecification } from '@/lib/specifications/permissions'
@@ -53,8 +53,9 @@ export const POST = secureMutationRoute({
     }
 
     const db = await getRequestSqlServerDataSource()
-    const responsiblePerson =
-      await resolveVerifiedRequirementResponsibilityPerson(db, responsibleHsaId)
+    const responsiblePerson = requirementResponsibilityPersonFromActor(
+      context.actor,
+    )
     try {
       const specification = await createSpecificationWithAudit(
         db,

--- a/components/CoAuthorsManagementModal.tsx
+++ b/components/CoAuthorsManagementModal.tsx
@@ -22,6 +22,7 @@ export interface CoAuthorSummary {
 
 interface CoAuthorFormRow extends CoAuthorSummary {
   clientId: string
+  verificationEvidence?: string
 }
 
 interface CoAuthorDraft {
@@ -183,6 +184,11 @@ export default function CoAuthorsManagementModal({
       const response = await apiFetch(endpoint, {
         body: JSON.stringify({
           coAuthorHsaIds: sortedNextCoAuthors.map(coAuthor => coAuthor.hsaId),
+          verificationEvidence: sortedNextCoAuthors.flatMap(coAuthor =>
+            coAuthor.verificationEvidence
+              ? [coAuthor.verificationEvidence]
+              : [],
+          ),
         }),
         headers: { 'Content-Type': 'application/json' },
         method: 'PUT',
@@ -191,7 +197,12 @@ export default function CoAuthorsManagementModal({
         setError((await readResponseMessage(response)) ?? saveErrorMessage)
         return false
       }
-      setCoAuthors(sortedNextCoAuthors)
+      setCoAuthors(
+        sortedNextCoAuthors.map(coAuthor => ({
+          ...coAuthor,
+          verificationEvidence: undefined,
+        })),
+      )
       await onChanged?.()
       return true
     } catch (saveError) {
@@ -241,6 +252,7 @@ export default function CoAuthorsManagementModal({
         displayName: person.displayName,
         email: person.email,
         hsaId: person.hsaId,
+        verificationEvidence: person.verificationEvidence,
       },
     ]
     if (await saveCoAuthorAssignments(nextCoAuthors)) {

--- a/components/CrudAdminPanel.tsx
+++ b/components/CrudAdminPanel.tsx
@@ -154,7 +154,13 @@ export default function CrudAdminPanel<TItem extends { id: CrudId }, TForm>({
         priority: 340,
         value: formMode,
       })}
-      onSubmit={controller.submit}
+      onSubmit={
+        formSubmitDisabled
+          ? event => {
+              event.preventDefault()
+            }
+          : controller.submit
+      }
     >
       {renderCrudFormBody(showHeading)}
     </form>

--- a/components/HsaPersonChangeModal.tsx
+++ b/components/HsaPersonChangeModal.tsx
@@ -114,7 +114,11 @@ export default function HsaPersonChangeModal({
 
   const handleSubmit = async () => {
     if (submitting) return
-    if (validationError || !isHsaId(trimmedNextHsaId)) {
+    if (
+      validationError ||
+      !isHsaId(trimmedNextHsaId) ||
+      verifiedPerson?.hsaId !== trimmedNextHsaId
+    ) {
       setSubmitError(validationError ?? invalidError)
       return
     }
@@ -210,7 +214,10 @@ export default function HsaPersonChangeModal({
           <button
             className="btn-primary"
             disabled={
-              submitting || !!validationError || !isHsaId(trimmedNextHsaId)
+              submitting ||
+              !!validationError ||
+              !isHsaId(trimmedNextHsaId) ||
+              verifiedPerson?.hsaId !== trimmedNextHsaId
             }
             onClick={handleSubmit}
             type="button"

--- a/components/HsaPersonVerifyField.tsx
+++ b/components/HsaPersonVerifyField.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { RefreshCw } from 'lucide-react'
+import { RefreshCw, ShieldAlert } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { useEffect, useRef, useState } from 'react'
 import {
@@ -11,24 +11,24 @@ import {
   isHsaIdPrefix,
   splitHsaId,
 } from '@/lib/auth/hsa-id'
+import { devMarker } from '@/lib/developer-mode-markers'
 import { apiFetch } from '@/lib/http/api-fetch'
 import { readResponseMessage } from '@/lib/http/response-message'
+import type { RequirementResponsibilityPersonVerificationPurpose } from '@/lib/requirements/responsibility-person-verification-contract'
 
 export type HsaPersonVerificationPurpose =
-  | 'requirement_area_owner'
-  | 'requirement_area_co_author'
-  | 'requirement_package_co_author'
-  | 'requirement_package_lead'
-  | 'requirements_specification_responsible'
-  | 'requirements_specification_co_author'
+  RequirementResponsibilityPersonVerificationPurpose
 
 export interface HsaPersonVerification {
   displayName: string
   email: string | null
   givenName: string
+  hasProtectedPersonalData: boolean
   hsaId: string
   middleName: string | null
   surname: string | null
+  verificationEvidence: string
+  verificationExpiresAt: string
 }
 
 interface HsaIdPrefixOption {
@@ -214,16 +214,26 @@ export default function HsaPersonVerifyField({
         return
       }
       const payload = (await response.json()) as {
-        person?: HsaPersonVerification
+        evidence?: string
+        expiresAt?: string
+        person?: Omit<
+          HsaPersonVerification,
+          'verificationEvidence' | 'verificationExpiresAt'
+        >
       }
-      if (!payload.person) {
+      if (!payload.person || !payload.evidence || !payload.expiresAt) {
         if (currentHsaIdRef.current !== requestedHsaId) return
         setError(errorFallback)
         return
       }
       if (currentHsaIdRef.current !== requestedHsaId) return
-      setVerification(payload.person)
-      onVerified?.(payload.person)
+      const verifiedPerson = {
+        ...payload.person,
+        verificationEvidence: payload.evidence,
+        verificationExpiresAt: payload.expiresAt,
+      }
+      setVerification(verifiedPerson)
+      onVerified?.(verifiedPerson)
     } catch {
       if (currentHsaIdRef.current !== requestedHsaId) return
       setError(errorFallback)
@@ -370,6 +380,24 @@ export default function HsaPersonVerifyField({
             />
           </label>
         </div>
+      ) : null}
+      {activeVerification?.hasProtectedPersonalData ? (
+        <p
+          className="flex items-start gap-2 rounded-xl border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-100"
+          role="status"
+          {...devMarker({
+            context: 'hsa person verification',
+            name: 'protection guidance',
+            value: purpose,
+          })}
+        >
+          <ShieldAlert
+            aria-hidden="true"
+            className="mt-0.5 h-4 w-4 shrink-0"
+            focusable={false}
+          />
+          {tc('hsaProtectedPersonGuidance')}
+        </p>
       ) : null}
       {error && (
         <p className="rounded-xl border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-300">

--- a/docs/adr/0029-hsa-personuppslag-som-restgrans-mot-integrationsplattform.md
+++ b/docs/adr/0029-hsa-personuppslag-som-restgrans-mot-integrationsplattform.md
@@ -77,3 +77,11 @@ uppgifterna ska bara visas där de behövs för ansvar, spårbarhet, uppdrag ell
 behörighetsprövning, och export, loggning, hjälptext och eventuell
 skyddsmarkering styrs av policybeslutet i GitHub issue
 [#326](https://github.com/viscalyx/Kravhantering/issues/326).
+
+Verifieringsanropet är läsande och lagrar inte HSA-svaret. Det returnerar i
+stället kortlivat, signerat bevis bundet till aktör, målidentitet, ändamål och
+omfattning. Slutlig tilldelning verifierar beviset och sparar personpost och
+ansvar i samma transaktion. Begränsningsnycklar och utfallsloggar använder
+icke-reversibla fingeravtryck, inte rått mål-HSA-id eller personuppgifter.
+Utfallet loggas som `success`, `not_found`, `conflict`, `throttled` eller
+`provider_failure`.

--- a/docs/governance/manuella-testfall.md
+++ b/docs/governance/manuella-testfall.md
@@ -713,13 +713,17 @@ på paketnamn, syfte och avgränsning och rensa sökningen. Öppna dialogen
 `Nytt kravpaket` och kontrollera ansvarssammanfattningen. Öppna radåtgärden
 `Hantera medförfattare`, öppna kopplade krav från redigeringsformuläret och
 starta byte av kravpaketsansvarig med HSA-id. Kontrollera även att listans
-skrivskyddade medförfattarkolumn visar namn utan HSA-id eller e-postadress.
+skrivskyddade medförfattarkolumn visar namn utan HSA-id eller e-postadress. Gör
+uppslaget mot en testperson markerad med skyddade personuppgifter.
 
 **Förväntat resultat:** Paketlistan filtreras och återställs korrekt. Den som
 skapar kravpaketet visas som kravpaketsansvarig utan redigerbart ansvarsfält.
 Kopplade krav öppnas i en skrivskyddad dialog utan att redigeringsformuläret
 försvinner. Medförfattare hanteras i separat dialog, och byte av
 kravpaketsansvarig verifierar HSA-id och visar namn och e-post som text.
+Den skyddade identiteten förblir synlig i det behöriga arbetsflödet och en
+tydlig vägledning begränsar användningen till uppdraget, uppmanar till minskad
+spridning och hänvisar till regionens dataskydds-, säkerhets- eller HR-funktion.
 
 ### REQ-14b: kravurvalsfrågor behåller flik och kan ordnas
 

--- a/docs/integrations/hsa-person-lookup-integration.md
+++ b/docs/integrations/hsa-person-lookup-integration.md
@@ -17,8 +17,9 @@ co-authors. The browser never calls Kong or the HSA directory directly. It
 only talks to the app's protected same-origin routes.
 
 Read views do not call HSA. Save routes also do not call HSA. Person lookup
-happens before save through the app-owned verify route, and the result is
-stored as a local `Kravansvarsperson` row keyed by HSA-id.
+happens before save through the app-owned verify route without persisting the
+lookup result. Only the final assignment atomically persists the verified
+person as a local `Kravansvarsperson` row and creates or updates the assignment.
 
 ## Devcontainer and Release Test Support
 

--- a/docs/integrations/hsa-person-lookup-integration.md
+++ b/docs/integrations/hsa-person-lookup-integration.md
@@ -83,16 +83,31 @@ enables mixed mode.
 The responsibility-assignment person lookup flow stays server-side. The browser
 calls `POST /api/requirement-responsibility-people/verify`, and the app checks
 session, CSRF, purpose, and scope before any local read or HSA lookup.
+It then applies per-caller, per-target, and caller-target limits. Caller and
+target use non-reversible HMAC fingerprints in throttle keys, and target
+fingerprints normalize HSA-id case to prevent variant-based bypasses. A limited
+request returns stable code `hsa_verification_throttled`, HTTP `429`,
+`Retry-After`, and `retryAfterSeconds` without calling local storage or the HSA
+provider.
 
 The route has two explicit modes:
 
 - `reuse_local` is used when the editor leaves an HSA-id field. If a local
   `Kravansvarsperson` row already exists, the app reuses it without calling
   HSA. If the row is missing, the app calls `HSA_PERSON_LOOKUP_URL`, normalizes
-  the response, and updates or inserts the local person row.
+  the response, and returns it without updating local person storage.
 - `refresh` is used by the manual fetch icon. It always calls
-  `HSA_PERSON_LOOKUP_URL` and updates or inserts the local person row with the
-  returned name components and e-mail.
+  `HSA_PERSON_LOOKUP_URL` and returns the normalized person without updating
+  local person storage.
+
+A successful response also contains short-lived, signed `evidence` and its
+`expiresAt` time. The evidence is bound to the authenticated caller, normalized
+target HSA-id, assignment purpose, optional scope ID, and verified person
+record. Final assignment routes reject missing, expired, tampered, cross-actor,
+cross-target, cross-purpose, or cross-scope evidence. Verification outcomes
+(`success`, `not_found`, `conflict`, `throttled`, and `provider_failure`) are
+audited with target fingerprints and operational metadata only, never the raw
+target HSA-id or returned person details.
 
 ## Technical API and authentication flows
 
@@ -141,7 +156,7 @@ sequenceDiagram
     end
     Kong-->>Client: Person JSON or mapped error
     Client-->>Verify: Normalized person or domain error
-    Verify-->>UI: Verified person payload or validation error
+    Verify-->>UI: Person + short-lived signed evidence, or stable error
 ```
 <!-- markdownlint-enable MD013 -->
 
@@ -213,41 +228,36 @@ sequenceDiagram
             DB-->>Verify: Local person row
         else Local person missing
             Verify->>Verify: Perform external HSA lookup
-            Verify->>DB: Store Kravansvarsperson
         end
-        Verify-->>UI: Read-only name and e-mail
+        Verify->>Verify: Sign actor/target/purpose/scope evidence
+        Verify-->>UI: Read-only identity and evidence
     else Editor selects Fetch icon
         UI->>Verify: POST /api/requirement-responsibility-people/verify mode=refresh
         Verify->>Policy: Validate session, CSRF, purpose and scope
         Policy-->>Verify: Allowed
         Verify->>Verify: Perform external HSA lookup
-        Verify->>DB: Store Kravansvarsperson
-        Verify-->>UI: Read-only name and e-mail
+        Verify->>Verify: Sign actor/target/purpose/scope evidence
+        Verify-->>UI: Read-only identity and evidence
     end
 
     alt Save responsibility assignment
         Editor->>UI: Save form
-        UI->>Save: POST/PUT area, specification or package route
+        UI->>Save: POST/PUT assignment with signed evidence
         Save->>Policy: Validate mutation permission
-        Save->>DB: Read Kravansvarsperson by HSA-id
-        alt Local person missing
-            Save->>Save: Wait briefly
-            Save->>DB: Read Kravansvarsperson again
-        end
-        alt Local person still missing
-            Save-->>UI: Error: verify HSA-id first
-        else Local person exists
-            Save->>DB: Store assignment HSA-id
-            DB-->>Save: Updated responsibility data
-            Save-->>UI: Saved response with local person data
-        end
+        Save->>Save: Validate actor, target, purpose, scope and expiry
+        Save->>DB: Begin serializable transaction
+        Save->>DB: Upsert verified person and assignment
+        DB-->>Save: Commit both changes
+        Save-->>UI: Saved response with local person data
     end
 ```
 
-The save routes require a local `Kravansvarsperson` row for the HSA-id being
-assigned. They retry the local read once after a short delay to handle a
-verification request that just completed. If the local row is still missing,
-the route returns an error asking the editor to verify the HSA-id first.
+The verification request never persists a person. The final assignment owns
+persistence: it validates the signed evidence, then upserts
+`Kravansvarsperson` and writes the responsibility assignment in one database
+transaction. Any failure rolls back both changes, preventing orphan person
+rows and partial assignments. Removing an assignment does not require new
+evidence; every newly added identity does.
 
 ## Related decisions
 

--- a/docs/security-privacy/api-security.md
+++ b/docs/security-privacy/api-security.md
@@ -174,7 +174,12 @@ Deferred from this contract:
   contract. `POST /api/requirement-responsibility-people/verify` is a
   same-origin, CSRF-protected editing helper that is only useful with an
   authenticated session, assignment purpose, and, where applicable, scoped edit
-  permission. The app does not expose a browser-usable general HSA search route.
+  permission. Caller and target fingerprints drive rate limits, sanitized
+  outcomes are audited, and successful lookups return short-lived evidence
+  bound to caller, target, purpose, scope, and expiry. Verification does not
+  persist the person; the final assignment route validates evidence and stores
+  person plus assignment atomically. The app does not expose a browser-usable
+  general HSA search route.
 - MCP remains outside the REST OpenAPI/Schemathesis contract. `/api/mcp` is
   governed by MCP schemas, tool-contract tests, Bearer-token authentication
   tests, the Admin-configured MCP payload-size guard that defaults to `1 MiB`

--- a/docs/security-privacy/informationsmangder-kravhantering.md
+++ b/docs/security-privacy/informationsmangder-kravhantering.md
@@ -92,8 +92,11 @@ nyckelhantering, loggplattform och behörighet till driftloggar.
 
 Kravansvarsperson kan också bära flaggan `hasProtectedPersonalData`, mappad
 från HSA `hsaProtectedPerson`, för att visa att HSA-personposten har skyddade
-personuppgifter. Flaggan transporteras och exporteras men ger ännu ingen
-särskild UI-maskering eller gallringsregel; sådan policy beslutas separat.
+personuppgifter. I ett behörigt och ändamålsbundet tilldelningsflöde visas den
+verifierade identiteten utan generell maskering. Gränssnittet visar samtidigt
+en skyddsvägledning som begränsar användningen till uppdraget, uppmanar till
+minskad spridning och hänvisar till regionens dataskydds-, säkerhets- eller
+HR-funktion. Flaggan ger ingen separat gallringsregel.
 
 ## Gallrings- och arkiveringsmatris
 

--- a/lib/auth/audit.ts
+++ b/lib/auth/audit.ts
@@ -43,6 +43,7 @@ export type SecurityEventName =
   | 'privacy.data_subject_export.generated'
   | 'privacy.erasure.executed'
   | 'privacy.erasure.previewed'
+  | 'requirements.hsa_verification.completed'
   | 'requirements.sensitive_mutation.succeeded'
 
 export type SecurityEventOutcome = 'success' | 'failure'

--- a/lib/dal/requirement-areas.ts
+++ b/lib/dal/requirement-areas.ts
@@ -5,7 +5,10 @@ import {
 import type { SqlServerDatabase } from '@/lib/db'
 import { conflictError, validationError } from '@/lib/requirements/errors'
 import type { RequirementResponsibilityPersonRecord } from '@/lib/requirements/responsibility-person'
-import { formatRequirementResponsibilityPersonName } from '@/lib/requirements/responsibility-person'
+import {
+  formatRequirementResponsibilityPersonName,
+  verifiedPeopleCoverAddedAssignments,
+} from '@/lib/requirements/responsibility-person'
 import { toIsoString } from '@/lib/typeorm/value-mappers'
 
 export interface RequirementAreaRow {
@@ -662,6 +665,7 @@ async function syncRequirementAreaCoAuthors(
   areaId: number,
   nextHsaIds: string[],
   changedBy: { displayName: string | null; hsaId: string | null } | undefined,
+  coAuthorPeople: RequirementResponsibilityPersonRecord[],
 ): Promise<string[]> {
   const existingRows = (await db.query(
     `
@@ -676,6 +680,13 @@ async function syncRequirementAreaCoAuthors(
   const existingIdSet = new Set(existingIds)
   const removedIds = existingIds.filter(hsaId => !nextIdSet.has(hsaId))
   const addedIds = nextHsaIds.filter(hsaId => !existingIdSet.has(hsaId))
+
+  if (!verifiedPeopleCoverAddedAssignments(addedIds, coAuthorPeople)) {
+    throw validationError(
+      'Verification evidence is required for every added requirement area co-author',
+      { reason: 'requirement_responsibility_person_evidence_required' },
+    )
+  }
 
   if (removedIds.length > 0) {
     const placeholders = removedIds
@@ -748,6 +759,7 @@ export async function replaceRequirementAreaCoAuthors(
       areaId,
       coAuthorHsaIds,
       data.changedBy,
+      data.coAuthorPeople ?? [],
     )
     await cleanupUnassignedRequirementResponsibilityPeople(
       manager,

--- a/lib/dal/requirement-packages.ts
+++ b/lib/dal/requirement-packages.ts
@@ -11,6 +11,7 @@ import { validationError } from '@/lib/requirements/errors'
 import {
   formatRequirementResponsibilityPersonName,
   type RequirementResponsibilityPersonRecord,
+  verifiedPeopleCoverAddedAssignments,
 } from '@/lib/requirements/responsibility-person'
 import { STATUS_PUBLISHED } from '@/lib/requirements/status-constants.mjs'
 import { toBoolean, toIsoString } from '@/lib/typeorm/value-mappers'
@@ -727,6 +728,7 @@ async function syncRequirementPackageCoAuthors(
   requirementPackageId: number,
   nextHsaIds: string[],
   changedBy: { displayName: string | null; hsaId: string | null } | undefined,
+  coAuthorPeople: RequirementResponsibilityPersonRecord[],
 ): Promise<string[]> {
   const existingRows = (await db.query(
     `
@@ -741,6 +743,13 @@ async function syncRequirementPackageCoAuthors(
   const existingIdSet = new Set(existingIds)
   const removedIds = existingIds.filter(hsaId => !nextIdSet.has(hsaId))
   const addedIds = nextHsaIds.filter(hsaId => !existingIdSet.has(hsaId))
+
+  if (!verifiedPeopleCoverAddedAssignments(addedIds, coAuthorPeople)) {
+    throw validationError(
+      'Verification evidence is required for every added requirement package co-author',
+      { reason: 'requirement_responsibility_person_evidence_required' },
+    )
+  }
 
   if (removedIds.length > 0) {
     const placeholders = removedIds
@@ -820,6 +829,7 @@ export async function replaceRequirementPackageCoAuthors(
       requirementPackageId,
       coAuthorHsaIds,
       data.changedBy,
+      data.coAuthorPeople ?? [],
     )
     await cleanupUnassignedRequirementResponsibilityPeople(
       manager,

--- a/lib/dal/requirements-specifications.ts
+++ b/lib/dal/requirements-specifications.ts
@@ -13,6 +13,7 @@ import {
 import {
   formatRequirementResponsibilityPersonName,
   type RequirementResponsibilityPersonRecord,
+  verifiedPeopleCoverAddedAssignments,
 } from '@/lib/requirements/responsibility-person'
 import {
   STATUS_DRAFT,
@@ -1412,6 +1413,7 @@ async function syncSpecificationCoAuthors(
   specificationId: number,
   nextHsaIds: string[],
   changedBy: { displayName: string | null; hsaId: string | null } | undefined,
+  coAuthorPeople: RequirementResponsibilityPersonRecord[],
 ): Promise<string[]> {
   const existingRows = (await db.query(
     `
@@ -1426,6 +1428,13 @@ async function syncSpecificationCoAuthors(
   const existingIdSet = new Set(existingIds)
   const removedIds = existingIds.filter(hsaId => !nextIdSet.has(hsaId))
   const addedIds = nextHsaIds.filter(hsaId => !existingIdSet.has(hsaId))
+
+  if (!verifiedPeopleCoverAddedAssignments(addedIds, coAuthorPeople)) {
+    throw validationError(
+      'Verification evidence is required for every added specification co-author',
+      { reason: 'requirement_responsibility_person_evidence_required' },
+    )
+  }
 
   if (removedIds.length > 0) {
     const placeholders = removedIds
@@ -1481,7 +1490,16 @@ export async function replaceSpecificationCoAuthors(
       )
     }
 
+    const coAuthorHsaIdSet = new Set(normalizedCoAuthorHsaIds)
     for (const coAuthorPerson of data.coAuthorPeople ?? []) {
+      if (
+        !coAuthorHsaIdSet.has(normalizeHsaIdForComparison(coAuthorPerson.hsaId))
+      ) {
+        throw validationError(
+          'Specification co-author person must match a co-author HSA-id',
+          { reason: 'co_author_person_hsa_id_mismatch' },
+        )
+      }
       await upsertRequirementResponsibilityPerson(manager, coAuthorPerson)
     }
     const removedHsaIds = await syncSpecificationCoAuthors(
@@ -1489,6 +1507,7 @@ export async function replaceSpecificationCoAuthors(
       specificationId,
       coAuthorHsaIds,
       data.changedBy,
+      data.coAuthorPeople ?? [],
     )
     await cleanupUnassignedRequirementResponsibilityPeople(
       manager,

--- a/lib/http/route-security-policy.ts
+++ b/lib/http/route-security-policy.ts
@@ -855,8 +855,8 @@ export const REST_OPERATION_DECLARATIONS = [
     '/api/requirement-responsibility-people/verify',
     'session',
     'same-origin',
-    'authenticated',
-    'framework-default',
+    'sensitive',
+    'no-store',
     'focused',
   ],
   [

--- a/lib/requirements/responsibility-person-verification-contract.ts
+++ b/lib/requirements/responsibility-person-verification-contract.ts
@@ -1,0 +1,11 @@
+export const REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_PURPOSES = [
+  'requirement_area_owner',
+  'requirement_area_co_author',
+  'requirement_package_co_author',
+  'requirement_package_lead',
+  'requirements_specification_responsible',
+  'requirements_specification_co_author',
+] as const
+
+export type RequirementResponsibilityPersonVerificationPurpose =
+  (typeof REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_PURPOSES)[number]

--- a/lib/requirements/responsibility-person-verification.ts
+++ b/lib/requirements/responsibility-person-verification.ts
@@ -1,37 +1,114 @@
-import { isHsaId } from '@/lib/auth/hsa-id'
-import {
-  getRequirementResponsibilityPerson,
-  upsertRequirementResponsibilityPerson,
-} from '@/lib/dal/requirement-responsibility-people'
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto'
+import { z } from 'zod'
+import { getAuthConfig } from '@/lib/auth/config'
+import { HSA_ID_MAX_LENGTH, isHsaId } from '@/lib/auth/hsa-id'
+import { getRequirementResponsibilityPerson } from '@/lib/dal/requirement-responsibility-people'
 import { lookupHsaPerson } from '@/lib/hsa/person-lookup'
+import type { ActorContext } from '@/lib/requirements/auth'
 import { validationError } from '@/lib/requirements/errors'
 import {
   formatRequirementResponsibilityPersonName,
   type RequirementResponsibilityPersonRecord,
 } from '@/lib/requirements/responsibility-person'
+import {
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_PURPOSES,
+  type RequirementResponsibilityPersonVerificationPurpose,
+} from '@/lib/requirements/responsibility-person-verification-contract'
+
+export {
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_PURPOSES,
+  type RequirementResponsibilityPersonVerificationPurpose,
+} from '@/lib/requirements/responsibility-person-verification-contract'
 
 export type RequirementResponsibilityPersonVerificationMode =
   | 'refresh'
   | 'reuse_local'
-
-const DEFAULT_VERIFIED_PERSON_RETRY_DELAY_MS = 1000
 
 export interface RequirementResponsibilityPersonVerificationPayload
   extends RequirementResponsibilityPersonRecord {
   displayName: string
 }
 
-interface ResolveVerifiedPersonOptions {
-  retryDelayMs?: number
+export interface RequirementResponsibilityPersonVerificationEvidence {
+  evidence: string
+  expiresAt: string
+}
+
+interface VerificationActor {
+  hsaId: string | null
+  id: string | null
+  source: ActorContext['source']
+}
+
+interface CreateVerificationEvidenceInput {
+  actor: VerificationActor
+  person: RequirementResponsibilityPersonRecord
+  purpose: RequirementResponsibilityPersonVerificationPurpose
+  scopeId?: number
+}
+
+export interface ResolveVerifiedPersonInput {
+  actor: VerificationActor
+  hsaId: string
+  purpose: RequirementResponsibilityPersonVerificationPurpose
+  scopeId?: number
+}
+
+interface VerificationEvidenceOptions {
+  now?: Date
+  secret?: string
+  ttlSeconds?: number
 }
 
 interface QueryExecutor {
   query(sql: string, parameters?: unknown[]): Promise<unknown>
 }
 
-function sleep(ms: number): Promise<void> {
-  if (ms <= 0) return Promise.resolve()
-  return new Promise(resolve => setTimeout(resolve, ms))
+const EVIDENCE_VERSION = 1
+const DEFAULT_EVIDENCE_TTL_SECONDS = 300
+const MAX_EVIDENCE_TTL_SECONDS = 600
+export const REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH = 4096
+const EVIDENCE_KEY_CONTEXT = 'kravhantering:hsa-verification-evidence:v1'
+const ACTOR_FINGERPRINT_KEY_CONTEXT = 'kravhantering:hsa-actor-fingerprint:v1'
+const FINGERPRINT_KEY_CONTEXT = 'kravhantering:hsa-target-fingerprint:v1'
+
+const actorSchema = z
+  .object({
+    hsaId: z.string().max(HSA_ID_MAX_LENGTH).nullable(),
+    id: z.string().max(255).nullable(),
+    source: z.enum(['anonymous', 'oidc', 'mcp']),
+  })
+  .strict()
+
+const personSchema = z
+  .object({
+    email: z.string().max(320).nullable(),
+    givenName: z.string().max(255),
+    hasProtectedPersonalData: z.boolean(),
+    hsaId: z.string().max(HSA_ID_MAX_LENGTH).refine(isHsaId),
+    middleName: z.string().max(255).nullable(),
+    surname: z.string().max(255).nullable(),
+  })
+  .strict()
+
+const evidencePayloadSchema = z
+  .object({
+    actor: actorSchema,
+    expiresAt: z.number().int().positive(),
+    issuedAt: z.number().int().positive(),
+    person: personSchema,
+    purpose: z.enum(REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_PURPOSES),
+    scopeId: z.number().int().positive().nullable(),
+    version: z.literal(EVIDENCE_VERSION),
+  })
+  .strict()
+
+type EvidencePayload = z.infer<typeof evidencePayloadSchema>
+
+function verificationEvidenceError(): never {
+  throw validationError('Verification evidence is invalid or expired', {
+    reason: 'requirement_responsibility_person_evidence_invalid',
+  })
 }
 
 function assertValidNormalizedHsaId(normalizedHsaId: string): void {
@@ -39,6 +116,171 @@ function assertValidNormalizedHsaId(normalizedHsaId: string): void {
   throw validationError('Expected a valid HSA-id', {
     reason: 'invalid_hsa_id',
   })
+}
+
+function evidenceSecret(options: VerificationEvidenceOptions): string {
+  const secret = options.secret ?? getAuthConfig().cookiePassword
+  if (secret.length < 32) {
+    throw new Error(
+      'HSA verification evidence secret must be at least 32 characters',
+    )
+  }
+  return secret
+}
+
+function derivedKey(secret: string, context: string): Buffer {
+  return createHash('sha256')
+    .update(context)
+    .update('\0')
+    .update(secret)
+    .digest()
+}
+
+function signPayload(payloadSegment: string, secret: string): string {
+  return createHmac('sha256', derivedKey(secret, EVIDENCE_KEY_CONTEXT))
+    .update(payloadSegment)
+    .digest('base64url')
+}
+
+function signaturesMatch(actual: string, expected: string): boolean {
+  try {
+    const actualBuffer = Buffer.from(actual, 'base64url')
+    const expectedBuffer = Buffer.from(expected, 'base64url')
+    return (
+      actualBuffer.toString('base64url') === actual &&
+      actualBuffer.length === expectedBuffer.length &&
+      timingSafeEqual(actualBuffer, expectedBuffer)
+    )
+  } catch {
+    return false
+  }
+}
+
+function normalizedActor(actor: VerificationActor): VerificationActor {
+  return {
+    hsaId: actor.hsaId?.trim() || null,
+    id: actor.id?.trim() || null,
+    source: actor.source,
+  }
+}
+
+function sameActor(left: VerificationActor, right: VerificationActor): boolean {
+  return (
+    left.source === right.source &&
+    left.id === right.id &&
+    left.hsaId === right.hsaId
+  )
+}
+
+function parseEvidence(
+  evidence: string,
+  options: VerificationEvidenceOptions,
+): EvidencePayload {
+  if (
+    !evidence ||
+    evidence.length >
+      REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH
+  ) {
+    return verificationEvidenceError()
+  }
+  const segments = evidence.split('.')
+  if (segments.length !== 2) return verificationEvidenceError()
+  const [payloadSegment, signature] = segments
+  if (!payloadSegment || !signature) return verificationEvidenceError()
+
+  const expectedSignature = signPayload(payloadSegment, evidenceSecret(options))
+  if (!signaturesMatch(signature, expectedSignature)) {
+    return verificationEvidenceError()
+  }
+
+  try {
+    const decoded = Buffer.from(payloadSegment, 'base64url').toString('utf8')
+    if (Buffer.from(decoded).toString('base64url') !== payloadSegment) {
+      return verificationEvidenceError()
+    }
+    return evidencePayloadSchema.parse(JSON.parse(decoded))
+  } catch {
+    return verificationEvidenceError()
+  }
+}
+
+export function requirementResponsibilityPersonTargetFingerprint(
+  hsaId: string,
+  options: Pick<VerificationEvidenceOptions, 'secret'> = {},
+): string {
+  const normalizedHsaId = hsaId.trim()
+  assertValidNormalizedHsaId(normalizedHsaId)
+  const digest = createHmac(
+    'sha256',
+    derivedKey(evidenceSecret(options), FINGERPRINT_KEY_CONTEXT),
+  )
+    .update(normalizedHsaId.toLowerCase())
+    .digest('base64url')
+    .slice(0, 22)
+  return `hfp_${digest}`
+}
+
+export function requirementResponsibilityPersonActorFingerprint(
+  actor: VerificationActor,
+  options: Pick<VerificationEvidenceOptions, 'secret'> = {},
+): string {
+  const digest = createHmac(
+    'sha256',
+    derivedKey(evidenceSecret(options), ACTOR_FINGERPRINT_KEY_CONTEXT),
+  )
+    .update(JSON.stringify(normalizedActor(actor)))
+    .digest('base64url')
+    .slice(0, 22)
+  return `afp_${digest}`
+}
+
+export function createRequirementResponsibilityPersonVerificationEvidence(
+  input: CreateVerificationEvidenceInput,
+  options: VerificationEvidenceOptions = {},
+): RequirementResponsibilityPersonVerificationEvidence {
+  const now = options.now ?? new Date()
+  const issuedAt = Math.floor(now.getTime() / 1000)
+  const ttlSeconds = options.ttlSeconds ?? DEFAULT_EVIDENCE_TTL_SECONDS
+  if (
+    !Number.isInteger(ttlSeconds) ||
+    ttlSeconds < 1 ||
+    ttlSeconds > MAX_EVIDENCE_TTL_SECONDS
+  ) {
+    throw new Error('Invalid HSA verification evidence TTL')
+  }
+  const payload = evidencePayloadSchema.parse({
+    actor: normalizedActor(input.actor),
+    expiresAt: issuedAt + ttlSeconds,
+    issuedAt,
+    person: {
+      email: input.person.email,
+      givenName: input.person.givenName,
+      hasProtectedPersonalData: input.person.hasProtectedPersonalData ?? false,
+      hsaId: input.person.hsaId.trim(),
+      middleName: input.person.middleName,
+      surname: input.person.surname,
+    },
+    purpose: input.purpose,
+    scopeId: input.scopeId ?? null,
+    version: EVIDENCE_VERSION,
+  })
+  const payloadSegment = Buffer.from(JSON.stringify(payload)).toString(
+    'base64url',
+  )
+  const evidence = `${payloadSegment}.${signPayload(
+    payloadSegment,
+    evidenceSecret(options),
+  )}`
+  if (
+    evidence.length >
+    REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH
+  ) {
+    throw new Error('HSA verification evidence exceeds its size limit')
+  }
+  return {
+    evidence,
+    expiresAt: new Date(payload.expiresAt * 1000).toISOString(),
+  }
 }
 
 export function toRequirementResponsibilityPersonVerificationPayload(
@@ -67,49 +309,79 @@ export async function verifyRequirementResponsibilityPerson(
     if (existing) return existing
   }
 
-  const person = await lookupHsaPerson(normalizedHsaId)
-  await upsertRequirementResponsibilityPerson(db, person)
-  return person
+  return lookupHsaPerson(normalizedHsaId)
 }
 
-export async function resolveVerifiedRequirementResponsibilityPerson(
-  db: QueryExecutor,
-  hsaId: string,
-  options: ResolveVerifiedPersonOptions = {},
-): Promise<RequirementResponsibilityPersonRecord> {
-  const normalizedHsaId = hsaId.trim()
+export function requirementResponsibilityPersonFromActor(
+  actor: Pick<
+    ActorContext,
+    | 'displayName'
+    | 'email'
+    | 'familyName'
+    | 'givenName'
+    | 'hsaId'
+    | 'isAuthenticated'
+  >,
+): RequirementResponsibilityPersonRecord {
+  const hsaId = actor.hsaId?.trim() ?? ''
+  assertValidNormalizedHsaId(hsaId)
+  if (!actor.isAuthenticated) {
+    throw validationError('Authenticated actor is required', {
+      reason: 'missing_actor_hsa_id',
+    })
+  }
+  return {
+    email: actor.email?.trim() || null,
+    givenName: actor.givenName?.trim() || actor.displayName.trim() || hsaId,
+    hsaId,
+    middleName: null,
+    surname: actor.familyName?.trim() || null,
+  }
+}
+
+export function resolveVerifiedRequirementResponsibilityPerson(
+  evidence: string,
+  expected: ResolveVerifiedPersonInput,
+  options: VerificationEvidenceOptions = {},
+): RequirementResponsibilityPersonRecord {
+  const normalizedHsaId = expected.hsaId.trim()
   assertValidNormalizedHsaId(normalizedHsaId)
-  const firstRead = await getRequirementResponsibilityPerson(
-    db,
-    normalizedHsaId,
-  )
-  if (firstRead) return firstRead
-
-  await sleep(options.retryDelayMs ?? DEFAULT_VERIFIED_PERSON_RETRY_DELAY_MS)
-
-  const secondRead = await getRequirementResponsibilityPerson(
-    db,
-    normalizedHsaId,
-  )
-  if (secondRead) return secondRead
-
-  throw validationError(
-    'HSA-id is not verified. Verify that the HSA-id is valid and that the requirement responsibility person could be fetched.',
-    {
-      httpStatus: 422,
-      reason: 'requirement_responsibility_person_not_verified',
-    },
-  )
+  const payload = parseEvidence(evidence, options)
+  const now = Math.floor((options.now ?? new Date()).getTime() / 1000)
+  const expectedScopeId = expected.scopeId ?? null
+  if (
+    payload.expiresAt <= now ||
+    payload.issuedAt > now + 30 ||
+    payload.expiresAt - payload.issuedAt > MAX_EVIDENCE_TTL_SECONDS ||
+    !sameActor(payload.actor, normalizedActor(expected.actor)) ||
+    payload.person.hsaId !== normalizedHsaId ||
+    payload.purpose !== expected.purpose ||
+    payload.scopeId !== expectedScopeId
+  ) {
+    return verificationEvidenceError()
+  }
+  return payload.person
 }
 
-export async function resolveVerifiedRequirementResponsibilityPeople(
-  db: QueryExecutor,
-  hsaIds: string[],
-  options: ResolveVerifiedPersonOptions = {},
-): Promise<RequirementResponsibilityPersonRecord[]> {
-  return Promise.all(
-    hsaIds.map(hsaId =>
-      resolveVerifiedRequirementResponsibilityPerson(db, hsaId, options),
-    ),
-  )
+export function resolveVerifiedRequirementResponsibilityPeople(
+  evidence: string[],
+  expected: Omit<ResolveVerifiedPersonInput, 'hsaId'> & { hsaIds: string[] },
+  options: VerificationEvidenceOptions = {},
+): RequirementResponsibilityPersonRecord[] {
+  const expectedHsaIds = new Set(expected.hsaIds.map(hsaId => hsaId.trim()))
+  const people = evidence.map(item => {
+    const payload = parseEvidence(item, options)
+    if (!expectedHsaIds.has(payload.person.hsaId)) {
+      return verificationEvidenceError()
+    }
+    return resolveVerifiedRequirementResponsibilityPerson(
+      item,
+      { ...expected, hsaId: payload.person.hsaId },
+      options,
+    )
+  })
+  if (new Set(people.map(person => person.hsaId)).size !== people.length) {
+    return verificationEvidenceError()
+  }
+  return people
 }

--- a/lib/requirements/responsibility-person.ts
+++ b/lib/requirements/responsibility-person.ts
@@ -30,3 +30,15 @@ export function formatRequirementResponsibilityPersonName(
 
   return parts.length > 0 ? parts.join(' ') : person.hsaId
 }
+
+export function verifiedPeopleCoverAddedAssignments(
+  addedHsaIds: readonly string[],
+  people: readonly RequirementResponsibilityPersonRecord[],
+): boolean {
+  const verifiedHsaIds = new Set(
+    people.map(person => person.hsaId.trim().toLowerCase()),
+  )
+  return addedHsaIds.every(hsaId =>
+    verifiedHsaIds.has(hsaId.trim().toLowerCase()),
+  )
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -21,6 +21,7 @@
     "hsaVerifyEmail": "Email",
     "hsaVerifyError": "Could not fetch person details.",
     "hsaVerifyName": "Name",
+    "hsaProtectedPersonGuidance": "Protected personal data: use this identity only for the authorized assignment and minimize further disclosure. Contact your regional privacy, security, or HR function if you are unsure how to proceed.",
     "hsaPrefixCurrent": "Current prefix",
     "hsaPrefixLabel": "HSA-id prefix",
     "hsaPrefixLoadError": "Could not load HSA-id prefixes.",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -21,6 +21,7 @@
     "hsaVerifyEmail": "E-post",
     "hsaVerifyError": "Kunde inte hämta personuppgifter.",
     "hsaVerifyName": "Namn",
+    "hsaProtectedPersonGuidance": "Skyddade personuppgifter: använd identiteten endast för det behöriga uppdraget och begränsa fortsatt spridning. Kontakta regionens dataskydds-, säkerhets- eller HR-funktion om du är osäker på hur du ska fortsätta.",
     "hsaPrefixCurrent": "Aktuellt prefix",
     "hsaPrefixLabel": "HSA-id-prefix",
     "hsaPrefixLoadError": "Kunde inte läsa HSA-id-prefix.",

--- a/tests/integration/authorization/02-requirement-area-owner.spec.ts
+++ b/tests/integration/authorization/02-requirement-area-owner.spec.ts
@@ -11,6 +11,7 @@ import {
   ROLE_STORAGE_STATE,
   referenceManualCases,
   seedAuthorizationResponsibilityPeople,
+  verifyResponsibilityPerson,
 } from './authorization-test-helpers'
 
 let fixture: AuthorizationFixture
@@ -198,14 +199,26 @@ test('AUTHZ-02/AUTH-10/AUTH-11/ADMIN-13: requirement area owners can manage thei
       'area-owner action log read',
     )
   } finally {
-    await areaOwner
-      .put(`/api/requirement-areas/${fixture.areaId}/co-authors`, {
-        data: {
-          coAuthorHsaIds: originalCoAuthors,
-          verificationEvidence: [],
-        },
-      })
-      .catch(() => undefined)
-    await areaOwner.dispose()
+    try {
+      const verificationEvidence = await Promise.all(
+        originalCoAuthors.map(hsaId =>
+          verifyResponsibilityPerson(areaOwner, {
+            hsaId,
+            purpose: 'requirement_area_co_author',
+            scopeId: fixture.areaId,
+          }),
+        ),
+      )
+      await areaOwner
+        .put(`/api/requirement-areas/${fixture.areaId}/co-authors`, {
+          data: {
+            coAuthorHsaIds: originalCoAuthors,
+            verificationEvidence,
+          },
+        })
+        .catch(() => undefined)
+    } finally {
+      await areaOwner.dispose()
+    }
   }
 })

--- a/tests/integration/authorization/02-requirement-area-owner.spec.ts
+++ b/tests/integration/authorization/02-requirement-area-owner.spec.ts
@@ -200,7 +200,10 @@ test('AUTHZ-02/AUTH-10/AUTH-11/ADMIN-13: requirement area owners can manage thei
   } finally {
     await areaOwner
       .put(`/api/requirement-areas/${fixture.areaId}/co-authors`, {
-        data: { coAuthorHsaIds: originalCoAuthors },
+        data: {
+          coAuthorHsaIds: originalCoAuthors,
+          verificationEvidence: [],
+        },
       })
       .catch(() => undefined)
     await areaOwner.dispose()

--- a/tests/integration/authorization/03-requirement-area-coauthor.spec.ts
+++ b/tests/integration/authorization/03-requirement-area-coauthor.spec.ts
@@ -5,6 +5,7 @@ import {
   createAuthorizationFixture,
   type DataSubjectExportResponse,
   expectStatus,
+  expectStatusCode,
   HSA,
   newRoleContext,
   ROLE_STORAGE_STATE,
@@ -167,7 +168,7 @@ test('AUTHZ-03/AUTH-10/AUTH-11: requirement area co-authors cannot delegate area
       403,
       'area co-author area metadata update',
     )
-    await expectStatus(
+    await expectStatusCode(
       await areaCoauthor.put(
         `/api/requirement-areas/${fixture.areaId}/co-authors`,
         {
@@ -179,6 +180,7 @@ test('AUTHZ-03/AUTH-10/AUTH-11: requirement area co-authors cannot delegate area
         },
       ),
       403,
+      'forbidden',
       'area co-author co-author update',
     )
   } finally {

--- a/tests/integration/authorization/03-requirement-area-coauthor.spec.ts
+++ b/tests/integration/authorization/03-requirement-area-coauthor.spec.ts
@@ -171,7 +171,10 @@ test('AUTHZ-03/AUTH-10/AUTH-11: requirement area co-authors cannot delegate area
       await areaCoauthor.put(
         `/api/requirement-areas/${fixture.areaId}/co-authors`,
         {
-          data: { coAuthorHsaIds: [HSA.areaCoauthor] },
+          data: {
+            coAuthorHsaIds: [HSA.areaCoauthor],
+            verificationEvidence: [],
+          },
           timeout: 30_000,
         },
       ),

--- a/tests/integration/authorization/04-specification-responsible.spec.ts
+++ b/tests/integration/authorization/04-specification-responsible.spec.ts
@@ -11,6 +11,7 @@ import {
   referenceManualCases,
   type SpecificationResponse,
   seedAuthorizationResponsibilityPeople,
+  verifyResponsibilityPerson,
 } from './authorization-test-helpers'
 
 let fixture: AuthorizationFixture
@@ -185,17 +186,29 @@ test('AUTHZ-04/AUTH-10/AUTH-11: specification responsible users can manage assig
       'specification responsible privacy preview',
     )
   } finally {
-    await specificationResponsible
-      .put(
-        `/api/requirements-specifications/${fixture.specificationId}/co-authors`,
-        {
-          data: {
-            coAuthorHsaIds: originalCoAuthors,
-            verificationEvidence: [],
-          },
-        },
+    try {
+      const verificationEvidence = await Promise.all(
+        originalCoAuthors.map(hsaId =>
+          verifyResponsibilityPerson(specificationResponsible, {
+            hsaId,
+            purpose: 'requirements_specification_co_author',
+            scopeId: fixture.specificationId,
+          }),
+        ),
       )
-      .catch(() => undefined)
-    await specificationResponsible.dispose()
+      await specificationResponsible
+        .put(
+          `/api/requirements-specifications/${fixture.specificationId}/co-authors`,
+          {
+            data: {
+              coAuthorHsaIds: originalCoAuthors,
+              verificationEvidence,
+            },
+          },
+        )
+        .catch(() => undefined)
+    } finally {
+      await specificationResponsible.dispose()
+    }
   }
 })

--- a/tests/integration/authorization/04-specification-responsible.spec.ts
+++ b/tests/integration/authorization/04-specification-responsible.spec.ts
@@ -189,7 +189,10 @@ test('AUTHZ-04/AUTH-10/AUTH-11: specification responsible users can manage assig
       .put(
         `/api/requirements-specifications/${fixture.specificationId}/co-authors`,
         {
-          data: { coAuthorHsaIds: originalCoAuthors },
+          data: {
+            coAuthorHsaIds: originalCoAuthors,
+            verificationEvidence: [],
+          },
         },
       )
       .catch(() => undefined)

--- a/tests/integration/authorization/05-specification-coauthor.spec.ts
+++ b/tests/integration/authorization/05-specification-coauthor.spec.ts
@@ -3,7 +3,7 @@ import {
   type AuthorizationFixture,
   createAuthorizationFixture,
   expectOk,
-  expectStatus,
+  expectStatusCode,
   HSA,
   newRoleContext,
   ROLE_STORAGE_STATE,
@@ -82,7 +82,7 @@ test('AUTHZ-05/AUTH-10/AUTH-11: specification co-authors can edit content but no
       ),
       'specification co-author content update',
     )
-    await expectStatus(
+    await expectStatusCode(
       await specificationCoauthor.put(
         `/api/requirements-specifications/${fixture.specificationId}/co-authors`,
         {
@@ -93,9 +93,10 @@ test('AUTHZ-05/AUTH-10/AUTH-11: specification co-authors can edit content but no
         },
       ),
       403,
+      'forbidden',
       'specification co-author co-author update',
     )
-    await expectStatus(
+    await expectStatusCode(
       await specificationCoauthor.put(
         `/api/requirements-specifications/${fixture.specificationId}/responsible`,
         {
@@ -106,6 +107,7 @@ test('AUTHZ-05/AUTH-10/AUTH-11: specification co-authors can edit content but no
         },
       ),
       403,
+      'forbidden',
       'specification co-author responsible update',
     )
   } finally {

--- a/tests/integration/authorization/05-specification-coauthor.spec.ts
+++ b/tests/integration/authorization/05-specification-coauthor.spec.ts
@@ -86,7 +86,10 @@ test('AUTHZ-05/AUTH-10/AUTH-11: specification co-authors can edit content but no
       await specificationCoauthor.put(
         `/api/requirements-specifications/${fixture.specificationId}/co-authors`,
         {
-          data: { coAuthorHsaIds: [HSA.areaCoauthor] },
+          data: {
+            coAuthorHsaIds: [HSA.areaCoauthor],
+            verificationEvidence: [],
+          },
         },
       ),
       403,
@@ -96,7 +99,10 @@ test('AUTHZ-05/AUTH-10/AUTH-11: specification co-authors can edit content but no
       await specificationCoauthor.put(
         `/api/requirements-specifications/${fixture.specificationId}/responsible`,
         {
-          data: { responsibleHsaId: HSA.specificationResponsible },
+          data: {
+            responsibleHsaId: HSA.specificationResponsible,
+            verificationEvidence: 'permission-check-evidence',
+          },
         },
       ),
       403,

--- a/tests/integration/authorization/06-requirement-package-lead.spec.ts
+++ b/tests/integration/authorization/06-requirement-package-lead.spec.ts
@@ -188,6 +188,7 @@ test('AUTHZ-06/AUTH-10/AUTH-11: requirement package leads can update packages bu
         {
           data: {
             coAuthorHsaIds: [HSA.packageCoauthor],
+            verificationEvidence: [],
           },
         },
       ),
@@ -209,6 +210,7 @@ test('AUTHZ-06/AUTH-10/AUTH-11: requirement package leads can update packages bu
           {
             data: {
               coAuthorHsaIds: originalCoAuthors,
+              verificationEvidence: [],
             },
           },
         ),

--- a/tests/integration/authorization/07-requirement-package-coauthor.spec.ts
+++ b/tests/integration/authorization/07-requirement-package-coauthor.spec.ts
@@ -5,6 +5,7 @@ import {
   type DataSubjectExportResponse,
   expectOk,
   expectStatus,
+  expectStatusCode,
   HSA,
   newRoleContext,
   type RequirementPackageResponse,
@@ -80,7 +81,7 @@ test('AUTHZ-07/AUTH-10/AUTH-11: requirement package co-authors are exported but 
       403,
       'package co-author update',
     )
-    await expectStatus(
+    await expectStatusCode(
       await packageCoauthor.put(
         `/api/requirement-packages/${fixture.packageId}/co-authors`,
         {
@@ -91,6 +92,7 @@ test('AUTHZ-07/AUTH-10/AUTH-11: requirement package co-authors are exported but 
         },
       ),
       403,
+      'forbidden',
       'package co-author co-author management',
     )
 

--- a/tests/integration/authorization/07-requirement-package-coauthor.spec.ts
+++ b/tests/integration/authorization/07-requirement-package-coauthor.spec.ts
@@ -86,6 +86,7 @@ test('AUTHZ-07/AUTH-10/AUTH-11: requirement package co-authors are exported but 
         {
           data: {
             coAuthorHsaIds: [],
+            verificationEvidence: [],
           },
         },
       ),

--- a/tests/integration/authorization/authorization-test-helpers.ts
+++ b/tests/integration/authorization/authorization-test-helpers.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import {
   type APIRequestContext,
   type APIResponse,
+  expect,
   request as playwrightRequest,
   type TestInfo,
 } from '@playwright/test'
@@ -381,7 +382,18 @@ export async function expectOk(
   return expectApiResponseOk(response, label)
 }
 
-async function verifyResponsibilityPerson(
+export async function expectStatusCode(
+  response: APIResponse,
+  status: number,
+  code: string,
+  label: string,
+): Promise<APIResponse> {
+  await expectStatus(response, status, label)
+  await expect(response.json()).resolves.toMatchObject({ code })
+  return response
+}
+
+export async function verifyResponsibilityPerson(
   request: APIRequestContext,
   input: {
     hsaId: string

--- a/tests/integration/authorization/authorization-test-helpers.ts
+++ b/tests/integration/authorization/authorization-test-helpers.ts
@@ -395,8 +395,8 @@ async function verifyResponsibilityPerson(
       | 'requirements_specification_responsible'
     scopeId?: number
   },
-): Promise<void> {
-  await expectOk(
+): Promise<string> {
+  const response = await expectOk(
     await request.post('/api/requirement-responsibility-people/verify', {
       data: {
         hsaId: input.hsaId,
@@ -407,6 +407,11 @@ async function verifyResponsibilityPerson(
     }),
     `verify ${input.purpose} ${input.hsaId}`,
   )
+  const payload = (await response.json()) as { evidence?: unknown }
+  if (typeof payload.evidence !== 'string' || !payload.evidence) {
+    throw new Error(`Verification did not return evidence for ${input.purpose}`)
+  }
+  return payload.evidence
 }
 
 function stamp(): string {
@@ -430,7 +435,7 @@ export async function createAuthorizationFixture(
   const packageName = `Behörighetspaket ${uniqueStamp}`
 
   try {
-    await verifyResponsibilityPerson(admin, {
+    const areaOwnerEvidence = await verifyResponsibilityPerson(admin, {
       hsaId: HSA.areaOwner,
       purpose: 'requirement_area_owner',
     })
@@ -441,27 +446,27 @@ export async function createAuthorizationFixture(
         name: `Behörighetsyta ${uniqueStamp}`,
         ownerHsaId: HSA.areaOwner,
         prefix: areaPrefix,
+        verificationEvidence: areaOwnerEvidence,
       },
     })
     await expectStatus(areaResponse, 201, 'create requirement area fixture')
     const area = (await areaResponse.json()) as RequirementAreaResponse
 
-    await verifyResponsibilityPerson(admin, {
+    const areaCoAuthorEvidence = await verifyResponsibilityPerson(admin, {
       hsaId: HSA.areaCoauthor,
       purpose: 'requirement_area_co_author',
       scopeId: area.id,
     })
     await expectOk(
       await admin.put(`/api/requirement-areas/${area.id}/co-authors`, {
-        data: { coAuthorHsaIds: [HSA.areaCoauthor] },
+        data: {
+          coAuthorHsaIds: [HSA.areaCoauthor],
+          verificationEvidence: [areaCoAuthorEvidence],
+        },
       }),
       'assign requirement area co-author',
     )
 
-    await verifyResponsibilityPerson(specificationResponsible, {
-      hsaId: HSA.specificationResponsible,
-      purpose: 'requirements_specification_responsible',
-    })
     const specificationResponse = await specificationResponsible.post(
       '/api/requirements-specifications',
       {
@@ -483,33 +488,27 @@ export async function createAuthorizationFixture(
     const specification =
       (await specificationResponse.json()) as SpecificationResponse
 
-    await verifyResponsibilityPerson(specificationResponsible, {
-      hsaId: HSA.specificationCoauthor,
-      purpose: 'requirements_specification_co_author',
-      scopeId: specification.id,
-    })
+    const specificationCoAuthorEvidence = await verifyResponsibilityPerson(
+      specificationResponsible,
+      {
+        hsaId: HSA.specificationCoauthor,
+        purpose: 'requirements_specification_co_author',
+        scopeId: specification.id,
+      },
+    )
     await expectOk(
       await specificationResponsible.put(
         `/api/requirements-specifications/${specification.id}/co-authors`,
         {
-          data: { coAuthorHsaIds: [HSA.specificationCoauthor] },
+          data: {
+            coAuthorHsaIds: [HSA.specificationCoauthor],
+            verificationEvidence: [specificationCoAuthorEvidence],
+          },
         },
       ),
       'assign specification co-author',
     )
 
-    await verifyResponsibilityPerson(admin, {
-      hsaId: HSA.admin,
-      purpose: 'requirement_package_lead',
-    })
-    await verifyResponsibilityPerson(admin, {
-      hsaId: HSA.packageLead,
-      purpose: 'requirement_package_lead',
-    })
-    await verifyResponsibilityPerson(admin, {
-      hsaId: HSA.packageCoauthor,
-      purpose: 'requirement_package_co_author',
-    })
     const packageResponse = await admin.post('/api/requirement-packages', {
       data: {
         name: packageName,
@@ -519,20 +518,32 @@ export async function createAuthorizationFixture(
     await expectStatus(packageResponse, 201, 'create package fixture')
     const requirementPackage =
       (await packageResponse.json()) as RequirementPackageResponse
+    const packageLeadEvidence = await verifyResponsibilityPerson(admin, {
+      hsaId: HSA.packageLead,
+      purpose: 'requirement_package_lead',
+      scopeId: requirementPackage.id,
+    })
     await expectOk(
       await admin.put(`/api/requirement-packages/${requirementPackage.id}`, {
         data: {
           leadHsaId: HSA.packageLead,
+          verificationEvidence: packageLeadEvidence,
         },
       }),
       'assign package lead fixture',
     )
+    const packageCoAuthorEvidence = await verifyResponsibilityPerson(admin, {
+      hsaId: HSA.packageCoauthor,
+      purpose: 'requirement_package_co_author',
+      scopeId: requirementPackage.id,
+    })
     await expectOk(
       await admin.put(
         `/api/requirement-packages/${requirementPackage.id}/co-authors`,
         {
           data: {
             coAuthorHsaIds: [HSA.packageCoauthor],
+            verificationEvidence: [packageCoAuthorEvidence],
           },
         },
       ),

--- a/tests/integration/requirement-packages/list.spec.ts
+++ b/tests/integration/requirement-packages/list.spec.ts
@@ -21,6 +21,7 @@ const deterministicPackageLeadVerification = {
   displayName: 'Ada Admin',
   email: 'ada.admin@example.test',
   givenName: 'Ada',
+  hasProtectedPersonalData: true,
   hsaId: 'SE5560000001-admin1',
   middleName: null,
   surname: 'Admin',
@@ -61,6 +62,8 @@ for (const viewport of viewports) {
           ) {
             await route.fulfill({
               body: JSON.stringify({
+                evidence: 'playwright-signed-evidence',
+                expiresAt: '2099-01-01T00:00:00.000Z',
                 person: deterministicPackageLeadVerification,
               }),
               contentType: 'application/json',
@@ -308,6 +311,9 @@ for (const viewport of viewports) {
         await expect(
           changeDialog.getByText('Ada Admin (ada.admin@example.test)'),
         ).toBeVisible()
+        await expect(
+          changeDialog.getByText(/Skyddade personuppgifter:/),
+        ).toContainText(/endast för det behöriga uppdraget/)
         expect(hsaVerifyRequests).toContainEqual(
           expect.objectContaining({
             hsaId: deterministicPackageLeadVerification.hsaId,

--- a/tests/unit/co-authors-management-modal.test.tsx
+++ b/tests/unit/co-authors-management-modal.test.tsx
@@ -138,10 +138,13 @@ describe('CoAuthorsManagementModal', () => {
       if (url === '/api/requirement-responsibility-people/verify') {
         return Promise.resolve(
           okJson({
+            evidence: 'signed-evidence',
+            expiresAt: '2026-08-12T10:05:00.000Z',
             person: {
               displayName: 'Cora CoAuthor',
               email: 'cora.coauthor@example.test',
               givenName: 'Cora',
+              hasProtectedPersonalData: false,
               hsaId: 'SE5560000001-coa1',
               middleName: null,
               surname: 'CoAuthor',
@@ -196,6 +199,7 @@ describe('CoAuthorsManagementModal', () => {
     ) as [string, RequestInit]
     expect(JSON.parse((putCall[1].body as string) ?? '{}')).toEqual({
       coAuthorHsaIds: ['SE5560000001-coa1'],
+      verificationEvidence: ['signed-evidence'],
     })
     expect(await screen.findByText('Cora CoAuthor')).toBeInTheDocument()
     expect(
@@ -228,10 +232,13 @@ describe('CoAuthorsManagementModal', () => {
       if (url === '/api/requirement-responsibility-people/verify') {
         return Promise.resolve(
           okJson({
+            evidence: 'signed-evidence',
+            expiresAt: '2026-08-12T10:05:00.000Z',
             person: {
               displayName: 'Cora CoAuthor',
               email: 'cora.coauthor@example.test',
               givenName: 'Cora',
+              hasProtectedPersonalData: false,
               hsaId: 'SE5560000001-coa1',
               middleName: null,
               surname: 'CoAuthor',
@@ -378,6 +385,7 @@ describe('CoAuthorsManagementModal', () => {
     ) as [string, RequestInit]
     expect(JSON.parse((putCall[1].body as string) ?? '{}')).toEqual({
       coAuthorHsaIds: [],
+      verificationEvidence: [],
     })
   })
 
@@ -434,6 +442,7 @@ describe('CoAuthorsManagementModal', () => {
     ) as [string, RequestInit]
     expect(JSON.parse((putCall[1].body as string) ?? '{}')).toEqual({
       coAuthorHsaIds: [],
+      verificationEvidence: [],
     })
   })
 })

--- a/tests/unit/hsa-person-change-modal.test.tsx
+++ b/tests/unit/hsa-person-change-modal.test.tsx
@@ -127,10 +127,13 @@ describe('HsaPersonChangeModal', () => {
       const url = String(input)
       if (url === '/api/hsa-id-prefixes') return okJson(prefixPayload())
       return okJson({
+        evidence: 'signed-evidence',
+        expiresAt: '2026-08-12T10:05:00.000Z',
         person: {
           displayName: 'Nora New',
           email: 'nora.new@example.test',
           givenName: 'Nora',
+          hasProtectedPersonalData: false,
           hsaId: 'SE5560000001-new1',
           middleName: null,
           surname: 'New',
@@ -176,7 +179,24 @@ describe('HsaPersonChangeModal', () => {
   it('resets on reopen, reports submit errors, and closes on cancel', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => okJson(prefixPayload())),
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input) === '/api/hsa-id-prefixes') {
+          return okJson(prefixPayload())
+        }
+        return okJson({
+          evidence: 'signed-evidence',
+          expiresAt: '2026-08-12T10:05:00.000Z',
+          person: {
+            displayName: 'Nora New',
+            email: 'nora.new@example.test',
+            givenName: 'Nora',
+            hasProtectedPersonalData: false,
+            hsaId: 'SE5560000001-new1',
+            middleName: null,
+            surname: 'New',
+          },
+        })
+      }),
     )
     const onSubmit = vi.fn(async () => ({
       error: 'Assignment failed',
@@ -204,7 +224,11 @@ describe('HsaPersonChangeModal', () => {
     const input = within(dialog).getByRole('textbox', { name: /New HSA-id/ })
     await waitFor(() => expect(input).toBeEnabled())
     fireEvent.change(input, { target: { value: 'new1' } })
-    fireEvent.click(within(dialog).getByRole('button', { name: 'Change' }))
+    const submitButton = within(dialog).getByRole('button', { name: 'Change' })
+    expect(submitButton).toBeDisabled()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Fetch' }))
+    await waitFor(() => expect(submitButton).toBeEnabled())
+    fireEvent.click(submitButton)
     await waitFor(() =>
       expect(within(dialog).getByRole('alert')).toHaveTextContent(
         'Assignment failed',

--- a/tests/unit/hsa-person-change-modal.test.tsx
+++ b/tests/unit/hsa-person-change-modal.test.tsx
@@ -63,6 +63,22 @@ function prefixPayload(prefix = 'SE5560000001') {
   }
 }
 
+function verifiedPersonResponse() {
+  return {
+    evidence: 'signed-evidence',
+    expiresAt: new Date(Date.now() + 300_000).toISOString(),
+    person: {
+      displayName: 'Nora New',
+      email: 'nora.new@example.test',
+      givenName: 'Nora',
+      hasProtectedPersonalData: false,
+      hsaId: 'SE5560000001-new1',
+      middleName: null,
+      surname: 'New',
+    },
+  }
+}
+
 describe('HsaPersonChangeModal', () => {
   afterEach(() => {
     vi.clearAllMocks()
@@ -126,19 +142,7 @@ describe('HsaPersonChangeModal', () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
       if (url === '/api/hsa-id-prefixes') return okJson(prefixPayload())
-      return okJson({
-        evidence: 'signed-evidence',
-        expiresAt: '2026-08-12T10:05:00.000Z',
-        person: {
-          displayName: 'Nora New',
-          email: 'nora.new@example.test',
-          givenName: 'Nora',
-          hasProtectedPersonalData: false,
-          hsaId: 'SE5560000001-new1',
-          middleName: null,
-          surname: 'New',
-        },
-      })
+      return okJson(verifiedPersonResponse())
     })
     vi.stubGlobal('fetch', fetchMock)
     const onSubmit = vi.fn(async () => ({ ok: true as const }))
@@ -183,19 +187,7 @@ describe('HsaPersonChangeModal', () => {
         if (String(input) === '/api/hsa-id-prefixes') {
           return okJson(prefixPayload())
         }
-        return okJson({
-          evidence: 'signed-evidence',
-          expiresAt: '2026-08-12T10:05:00.000Z',
-          person: {
-            displayName: 'Nora New',
-            email: 'nora.new@example.test',
-            givenName: 'Nora',
-            hasProtectedPersonalData: false,
-            hsaId: 'SE5560000001-new1',
-            middleName: null,
-            surname: 'New',
-          },
-        })
+        return okJson(verifiedPersonResponse())
       }),
     )
     const onSubmit = vi.fn(async () => ({

--- a/tests/unit/hsa-person-verify-field.test.tsx
+++ b/tests/unit/hsa-person-verify-field.test.tsx
@@ -23,6 +23,10 @@ function okJson(body: unknown) {
   })
 }
 
+function futureExpiresAt(): string {
+  return new Date(Date.now() + 300_000).toISOString()
+}
+
 function ControlledHsaPersonVerifyField() {
   const [hsaId, setHsaId] = useState('SE5560000001-old1')
   return (
@@ -149,7 +153,7 @@ describe('HsaPersonVerifyField', () => {
           new Response(
             JSON.stringify({
               evidence: 'signed-evidence',
-              expiresAt: '2026-08-12T10:05:00.000Z',
+              expiresAt: futureExpiresAt(),
               person: {
                 displayName: 'Nora New',
                 email: null,
@@ -253,7 +257,7 @@ describe('HsaPersonVerifyField', () => {
           new Response(
             JSON.stringify({
               evidence: 'signed-evidence',
-              expiresAt: '2026-08-12T10:05:00.000Z',
+              expiresAt: futureExpiresAt(),
               person: {
                 displayName: 'Nora New',
                 email: 'nora.new@example.test',
@@ -418,7 +422,7 @@ describe('HsaPersonVerifyField', () => {
         new Response(
           JSON.stringify({
             evidence: 'signed-evidence',
-            expiresAt: '2026-08-12T10:05:00.000Z',
+            expiresAt: futureExpiresAt(),
             person: {
               displayName: 'Ada Admin',
               email: 'ada.admin@example.test',
@@ -518,7 +522,7 @@ describe('HsaPersonVerifyField', () => {
       vi.fn(async () =>
         okJson({
           evidence: 'signed-evidence',
-          expiresAt: '2026-08-12T10:05:00.000Z',
+          expiresAt: futureExpiresAt(),
           person: {
             displayName: 'Protected Person',
             email: 'protected@example.test',

--- a/tests/unit/hsa-person-verify-field.test.tsx
+++ b/tests/unit/hsa-person-verify-field.test.tsx
@@ -148,10 +148,13 @@ describe('HsaPersonVerifyField', () => {
         return Promise.resolve(
           new Response(
             JSON.stringify({
+              evidence: 'signed-evidence',
+              expiresAt: '2026-08-12T10:05:00.000Z',
               person: {
                 displayName: 'Nora New',
                 email: null,
                 givenName: 'Nora',
+                hasProtectedPersonalData: false,
                 hsaId: 'SE5560000001-new1',
                 middleName: null,
                 surname: 'New',
@@ -249,10 +252,13 @@ describe('HsaPersonVerifyField', () => {
         return Promise.resolve(
           new Response(
             JSON.stringify({
+              evidence: 'signed-evidence',
+              expiresAt: '2026-08-12T10:05:00.000Z',
               person: {
                 displayName: 'Nora New',
                 email: 'nora.new@example.test',
                 givenName: 'Nora',
+                hasProtectedPersonalData: false,
                 hsaId: 'SE5560000001-new1',
                 middleName: null,
                 surname: 'New',
@@ -411,10 +417,13 @@ describe('HsaPersonVerifyField', () => {
       async () =>
         new Response(
           JSON.stringify({
+            evidence: 'signed-evidence',
+            expiresAt: '2026-08-12T10:05:00.000Z',
             person: {
               displayName: 'Ada Admin',
               email: 'ada.admin@example.test',
               givenName: 'Ada',
+              hasProtectedPersonalData: false,
               hsaId: 'SE5560000001-admin1',
               middleName: null,
               surname: 'Admin',
@@ -501,6 +510,53 @@ describe('HsaPersonVerifyField', () => {
     expect(screen.queryByText('Unavailable')).not.toBeInTheDocument()
     expect(screen.queryByText('Name')).not.toBeInTheDocument()
     expect(screen.queryByText('Email')).not.toBeInTheDocument()
+  })
+
+  it('shows protection guidance only after a protected person is verified', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        okJson({
+          evidence: 'signed-evidence',
+          expiresAt: '2026-08-12T10:05:00.000Z',
+          person: {
+            displayName: 'Protected Person',
+            email: 'protected@example.test',
+            givenName: 'Protected',
+            hasProtectedPersonalData: true,
+            hsaId: 'SE5560000001-protected1',
+            middleName: null,
+            surname: 'Person',
+          },
+        }),
+      ),
+    )
+
+    render(
+      <HsaPersonVerifyField
+        emailLabel="Email"
+        errorFallback="Could not verify"
+        fetchingLabel="Fetching"
+        fetchLabel="Fetch"
+        hsaId="SE5560000001-protected1"
+        inputClassName="input"
+        inputId="hsa-id"
+        nameLabel="Name"
+        onHsaIdChange={vi.fn()}
+        purpose="requirements_specification_responsible"
+        readOnly
+        unavailableText="Unavailable"
+      />,
+    )
+
+    expect(
+      screen.queryByText('common.hsaProtectedPersonGuidance'),
+    ).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Fetch' }))
+    expect(
+      await screen.findByText('common.hsaProtectedPersonGuidance'),
+    ).toHaveAttribute('role', 'status')
+    expect(screen.getByDisplayValue('Protected Person')).toBeVisible()
   })
 
   it('uses the compact HSA-id layout only when requested', async () => {

--- a/tests/unit/requirement-area-route-edge-cases.test.ts
+++ b/tests/unit/requirement-area-route-edge-cases.test.ts
@@ -53,6 +53,7 @@ vi.mock('@/lib/admin/privileged-audit', () => ({
 }))
 
 vi.mock('@/lib/requirements/responsibility-person-verification', () => ({
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH: 4096,
   resolveVerifiedRequirementResponsibilityPeople: state.resolvePeople,
   resolveVerifiedRequirementResponsibilityPerson: state.resolvePerson,
 }))
@@ -87,8 +88,8 @@ describe('requirement-area routes', () => {
     state.getAreaById.mockResolvedValue({ id: 7 })
     state.listRequirementAreaCoAuthors.mockResolvedValue([{ hsaId: 'author' }])
     state.replaceRequirementAreaCoAuthors.mockResolvedValue({ areaId: 7 })
-    state.resolvePeople.mockResolvedValue([])
-    state.resolvePerson.mockResolvedValue({ hsaId: 'SE5560000001-next' })
+    state.resolvePeople.mockReturnValue([])
+    state.resolvePerson.mockReturnValue({ hsaId: 'SE5560000001-next' })
     state.updateAreaWithOwnerCheck.mockResolvedValue({ id: 7 })
   })
 
@@ -114,7 +115,10 @@ describe('requirement-area routes', () => {
 
   it('covers co-author PUT validation, authorization, and outcomes', async () => {
     const path = '/api/requirement-areas/7/co-authors'
-    const body = { coAuthorHsaIds: ['SE5560000001-author'] }
+    const body = {
+      coAuthorHsaIds: ['SE5560000001-author'],
+      verificationEvidence: ['verified-author'],
+    }
     expect(
       (await callMutation(areaCoAuthorsPut, path, 'PUT', { body, id: '7' }))
         .status,
@@ -235,20 +239,26 @@ describe('requirement-area routes', () => {
   it('executes owner resolution and observes policy outcomes', async () => {
     state.updateAreaWithOwnerCheck.mockImplementationOnce(
       async (_db: unknown, _id: number, data: Record<string, unknown>) => {
-        const resolveOwnerPerson = data.resolveOwnerPerson as (
-          executor: unknown,
-          hsaId: string,
-        ) => Promise<unknown>
-        await resolveOwnerPerson(db, 'SE5560000001-next')
+        expect(data.ownerPerson).toEqual({ hsaId: 'SE5560000001-next' })
         return { id: 7 }
       },
     )
     const path = '/api/requirement-areas/7'
-    const body = { ownerHsaId: 'SE5560000001-next' }
+    const body = {
+      ownerHsaId: 'SE5560000001-next',
+      verificationEvidence: 'verified-owner',
+    }
     expect(
       (await callMutation(areaPut, path, 'PUT', { body, id: '7' })).status,
     ).toBe(200)
-    expect(state.resolvePerson).toHaveBeenCalledWith(db, 'SE5560000001-next')
+    expect(state.resolvePerson).toHaveBeenCalledWith(
+      'verified-owner',
+      expect.objectContaining({
+        hsaId: 'SE5560000001-next',
+        purpose: 'requirement_area_owner',
+        scopeId: 7,
+      }),
+    )
 
     state.getAreaById.mockResolvedValueOnce(null)
     expect(

--- a/tests/unit/requirement-area-route-edge-cases.test.ts
+++ b/tests/unit/requirement-area-route-edge-cases.test.ts
@@ -294,4 +294,25 @@ describe('requirement-area routes', () => {
       ).status,
     ).toBe(404)
   })
+
+  it('requires owner evidence only when an owner is being changed', async () => {
+    const path = '/api/requirement-areas/7'
+
+    expect(
+      (
+        await callMutation(areaPut, path, 'PUT', {
+          body: { ownerHsaId: 'SE5560000001-next' },
+          id: '7',
+        })
+      ).status,
+    ).toBe(400)
+    expect(
+      (
+        await callMutation(areaPut, path, 'PUT', {
+          body: { name: 'Updated', verificationEvidence: 'orphan-evidence' },
+          id: '7',
+        })
+      ).status,
+    ).toBe(400)
+  })
 })

--- a/tests/unit/requirement-areas-client.test.tsx
+++ b/tests/unit/requirement-areas-client.test.tsx
@@ -74,7 +74,7 @@ const hsaIdPrefixPayload = {
 const verificationResponse = (hsaId: string, displayName = 'Verified Person') =>
   okJson({
     evidence: 'signed-evidence',
-    expiresAt: '2026-08-12T10:05:00.000Z',
+    expiresAt: new Date(Date.now() + 300_000).toISOString(),
     person: {
       displayName,
       email: 'verified.person@example.test',
@@ -219,6 +219,19 @@ describe('RequirementAreasClient', () => {
       target: { value: 'new1' },
     })
 
+    const saveButton = within(dialog).getByRole('button', {
+      name: /common\.save/i,
+    })
+    expect(saveButton).toBeDisabled()
+    fireEvent.submit(saveButton.closest('form') as HTMLFormElement)
+    expect(
+      fetchMock.mock.calls.some(
+        ([url, init]) =>
+          url === '/api/requirement-areas' &&
+          (init as RequestInit | undefined)?.method === 'POST',
+      ),
+    ).toBe(false)
+
     fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
       if (url === '/api/requirement-areas' && init?.method === 'POST')
         return okJson({ id: 3 })
@@ -231,10 +244,9 @@ describe('RequirementAreasClient', () => {
     })
 
     await verifyPersonIn(dialog)
+    expect(saveButton).toBeEnabled()
 
-    fireEvent.click(
-      within(dialog).getByRole('button', { name: /common\.save/i }),
-    )
+    fireEvent.click(saveButton)
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(

--- a/tests/unit/requirement-areas-client.test.tsx
+++ b/tests/unit/requirement-areas-client.test.tsx
@@ -71,6 +71,34 @@ const hsaIdPrefixPayload = {
   ],
 }
 
+const verificationResponse = (hsaId: string, displayName = 'Verified Person') =>
+  okJson({
+    evidence: 'signed-evidence',
+    expiresAt: '2026-08-12T10:05:00.000Z',
+    person: {
+      displayName,
+      email: 'verified.person@example.test',
+      givenName: 'Verified',
+      hasProtectedPersonalData: false,
+      hsaId,
+      middleName: null,
+      surname: 'Person',
+    },
+  })
+
+async function verifyPersonIn(dialog: HTMLElement) {
+  const verifyButton = within(dialog).getByRole('button', {
+    name: /common\.fetchHsaPerson/,
+  })
+  fireEvent.click(verifyButton)
+  await waitFor(() => {
+    expect(
+      within(dialog).queryByDisplayValue('Verified Person') ??
+        within(dialog).queryByText(/Verified Person/),
+    ).toBeInTheDocument()
+  })
+}
+
 async function openAreaEditDialog() {
   fireEvent.click(screen.getAllByRole('button', { name: /common\.edit/i })[0])
   return screen.findByRole('dialog', { name: 'area.editArea' })
@@ -197,8 +225,12 @@ describe('RequirementAreasClient', () => {
       if (url === '/api/requirement-area-stewardship')
         return okJson({ areas: sampleAreas })
       if (url === '/api/hsa-id-prefixes') return okJson(hsaIdPrefixPayload)
+      if (url === '/api/requirement-responsibility-people/verify')
+        return verificationResponse('SE5560000001-new1')
       return okJson({})
     })
+
+    await verifyPersonIn(dialog)
 
     fireEvent.click(
       within(dialog).getByRole('button', { name: /common\.save/i }),
@@ -221,6 +253,7 @@ describe('RequirementAreasClient', () => {
         name: 'New requirement area',
         ownerHsaId: 'SE5560000001-new1',
         prefix: 'NEW',
+        verificationEvidence: 'signed-evidence',
       }),
     )
   })
@@ -324,16 +357,7 @@ describe('RequirementAreasClient', () => {
         return okJson({ coAuthors: [] })
       }
       if (url === '/api/requirement-responsibility-people/verify') {
-        return okJson({
-          person: {
-            displayName: 'Cora CoAuthor',
-            email: 'cora.coauthor@example.test',
-            givenName: 'Cora',
-            hsaId: 'SE5560000001-coa1',
-            middleName: null,
-            surname: 'CoAuthor',
-          },
-        })
+        return verificationResponse('SE5560000001-coa1', 'Cora CoAuthor')
       }
       return okJson({})
     })
@@ -383,6 +407,7 @@ describe('RequirementAreasClient', () => {
     ) as [string, RequestInit]
     expect(JSON.parse((putCall[1].body as string) ?? '{}')).toEqual({
       coAuthorHsaIds: ['SE5560000001-coa1'],
+      verificationEvidence: ['signed-evidence'],
     })
     expect(within(dialog).getByText(/Cora CoAuthor/)).toBeInTheDocument()
     await waitFor(() => {
@@ -405,16 +430,7 @@ describe('RequirementAreasClient', () => {
         return okJson({ coAuthors: [] })
       }
       if (url === '/api/requirement-responsibility-people/verify') {
-        return okJson({
-          person: {
-            displayName: 'Cora CoAuthor',
-            email: 'cora.coauthor@example.test',
-            givenName: 'Cora',
-            hsaId: 'SE5560000001-coa1',
-            middleName: null,
-            surname: 'CoAuthor',
-          },
-        })
+        return verificationResponse('SE5560000001-coa1', 'Cora CoAuthor')
       }
       return okJson({})
     })
@@ -503,6 +519,7 @@ describe('RequirementAreasClient', () => {
     ) as [string, RequestInit]
     expect(JSON.parse((putCall[1].body as string) ?? '{}')).toEqual({
       coAuthorHsaIds: [],
+      verificationEvidence: [],
     })
   })
 
@@ -558,6 +575,7 @@ describe('RequirementAreasClient', () => {
     ) as [string, RequestInit]
     expect(JSON.parse((putCall[1].body as string) ?? '{}')).toEqual({
       coAuthorHsaIds: [],
+      verificationEvidence: [],
     })
   })
 
@@ -603,7 +621,7 @@ describe('RequirementAreasClient', () => {
     fireEvent.change(newOwnerInput, {
       target: { value: 'next1' },
     })
-    expect(changeOwnerButton).toBeEnabled()
+    expect(changeOwnerButton).toBeDisabled()
 
     fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
       if (url === '/api/requirement-areas/1' && init?.method === 'PUT')
@@ -619,8 +637,13 @@ describe('RequirementAreasClient', () => {
           ],
         })
       if (url === '/api/hsa-id-prefixes') return okJson(hsaIdPrefixPayload)
+      if (url === '/api/requirement-responsibility-people/verify')
+        return verificationResponse('NO5560000001-next1')
       return okJson({})
     })
+
+    await verifyPersonIn(dialog)
+    expect(changeOwnerButton).toBeEnabled()
 
     fireEvent.click(changeOwnerButton)
 
@@ -636,7 +659,10 @@ describe('RequirementAreasClient', () => {
         (init as RequestInit | undefined)?.method === 'PUT',
     )
     expect((putCall?.[1] as RequestInit | undefined)?.body).toBe(
-      JSON.stringify({ ownerHsaId: 'NO5560000001-next1' }),
+      JSON.stringify({
+        ownerHsaId: 'NO5560000001-next1',
+        verificationEvidence: 'signed-evidence',
+      }),
     )
     await waitFor(() => {
       expect(
@@ -679,8 +705,12 @@ describe('RequirementAreasClient', () => {
       if (url === '/api/requirement-area-stewardship')
         return okJson({ areas: sampleAreas })
       if (url === '/api/hsa-id-prefixes') return okJson(hsaIdPrefixPayload)
+      if (url === '/api/requirement-responsibility-people/verify')
+        return verificationResponse('SE5560000001-next1')
       return okJson({})
     })
+
+    await verifyPersonIn(dialog)
 
     fireEvent.click(
       within(dialog).getByRole('button', { name: /area\.changeOwner/ }),

--- a/tests/unit/requirement-areas-dal.test.ts
+++ b/tests/unit/requirement-areas-dal.test.ts
@@ -284,6 +284,141 @@ describe('requirement-areas DAL', () => {
     ).toBe(false)
   })
 
+  it('rejects a newly added co-author without verified person evidence', async () => {
+    const { db, query } = createSqlServerDb()
+    query
+      .mockResolvedValueOnce([{ ownerHsaId: 'SE5560000001-owner1' }])
+      .mockResolvedValueOnce([])
+
+    await expect(
+      replaceRequirementAreaCoAuthors(db, 11, {
+        coAuthorHsaIds: ['SE5560000001-coa1'],
+      }),
+    ).rejects.toMatchObject({
+      code: 'validation',
+      details: {
+        reason: 'requirement_responsibility_person_evidence_required',
+      },
+    })
+
+    expect(
+      query.mock.calls.some(([sql]) =>
+        String(sql).includes('INSERT INTO requirement_area_co_authors'),
+      ),
+    ).toBe(false)
+  })
+
+  it('rolls back the person upsert when the co-author assignment fails', async () => {
+    const state = { assignmentExists: false, personExists: false }
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM requirement_areas')) {
+        return [{ ownerHsaId: 'SE5560000001-owner1' }]
+      }
+      if (sql.includes('MERGE INTO requirement_responsibility_people')) {
+        state.personExists = true
+        return []
+      }
+      if (
+        sql.includes('FROM requirement_area_co_authors') &&
+        sql.includes('SELECT hsa_id')
+      ) {
+        return []
+      }
+      if (sql.includes('INSERT INTO requirement_area_co_authors')) {
+        state.assignmentExists = true
+        throw new Error('assignment insert failed')
+      }
+      return []
+    })
+    const transaction = vi.fn(
+      async (
+        _isolation: string,
+        callback: (manager: { query: typeof query }) => Promise<unknown>,
+      ) => {
+        const snapshot = { ...state }
+        try {
+          return await callback({ query })
+        } catch (error) {
+          Object.assign(state, snapshot)
+          throw error
+        }
+      },
+    )
+    const db = { transaction } as unknown as Parameters<
+      typeof replaceRequirementAreaCoAuthors
+    >[0]
+
+    await expect(
+      replaceRequirementAreaCoAuthors(db, 11, {
+        coAuthorHsaIds: ['SE5560000001-coa1'],
+        coAuthorPeople: [
+          {
+            email: 'co.author@example.test',
+            givenName: 'Co',
+            hsaId: 'SE5560000001-coa1',
+            middleName: null,
+            surname: 'Author',
+          },
+        ],
+      }),
+    ).rejects.toThrow('assignment insert failed')
+
+    expect(transaction).toHaveBeenCalledWith('SERIALIZABLE', expect.anything())
+    expect(state).toEqual({ assignmentExists: false, personExists: false })
+  })
+
+  it('rolls back the person upsert when the owner assignment fails', async () => {
+    const state = { assignmentExists: false, personExists: false }
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM requirement_areas WITH')) {
+        return [{ ownerHsaId: 'SE5560000001-old1', prefix: 'KH' }]
+      }
+      if (sql.includes('FROM requirement_area_co_authors WITH')) return []
+      if (sql.includes('MERGE INTO requirement_responsibility_people')) {
+        state.personExists = true
+        return []
+      }
+      if (sql.includes('UPDATE requirement_areas')) {
+        state.assignmentExists = true
+        throw new Error('owner update failed')
+      }
+      return []
+    })
+    const transaction = vi.fn(
+      async (
+        _isolation: string,
+        callback: (manager: { query: typeof query }) => Promise<unknown>,
+      ) => {
+        const snapshot = { ...state }
+        try {
+          return await callback({ query })
+        } catch (error) {
+          Object.assign(state, snapshot)
+          throw error
+        }
+      },
+    )
+    const db = { transaction } as unknown as Parameters<
+      typeof updateAreaWithOwnerCheck
+    >[0]
+
+    await expect(
+      updateAreaWithOwnerCheck(db, 11, {
+        ownerHsaId: 'SE5560000001-new1',
+        ownerPerson: {
+          email: 'new.owner@example.test',
+          givenName: 'New',
+          hsaId: 'SE5560000001-new1',
+          middleName: null,
+          surname: 'Owner',
+        },
+      }),
+    ).rejects.toThrow('owner update failed')
+
+    expect(transaction).toHaveBeenCalledWith('SERIALIZABLE', expect.anything())
+    expect(state).toEqual({ assignmentExists: false, personExists: false })
+  })
+
   it('rejects owner and co-author conflicts after normalizing whitespace and case', async () => {
     const { db, query, transaction } = createSqlServerDb()
     query.mockResolvedValueOnce([{ ownerHsaId: ' SE5560000001-Owner1 ' }])

--- a/tests/unit/requirement-areas-route.test.ts
+++ b/tests/unit/requirement-areas-route.test.ts
@@ -71,6 +71,7 @@ vi.mock('@/lib/dal/requirement-areas', () => ({
   updateAreaWithOwnerCheck: mocks.updateAreaWithOwnerCheck,
 }))
 vi.mock('@/lib/requirements/responsibility-person-verification', () => ({
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH: 4096,
   resolveVerifiedRequirementResponsibilityPerson:
     mocks.resolveVerifiedRequirementResponsibilityPerson,
 }))
@@ -124,7 +125,7 @@ describe('requirement-areas route', () => {
       prefix: 'INT',
     })
     mocks.listAreaIdsActorCanAuthor.mockResolvedValue([])
-    mocks.resolveVerifiedRequirementResponsibilityPerson.mockResolvedValue({
+    mocks.resolveVerifiedRequirementResponsibilityPerson.mockReturnValue({
       email: 'new@example.test',
       givenName: 'New',
       hsaId: 'NO5560000001-new1',
@@ -357,6 +358,7 @@ describe('requirement-areas route', () => {
         ownerHsaId: 'NO5560000001-new1',
         prefix: 'NEW',
         name: 'New requirement area',
+        verificationEvidence: 'verified-owner',
       }
       mocks.createArea.mockResolvedValue({ id: 3, ...body })
 
@@ -364,10 +366,12 @@ describe('requirement-areas route', () => {
       expect(res.status).toBe(201)
       expect(await res.json()).toMatchObject({ id: 3 })
       expect(mocks.createArea).toHaveBeenCalledWith(mocks.db, {
-        ...body,
+        name: body.name,
+        ownerHsaId: body.ownerHsaId,
         ownerPerson: expect.objectContaining({
           hsaId: 'NO5560000001-new1',
         }),
+        prefix: body.prefix,
       })
       expect(mocks.recordAdminPrivilegedActionSucceeded).toHaveBeenCalledWith(
         expect.objectContaining({ requestId: 'request-area' }),
@@ -381,19 +385,18 @@ describe('requirement-areas route', () => {
     })
 
     it('uses a locally verified owner person without HSA lookup on save', async () => {
-      mocks.resolveVerifiedRequirementResponsibilityPerson.mockResolvedValueOnce(
-        {
-          email: 'verified.owner@example.test',
-          givenName: 'Verified',
-          hsaId: 'NO5560000001-new1',
-          middleName: null,
-          surname: 'Owner',
-        },
-      )
+      mocks.resolveVerifiedRequirementResponsibilityPerson.mockReturnValueOnce({
+        email: 'verified.owner@example.test',
+        givenName: 'Verified',
+        hsaId: 'NO5560000001-new1',
+        middleName: null,
+        surname: 'Owner',
+      })
       const body = {
         ownerHsaId: 'NO5560000001-new1',
         prefix: 'NEW',
         name: 'New requirement area',
+        verificationEvidence: 'verified-owner',
       }
       mocks.createArea.mockResolvedValue({ id: 4, ...body })
 
@@ -402,7 +405,13 @@ describe('requirement-areas route', () => {
       expect(res.status).toBe(201)
       expect(
         mocks.resolveVerifiedRequirementResponsibilityPerson,
-      ).toHaveBeenCalledWith(mocks.db, 'NO5560000001-new1')
+      ).toHaveBeenCalledWith(
+        'verified-owner',
+        expect.objectContaining({
+          hsaId: 'NO5560000001-new1',
+          purpose: 'requirement_area_owner',
+        }),
+      )
       expect(mocks.createArea).toHaveBeenCalledWith(mocks.db, {
         name: 'New requirement area',
         ownerHsaId: 'NO5560000001-new1',
@@ -448,7 +457,7 @@ describe('requirement-areas route', () => {
 
   describe('PUT', () => {
     it('can change ownerHsaId', async () => {
-      mocks.resolveVerifiedRequirementResponsibilityPerson.mockResolvedValue({
+      mocks.resolveVerifiedRequirementResponsibilityPerson.mockReturnValue({
         email: 'next@example.test',
         givenName: 'Next',
         hsaId: 'NO5560000001-next1',
@@ -465,7 +474,10 @@ describe('requirement-areas route', () => {
 
       const res = await PUT(
         request(
-          { ownerHsaId: 'NO5560000001-next1' },
+          {
+            ownerHsaId: 'NO5560000001-next1',
+            verificationEvidence: 'verified-owner',
+          },
           'http://localhost/api/requirement-areas/1',
           'PUT',
         ),
@@ -478,7 +490,9 @@ describe('requirement-areas route', () => {
         1,
         expect.objectContaining({
           ownerHsaId: 'NO5560000001-next1',
-          resolveOwnerPerson: expect.any(Function),
+          ownerPerson: expect.objectContaining({
+            hsaId: 'NO5560000001-next1',
+          }),
         }),
       )
       expect(mocks.recordAdminPrivilegedActionSucceeded).toHaveBeenCalledWith(
@@ -557,7 +571,10 @@ describe('requirement-areas route', () => {
 
       const res = await PUT(
         request(
-          { ownerHsaId: 'NO5560000001-next1' },
+          {
+            ownerHsaId: 'NO5560000001-next1',
+            verificationEvidence: 'verified-owner',
+          },
           'http://localhost/api/requirement-areas/1',
           'PUT',
         ),

--- a/tests/unit/requirement-package-route-edge-cases.test.ts
+++ b/tests/unit/requirement-package-route-edge-cases.test.ts
@@ -321,6 +321,20 @@ describe('requirement-package routes', () => {
     ).toBe(400)
   })
 
+  it('rejects lead verification evidence without a lead change', async () => {
+    expect(
+      (
+        await callMutation(packagePut, '/api/requirement-packages/7', 'PUT', {
+          body: {
+            name: 'Updated',
+            verificationEvidence: 'orphan-evidence',
+          },
+          id: '7',
+        })
+      ).status,
+    ).toBe(400)
+  })
+
   it('covers delete conflict, missing, success, audit failure, and reactivation', async () => {
     const path = '/api/requirement-packages/7'
     state.deleteRequirementPackage.mockResolvedValueOnce({

--- a/tests/unit/requirement-package-route-edge-cases.test.ts
+++ b/tests/unit/requirement-package-route-edge-cases.test.ts
@@ -28,6 +28,7 @@ const state = vi.hoisted(() => ({
   requirePackagePermission: vi.fn(),
   resolvePeople: vi.fn(),
   resolvePerson: vi.fn(),
+  responsibilityPersonFromActor: vi.fn(),
   updateRequirementPackage: vi.fn(),
 }))
 
@@ -70,6 +71,8 @@ vi.mock('@/lib/requirements/requirement-package-permissions', () => ({
 }))
 
 vi.mock('@/lib/requirements/responsibility-person-verification', () => ({
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH: 4096,
+  requirementResponsibilityPersonFromActor: state.responsibilityPersonFromActor,
   resolveVerifiedRequirementResponsibilityPeople: state.resolvePeople,
   resolveVerifiedRequirementResponsibilityPerson: state.resolvePerson,
 }))
@@ -122,8 +125,8 @@ describe('requirement-package routes', () => {
       coAuthorHsaIds: ['SE5560000001-author'],
       requirementPackageId: 7,
     })
-    state.resolvePeople.mockResolvedValue([])
-    state.resolvePerson.mockResolvedValue({ hsaId: 'SE5560000001-next' })
+    state.resolvePeople.mockReturnValue([])
+    state.resolvePerson.mockReturnValue({ hsaId: 'SE5560000001-next' })
     state.updateRequirementPackage.mockResolvedValue({ id: 7 })
     state.deleteRequirementPackage.mockResolvedValue({
       cleanup: { removedLinkCount: 0 },
@@ -176,7 +179,10 @@ describe('requirement-package routes', () => {
     )
 
     const path = '/api/requirement-packages/7/co-authors'
-    const body = { coAuthorHsaIds: ['SE5560000001-author'] }
+    const body = {
+      coAuthorHsaIds: ['SE5560000001-author'],
+      verificationEvidence: ['verified-author'],
+    }
     expect(
       (
         await callMutation(packageCoAuthorsPut, path, 'PUT', {

--- a/tests/unit/requirement-package-route-edge-cases.test.ts
+++ b/tests/unit/requirement-package-route-edge-cases.test.ts
@@ -280,6 +280,24 @@ describe('requirement-package routes', () => {
         })
       ).status,
     ).toBe(200)
+    expect(
+      (
+        await callMutation(packagePut, path, 'PUT', {
+          body: {
+            leadHsaId: 'SE5560000001-next',
+            verificationEvidence: 'verified-lead',
+          },
+          id: '7',
+        })
+      ).status,
+    ).toBe(200)
+    expect(state.audit).toHaveBeenLastCalledWith(
+      db,
+      context,
+      expect.objectContaining({
+        details: { changedFields: ['leadHsaId'] },
+      }),
+    )
     state.getRequirementPackageById.mockResolvedValueOnce(null)
     expect(
       (

--- a/tests/unit/requirement-packages-client.test.tsx
+++ b/tests/unit/requirement-packages-client.test.tsx
@@ -71,7 +71,7 @@ const hsaIdPrefixPayload = {
 const verificationResponse = (hsaId: string, displayName = 'Verified Lead') =>
   okJson({
     evidence: 'signed-evidence',
-    expiresAt: '2026-08-12T10:05:00.000Z',
+    expiresAt: new Date(Date.now() + 300_000).toISOString(),
     person: {
       displayName,
       email: 'verified.lead@example.test',

--- a/tests/unit/requirement-packages-client.test.tsx
+++ b/tests/unit/requirement-packages-client.test.tsx
@@ -68,6 +68,31 @@ const hsaIdPrefixPayload = {
   prefixes: [{ id: 1, isDefault: true, label: null, prefix: 'SE5560000001' }],
 }
 
+const verificationResponse = (hsaId: string, displayName = 'Verified Lead') =>
+  okJson({
+    evidence: 'signed-evidence',
+    expiresAt: '2026-08-12T10:05:00.000Z',
+    person: {
+      displayName,
+      email: 'verified.lead@example.test',
+      givenName: 'Verified',
+      hasProtectedPersonalData: false,
+      hsaId,
+      middleName: null,
+      surname: 'Lead',
+    },
+  })
+
+async function verifyLeadIn(
+  dialog: HTMLElement,
+  displayName = 'Verified Lead',
+) {
+  fireEvent.click(
+    within(dialog).getByRole('button', { name: /common\.fetchHsaPerson/ }),
+  )
+  await within(dialog).findByText(new RegExp(displayName))
+}
+
 const sampleRequirementPackages = [
   {
     coAuthors: [
@@ -882,6 +907,8 @@ describe('RequirementPackagesClient', () => {
       if (urlString === '/api/auth/me') return okJson(currentAuthMe)
       if (urlString === '/api/hsa-id-prefixes')
         return okJson(hsaIdPrefixPayload)
+      if (urlString === '/api/requirement-responsibility-people/verify')
+        return verificationResponse('SE5560000001-new1', 'New Lead')
       if (urlString === '/api/requirement-packages/1' && init?.method === 'PUT')
         return okJson({
           id: 1,
@@ -895,6 +922,8 @@ describe('RequirementPackagesClient', () => {
       return okJson({})
     })
 
+    await verifyLeadIn(changeDialog, 'New Lead')
+
     fireEvent.click(
       within(changeDialog).getByRole('button', {
         name: /requirementPackage\.changeLead/,
@@ -905,7 +934,10 @@ describe('RequirementPackagesClient', () => {
       expect(fetchMock).toHaveBeenCalledWith(
         '/api/requirement-packages/1',
         expect.objectContaining({
-          body: JSON.stringify({ leadHsaId: 'SE5560000001-new1' }),
+          body: JSON.stringify({
+            leadHsaId: 'SE5560000001-new1',
+            verificationEvidence: 'signed-evidence',
+          }),
           method: 'PUT',
         }),
       )
@@ -953,6 +985,8 @@ describe('RequirementPackagesClient', () => {
       if (urlString === '/api/auth/me') return okJson(currentAuthMe)
       if (urlString === '/api/hsa-id-prefixes')
         return okJson(hsaIdPrefixPayload)
+      if (urlString === '/api/requirement-responsibility-people/verify')
+        return verificationResponse('SE5560000001-new1')
       if (urlString === '/api/requirement-packages/1' && init?.method === 'PUT')
         return notOk({ error: 'Package lead handover failed' })
       if (urlString.startsWith('/api/requirement-packages?')) {
@@ -960,6 +994,8 @@ describe('RequirementPackagesClient', () => {
       }
       return okJson({})
     })
+
+    await verifyLeadIn(changeDialog)
 
     fireEvent.click(
       within(changeDialog).getByRole('button', {
@@ -991,6 +1027,8 @@ describe('RequirementPackagesClient', () => {
       if (urlString === '/api/auth/me') return okJson(nonAdminAuthMe)
       if (urlString === '/api/hsa-id-prefixes')
         return okJson(hsaIdPrefixPayload)
+      if (urlString === '/api/requirement-responsibility-people/verify')
+        return verificationResponse('SE5560000001-next1')
       if (urlString === '/api/requirement-packages/1' && init?.method === 'PUT')
         return okJson({ id: 1, leadHsaId: 'SE5560000001-next1' })
       if (urlString.startsWith('/api/requirement-packages?')) {
@@ -1022,6 +1060,7 @@ describe('RequirementPackagesClient', () => {
       expect(newLeadInput).toBeEnabled()
     })
     fireEvent.change(newLeadInput, { target: { value: 'next1' } })
+    await verifyLeadIn(changeDialog)
     fireEvent.click(
       within(changeDialog).getByRole('button', {
         name: /requirementPackage\.changeLead/,

--- a/tests/unit/requirement-packages-dal.test.ts
+++ b/tests/unit/requirement-packages-dal.test.ts
@@ -408,6 +408,58 @@ describe('requirement-packages DAL', () => {
     })
   })
 
+  it('rolls back the person upsert when the lead assignment fails', async () => {
+    const state = { assignmentExists: false, personExists: false }
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM requirement_packages WITH')) {
+        return [{ leadHsaId: 'SE5560000001-old1' }]
+      }
+      if (sql.includes('FROM requirement_package_co_authors WITH')) return []
+      if (sql.includes('MERGE INTO requirement_responsibility_people')) {
+        state.personExists = true
+        return []
+      }
+      if (sql.includes('UPDATE requirement_packages')) {
+        state.assignmentExists = true
+        throw new Error('lead update failed')
+      }
+      return []
+    })
+    const transaction = vi.fn(
+      async (
+        _isolation: string,
+        callback: (manager: { query: typeof query }) => Promise<unknown>,
+      ) => {
+        const snapshot = { ...state }
+        try {
+          return await callback({ query })
+        } catch (error) {
+          Object.assign(state, snapshot)
+          throw error
+        }
+      },
+    )
+    const db = { transaction } as unknown as Parameters<
+      typeof updateRequirementPackage
+    >[0]
+
+    await expect(
+      updateRequirementPackage(db, 13, {
+        leadHsaId: 'SE5560000001-new1',
+        leadPerson: {
+          email: 'new.lead@example.test',
+          givenName: 'New',
+          hsaId: 'SE5560000001-new1',
+          middleName: null,
+          surname: 'Lead',
+        },
+      }),
+    ).rejects.toThrow('lead update failed')
+
+    expect(transaction).toHaveBeenCalledWith('SERIALIZABLE', expect.anything())
+    expect(state).toEqual({ assignmentExists: false, personExists: false })
+  })
+
   it('rejects lead changes to an existing package co-author before updating', async () => {
     const query = vi
       .fn()
@@ -542,6 +594,65 @@ describe('requirement-packages DAL', () => {
       'INSERT INTO requirement_package_co_authors',
     )
     expect(String(query.mock.calls[5]?.[0])).toContain('DELETE person')
+  })
+
+  it('rolls back the person upsert when a package co-author assignment fails', async () => {
+    const state = { assignmentExists: false, personExists: false }
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM requirement_packages WITH')) {
+        return [{ leadHsaId: 'SE5560000001-lead1' }]
+      }
+      if (sql.includes('MERGE INTO requirement_responsibility_people')) {
+        state.personExists = true
+        return []
+      }
+      if (
+        sql.includes('FROM requirement_package_co_authors') &&
+        sql.includes('SELECT hsa_id')
+      ) {
+        return []
+      }
+      if (sql.includes('INSERT INTO requirement_package_co_authors')) {
+        state.assignmentExists = true
+        throw new Error('co-author insert failed')
+      }
+      return []
+    })
+    const transaction = vi.fn(
+      async (
+        _isolation: string,
+        callback: (manager: { query: typeof query }) => Promise<unknown>,
+      ) => {
+        const snapshot = { ...state }
+        try {
+          return await callback({ query })
+        } catch (error) {
+          Object.assign(state, snapshot)
+          throw error
+        }
+      },
+    )
+    const db = { transaction } as unknown as Parameters<
+      typeof replaceRequirementPackageCoAuthors
+    >[0]
+
+    await expect(
+      replaceRequirementPackageCoAuthors(db, 13, {
+        coAuthorHsaIds: ['SE5560000001-coa1'],
+        coAuthorPeople: [
+          {
+            email: 'co.author@example.test',
+            givenName: 'Co',
+            hsaId: 'SE5560000001-coa1',
+            middleName: null,
+            surname: 'Author',
+          },
+        ],
+      }),
+    ).rejects.toThrow('co-author insert failed')
+
+    expect(transaction).toHaveBeenCalledWith('SERIALIZABLE', expect.anything())
+    expect(state).toEqual({ assignmentExists: false, personExists: false })
   })
 
   it('rejects package co-author replacements that include the package lead', async () => {

--- a/tests/unit/requirements-specifications-dal.test.ts
+++ b/tests/unit/requirements-specifications-dal.test.ts
@@ -832,6 +832,58 @@ describe('requirements-specifications DAL (SQL Server path)', () => {
     })
   })
 
+  it('rolls back the person upsert when the responsible assignment fails', async () => {
+    const state = { assignmentExists: false, personExists: false }
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM requirements_specifications WITH')) {
+        return [{ responsibleHsaId: 'SE5560000001-old1' }]
+      }
+      if (sql.includes('FROM specification_co_authors WITH')) return []
+      if (sql.includes('MERGE INTO requirement_responsibility_people')) {
+        state.personExists = true
+        return []
+      }
+      if (sql.includes('UPDATE requirements_specifications')) {
+        state.assignmentExists = true
+        throw new Error('responsible update failed')
+      }
+      return []
+    })
+    const transaction = vi.fn(
+      async (
+        _isolation: string,
+        callback: (manager: { query: typeof query }) => Promise<unknown>,
+      ) => {
+        const snapshot = { ...state }
+        try {
+          return await callback({ query })
+        } catch (error) {
+          Object.assign(state, snapshot)
+          throw error
+        }
+      },
+    )
+    const db = { transaction } as unknown as Parameters<
+      typeof updateSpecificationResponsible
+    >[0]
+
+    await expect(
+      updateSpecificationResponsible(db, 11, {
+        responsibleHsaId: 'SE5560000001-new1',
+        responsiblePerson: {
+          email: 'new.responsible@example.test',
+          givenName: 'New',
+          hsaId: 'SE5560000001-new1',
+          middleName: null,
+          surname: 'Responsible',
+        },
+      }),
+    ).rejects.toThrow('responsible update failed')
+
+    expect(transaction).toHaveBeenCalledWith('SERIALIZABLE', expect.anything())
+    expect(state).toEqual({ assignmentExists: false, personExists: false })
+  })
+
   it('rejects invalid specification co-author HSA-ids before syncing assignments', async () => {
     const { db, query } = createSqlServerDb()
     query.mockResolvedValueOnce([{ responsibleHsaId: 'SE5560000001-ada1' }])
@@ -862,13 +914,22 @@ describe('requirements-specifications DAL (SQL Server path)', () => {
 
     const result = await replaceSpecificationCoAuthors(db, 11, {
       coAuthorHsaIds: [' SE5560000001-coa1 ', 'SE5560000001-coa1'],
+      coAuthorPeople: [
+        {
+          email: 'co.author@example.test',
+          givenName: 'Co',
+          hsaId: 'SE5560000001-coa1',
+          middleName: null,
+          surname: 'Author',
+        },
+      ],
     })
 
     expect(result).toEqual({
       coAuthorHsaIds: ['SE5560000001-coa1'],
       specificationId: 11,
     })
-    expect(query.mock.calls[2]?.[1]).toEqual([
+    expect(query.mock.calls[3]?.[1]).toEqual([
       11,
       'SE5560000001-coa1',
       expect.any(Date),
@@ -877,10 +938,70 @@ describe('requirements-specifications DAL (SQL Server path)', () => {
     ])
   })
 
+  it('rolls back the person upsert when a specification co-author assignment fails', async () => {
+    const state = { assignmentExists: false, personExists: false }
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM requirements_specifications WITH')) {
+        return [{ responsibleHsaId: 'SE5560000001-owner1' }]
+      }
+      if (sql.includes('MERGE INTO requirement_responsibility_people')) {
+        state.personExists = true
+        return []
+      }
+      if (
+        sql.includes('FROM specification_co_authors') &&
+        sql.includes('SELECT hsa_id')
+      ) {
+        return []
+      }
+      if (sql.includes('INSERT INTO specification_co_authors')) {
+        state.assignmentExists = true
+        throw new Error('co-author insert failed')
+      }
+      return []
+    })
+    const transaction = vi.fn(
+      async (
+        _isolation: string,
+        callback: (manager: { query: typeof query }) => Promise<unknown>,
+      ) => {
+        const snapshot = { ...state }
+        try {
+          return await callback({ query })
+        } catch (error) {
+          Object.assign(state, snapshot)
+          throw error
+        }
+      },
+    )
+    const db = { transaction } as unknown as Parameters<
+      typeof replaceSpecificationCoAuthors
+    >[0]
+
+    await expect(
+      replaceSpecificationCoAuthors(db, 11, {
+        coAuthorHsaIds: ['SE5560000001-coa1'],
+        coAuthorPeople: [
+          {
+            email: 'co.author@example.test',
+            givenName: 'Co',
+            hsaId: 'SE5560000001-coa1',
+            middleName: null,
+            surname: 'Author',
+          },
+        ],
+      }),
+    ).rejects.toThrow('co-author insert failed')
+
+    expect(transaction).toHaveBeenCalledWith('SERIALIZABLE', expect.anything())
+    expect(state).toEqual({ assignmentExists: false, personExists: false })
+  })
+
   it('removes stale co-authors and handles a missing specification', async () => {
     const { db, query } = createSqlServerDb()
     query
       .mockResolvedValueOnce([{ responsibleHsaId: 'SE5560000001-ada1' }])
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         { hsaId: 'SE5560000001-old1' },
         { hsaId: 'SE5560000001-keep1' },
@@ -896,12 +1017,21 @@ describe('requirements-specifications DAL (SQL Server path)', () => {
           hsaId: 'SE5560000001-ada1',
         },
         coAuthorHsaIds: ['SE5560000001-keep1', 'SE5560000001-new1'],
+        coAuthorPeople: [
+          {
+            email: 'new.coauthor@example.test',
+            givenName: 'New',
+            hsaId: 'SE5560000001-new1',
+            middleName: null,
+            surname: 'Coauthor',
+          },
+        ],
       }),
     ).resolves.toEqual({
       coAuthorHsaIds: ['SE5560000001-keep1', 'SE5560000001-new1'],
       specificationId: 11,
     })
-    expect(query.mock.calls[2]?.[1]).toEqual([11, 'SE5560000001-old1'])
+    expect(query.mock.calls[3]?.[1]).toEqual([11, 'SE5560000001-old1'])
 
     const missing = createSqlServerDb()
     missing.query.mockResolvedValueOnce([])

--- a/tests/unit/responsibility-person-verification.test.ts
+++ b/tests/unit/responsibility-person-verification.test.ts
@@ -252,6 +252,19 @@ describe('responsibility person verification', () => {
     },
   )
 
+  it('rejects an undersized evidence signing secret', () => {
+    expect(() =>
+      createRequirementResponsibilityPersonVerificationEvidence(
+        {
+          actor: ACTOR,
+          person: LOOKUP_PERSON,
+          purpose: 'requirement_area_owner',
+        },
+        { secret: 'too-short' },
+      ),
+    ).toThrow('HSA verification evidence secret must be at least 32 characters')
+  })
+
   it('resolves a unique evidence set and rejects missing or duplicate targets', () => {
     const now = new Date('2026-08-12T10:00:00.000Z')
     const secondPerson = {

--- a/tests/unit/responsibility-person-verification.test.ts
+++ b/tests/unit/responsibility-person-verification.test.ts
@@ -19,9 +19,12 @@ vi.mock('@/lib/hsa/person-lookup', () => ({
 
 import {
   createRequirementResponsibilityPersonVerificationEvidence,
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH,
   REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_PURPOSES,
   requirementResponsibilityPersonActorFingerprint,
+  requirementResponsibilityPersonFromActor,
   requirementResponsibilityPersonTargetFingerprint,
+  resolveVerifiedRequirementResponsibilityPeople,
   resolveVerifiedRequirementResponsibilityPerson,
   toRequirementResponsibilityPersonVerificationPayload,
   verifyRequirementResponsibilityPerson,
@@ -205,6 +208,105 @@ describe('responsibility person verification', () => {
     ).toThrow('Verification evidence is invalid or expired')
   })
 
+  it.each([
+    '',
+    'payload-without-signature',
+    '.signature',
+    'payload.',
+    'x'.repeat(
+      REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_EVIDENCE_MAX_LENGTH + 1,
+    ),
+  ])(
+    'rejects malformed verification evidence without decoding it',
+    evidence => {
+      expect(() =>
+        resolveVerifiedRequirementResponsibilityPerson(
+          evidence,
+          {
+            actor: ACTOR,
+            hsaId: LOOKUP_PERSON.hsaId,
+            purpose: 'requirement_area_owner',
+          },
+          {
+            now: new Date('2026-08-12T10:00:30.000Z'),
+            secret: EVIDENCE_SECRET,
+          },
+        ),
+      ).toThrow('Verification evidence is invalid or expired')
+    },
+  )
+
+  it.each([0, 601, 1.5])(
+    'rejects an unsafe evidence TTL of %s seconds',
+    ttlSeconds => {
+      expect(() =>
+        createRequirementResponsibilityPersonVerificationEvidence(
+          {
+            actor: ACTOR,
+            person: LOOKUP_PERSON,
+            purpose: 'requirement_area_owner',
+          },
+          { secret: EVIDENCE_SECRET, ttlSeconds },
+        ),
+      ).toThrow('Invalid HSA verification evidence TTL')
+    },
+  )
+
+  it('resolves a unique evidence set and rejects missing or duplicate targets', () => {
+    const now = new Date('2026-08-12T10:00:00.000Z')
+    const secondPerson = {
+      ...LOCAL_PERSON,
+      hsaId: 'SE5560000001-local2',
+    }
+    const evidence = [LOOKUP_PERSON, secondPerson].map(
+      person =>
+        createRequirementResponsibilityPersonVerificationEvidence(
+          {
+            actor: ACTOR,
+            person,
+            purpose: 'requirements_specification_co_author',
+            scopeId: 17,
+          },
+          { now, secret: EVIDENCE_SECRET },
+        ).evidence,
+    )
+    const expected = {
+      actor: ACTOR,
+      hsaIds: [LOOKUP_PERSON.hsaId, secondPerson.hsaId],
+      purpose: 'requirements_specification_co_author' as const,
+      scopeId: 17,
+    }
+    const options = {
+      now: new Date('2026-08-12T10:01:00.000Z'),
+      secret: EVIDENCE_SECRET,
+    }
+
+    expect(
+      resolveVerifiedRequirementResponsibilityPeople(
+        evidence,
+        expected,
+        options,
+      ),
+    ).toEqual([
+      { ...LOOKUP_PERSON, hasProtectedPersonalData: false },
+      { ...secondPerson, hasProtectedPersonalData: false },
+    ])
+    expect(() =>
+      resolveVerifiedRequirementResponsibilityPeople(
+        [evidence[0], evidence[0]],
+        expected,
+        options,
+      ),
+    ).toThrow('Verification evidence is invalid or expired')
+    expect(() =>
+      resolveVerifiedRequirementResponsibilityPeople(
+        [evidence[1]],
+        { ...expected, hsaIds: [LOOKUP_PERSON.hsaId] },
+        options,
+      ),
+    ).toThrow('Verification evidence is invalid or expired')
+  })
+
   it.each(REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_PURPOSES)(
     'binds evidence for the supported %s assignment purpose',
     purpose => {
@@ -287,6 +389,20 @@ describe('responsibility person verification', () => {
     ).not.toBe(fingerprint)
   })
 
+  it('normalizes optional actor identity fields before fingerprinting', () => {
+    const whitespaceFingerprint =
+      requirementResponsibilityPersonActorFingerprint(
+        { hsaId: ' ', id: ' ', source: 'anonymous' },
+        { secret: EVIDENCE_SECRET },
+      )
+    const nullFingerprint = requirementResponsibilityPersonActorFingerprint(
+      { hsaId: null, id: null, source: 'anonymous' },
+      { secret: EVIDENCE_SECRET },
+    )
+
+    expect(whitespaceFingerprint).toBe(nullFingerprint)
+  })
+
   it('creates one stable target fingerprint across HSA-id case variants', () => {
     const lowerCase = requirementResponsibilityPersonTargetFingerprint(
       'SE5560000001-target1',
@@ -310,5 +426,52 @@ describe('responsibility person verification', () => {
       ),
     ).rejects.toSatisfy(error => isRequirementsServiceError(error))
     expect(mocks.lookupHsaPerson).not.toHaveBeenCalled()
+  })
+
+  it('builds a server-trusted person from the authenticated actor', () => {
+    expect(
+      requirementResponsibilityPersonFromActor({
+        displayName: '  Display Name  ',
+        email: '  actor@example.test  ',
+        familyName: '  Family  ',
+        givenName: '  Given  ',
+        hsaId: '  SE5560000001-actor1  ',
+        isAuthenticated: true,
+      }),
+    ).toEqual({
+      email: 'actor@example.test',
+      givenName: 'Given',
+      hsaId: 'SE5560000001-actor1',
+      middleName: null,
+      surname: 'Family',
+    })
+
+    expect(
+      requirementResponsibilityPersonFromActor({
+        displayName: '  Display fallback  ',
+        email: ' ',
+        familyName: ' ',
+        givenName: ' ',
+        hsaId: 'SE5560000001-actor1',
+        isAuthenticated: true,
+      }),
+    ).toMatchObject({
+      email: null,
+      givenName: 'Display fallback',
+      surname: null,
+    })
+  })
+
+  it('rejects an unauthenticated actor when deriving assignment identity', () => {
+    expect(() =>
+      requirementResponsibilityPersonFromActor({
+        displayName: 'Anonymous',
+        email: undefined,
+        familyName: undefined,
+        givenName: undefined,
+        hsaId: 'SE5560000001-actor1',
+        isAuthenticated: false,
+      }),
+    ).toThrow('Authenticated actor is required')
   })
 })

--- a/tests/unit/responsibility-person-verification.test.ts
+++ b/tests/unit/responsibility-person-verification.test.ts
@@ -138,6 +138,22 @@ describe('responsibility person verification', () => {
       ),
     ).toEqual({ ...LOOKUP_PERSON, hasProtectedPersonalData: false })
 
+    expect(() =>
+      resolveVerifiedRequirementResponsibilityPerson(
+        verification.evidence,
+        {
+          actor: ACTOR,
+          hsaId: LOOKUP_PERSON.hsaId,
+          purpose: 'requirement_area_co_author',
+          scopeId: 42,
+        },
+        {
+          now: new Date('2026-08-12T10:05:00.000Z'),
+          secret: EVIDENCE_SECRET,
+        },
+      ),
+    ).toThrow('Verification evidence is invalid or expired')
+
     const mismatches = [
       { actor: { ...ACTOR, id: 'another-actor' } },
       { hsaId: 'SE5560000001-other1' },
@@ -354,6 +370,39 @@ describe('responsibility person verification', () => {
       ).toMatchObject({ hsaId: LOOKUP_PERSON.hsaId })
     },
   )
+
+  it('binds requirement package lead evidence to a package scope', () => {
+    const scopeId = 23
+    const verification =
+      createRequirementResponsibilityPersonVerificationEvidence(
+        {
+          actor: ACTOR,
+          person: LOOKUP_PERSON,
+          purpose: 'requirement_package_lead',
+          scopeId,
+        },
+        {
+          now: new Date('2026-08-12T10:00:00.000Z'),
+          secret: EVIDENCE_SECRET,
+        },
+      )
+
+    expect(
+      resolveVerifiedRequirementResponsibilityPerson(
+        verification.evidence,
+        {
+          actor: ACTOR,
+          hsaId: LOOKUP_PERSON.hsaId,
+          purpose: 'requirement_package_lead',
+          scopeId,
+        },
+        {
+          now: new Date('2026-08-12T10:01:00.000Z'),
+          secret: EVIDENCE_SECRET,
+        },
+      ),
+    ).toMatchObject({ hsaId: LOOKUP_PERSON.hsaId })
+  })
 
   it('normalizes names and protected-data flags in the verification payload', () => {
     expect(

--- a/tests/unit/responsibility-person-verification.test.ts
+++ b/tests/unit/responsibility-person-verification.test.ts
@@ -18,7 +18,10 @@ vi.mock('@/lib/hsa/person-lookup', () => ({
 }))
 
 import {
-  resolveVerifiedRequirementResponsibilityPeople,
+  createRequirementResponsibilityPersonVerificationEvidence,
+  REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_PURPOSES,
+  requirementResponsibilityPersonActorFingerprint,
+  requirementResponsibilityPersonTargetFingerprint,
   resolveVerifiedRequirementResponsibilityPerson,
   toRequirementResponsibilityPersonVerificationPayload,
   verifyRequirementResponsibilityPerson,
@@ -39,6 +42,14 @@ const LOOKUP_PERSON = {
   middleName: null,
   surname: 'Owner',
 }
+
+const ACTOR = {
+  hsaId: 'SE5560000001-route',
+  id: 'route-test',
+  source: 'oidc' as const,
+}
+
+const EVIDENCE_SECRET = 'test-verification-secret-at-least-32-characters'
 
 describe('responsibility person verification', () => {
   beforeEach(() => {
@@ -65,7 +76,7 @@ describe('responsibility person verification', () => {
     expect(mocks.upsertRequirementResponsibilityPerson).not.toHaveBeenCalled()
   })
 
-  it('fetches and stores a person in reuse-local mode when no local row exists', async () => {
+  it('fetches without storing a person in reuse-local mode when no local row exists', async () => {
     await expect(
       verifyRequirementResponsibilityPerson(
         'mock-db' as never,
@@ -75,10 +86,7 @@ describe('responsibility person verification', () => {
     ).resolves.toEqual(LOOKUP_PERSON)
 
     expect(mocks.lookupHsaPerson).toHaveBeenCalledWith('SE5560000001-sara1')
-    expect(mocks.upsertRequirementResponsibilityPerson).toHaveBeenCalledWith(
-      'mock-db',
-      LOOKUP_PERSON,
-    )
+    expect(mocks.upsertRequirementResponsibilityPerson).not.toHaveBeenCalled()
   })
 
   it('always refreshes from HSA in refresh mode even when a local row exists', async () => {
@@ -94,84 +102,143 @@ describe('responsibility person verification', () => {
 
     expect(mocks.getRequirementResponsibilityPerson).not.toHaveBeenCalled()
     expect(mocks.lookupHsaPerson).toHaveBeenCalledWith('SE5560000001-sara1')
-    expect(mocks.upsertRequirementResponsibilityPerson).toHaveBeenCalledWith(
-      'mock-db',
-      LOOKUP_PERSON,
-    )
+    expect(mocks.upsertRequirementResponsibilityPerson).not.toHaveBeenCalled()
   })
 
-  it('resolves a verified person from the local table during save', async () => {
-    mocks.getRequirementResponsibilityPerson.mockResolvedValueOnce(LOCAL_PERSON)
+  it('accepts short-lived evidence only for its actor, target, purpose, and scope', () => {
+    const issuedAt = new Date('2026-08-12T10:00:00.000Z')
+    const verification =
+      createRequirementResponsibilityPersonVerificationEvidence(
+        {
+          actor: ACTOR,
+          person: LOOKUP_PERSON,
+          purpose: 'requirement_area_co_author',
+          scopeId: 42,
+        },
+        { now: issuedAt, secret: EVIDENCE_SECRET, ttlSeconds: 300 },
+      )
 
-    await expect(
+    expect(verification.expiresAt).toBe('2026-08-12T10:05:00.000Z')
+    expect(
       resolveVerifiedRequirementResponsibilityPerson(
-        'mock-db' as never,
-        'SE5560000001-local1',
-        { retryDelayMs: 0 },
+        verification.evidence,
+        {
+          actor: ACTOR,
+          hsaId: LOOKUP_PERSON.hsaId,
+          purpose: 'requirement_area_co_author',
+          scopeId: 42,
+        },
+        {
+          now: new Date('2026-08-12T10:04:59.000Z'),
+          secret: EVIDENCE_SECRET,
+        },
       ),
-    ).resolves.toEqual(LOCAL_PERSON)
+    ).toEqual({ ...LOOKUP_PERSON, hasProtectedPersonalData: false })
 
-    expect(mocks.lookupHsaPerson).not.toHaveBeenCalled()
+    const mismatches = [
+      { actor: { ...ACTOR, id: 'another-actor' } },
+      { hsaId: 'SE5560000001-other1' },
+      { purpose: 'requirement_package_co_author' as const },
+      { scopeId: 43 },
+    ]
+    for (const mismatch of mismatches) {
+      expect(() =>
+        resolveVerifiedRequirementResponsibilityPerson(
+          verification.evidence,
+          {
+            actor: ACTOR,
+            hsaId: LOOKUP_PERSON.hsaId,
+            purpose: 'requirement_area_co_author',
+            scopeId: 42,
+            ...mismatch,
+          },
+          {
+            now: new Date('2026-08-12T10:04:59.000Z'),
+            secret: EVIDENCE_SECRET,
+          },
+        ),
+      ).toThrow('Verification evidence is invalid or expired')
+    }
   })
 
-  it('fails invalid HSA-id formats before local reads or retry delay', async () => {
-    await expect(
+  it('rejects expired and tampered verification evidence', () => {
+    const verification =
+      createRequirementResponsibilityPersonVerificationEvidence(
+        {
+          actor: ACTOR,
+          person: LOOKUP_PERSON,
+          purpose: 'requirements_specification_responsible',
+          scopeId: 7,
+        },
+        {
+          now: new Date('2026-08-12T10:00:00.000Z'),
+          secret: EVIDENCE_SECRET,
+          ttlSeconds: 60,
+        },
+      )
+    const expected = {
+      actor: ACTOR,
+      hsaId: LOOKUP_PERSON.hsaId,
+      purpose: 'requirements_specification_responsible' as const,
+      scopeId: 7,
+    }
+
+    expect(() =>
       resolveVerifiedRequirementResponsibilityPerson(
-        'mock-db' as never,
-        'not-a-valid-hsa-id',
-        { retryDelayMs: 10_000 },
+        verification.evidence,
+        expected,
+        {
+          now: new Date('2026-08-12T10:01:00.000Z'),
+          secret: EVIDENCE_SECRET,
+        },
       ),
-    ).rejects.toSatisfy(error => {
-      expect(isRequirementsServiceError(error)).toBe(true)
-      if (isRequirementsServiceError(error)) {
-        expect(error.code).toBe('validation')
-        expect(error.details).toMatchObject({ reason: 'invalid_hsa_id' })
-      }
-      return true
-    })
+    ).toThrow('Verification evidence is invalid or expired')
 
-    expect(mocks.getRequirementResponsibilityPerson).not.toHaveBeenCalled()
-    expect(mocks.lookupHsaPerson).not.toHaveBeenCalled()
+    const tampered = `${verification.evidence.slice(0, -1)}${
+      verification.evidence.endsWith('a') ? 'b' : 'a'
+    }`
+    expect(() =>
+      resolveVerifiedRequirementResponsibilityPerson(tampered, expected, {
+        now: new Date('2026-08-12T10:00:30.000Z'),
+        secret: EVIDENCE_SECRET,
+      }),
+    ).toThrow('Verification evidence is invalid or expired')
   })
 
-  it('retries the local table once before failing save validation', async () => {
-    mocks.getRequirementResponsibilityPerson
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(LOCAL_PERSON)
+  it.each(REQUIREMENT_RESPONSIBILITY_PERSON_VERIFICATION_PURPOSES)(
+    'binds evidence for the supported %s assignment purpose',
+    purpose => {
+      const scopeId =
+        purpose === 'requirement_area_owner' ||
+        purpose === 'requirement_package_lead'
+          ? undefined
+          : 17
+      const verification =
+        createRequirementResponsibilityPersonVerificationEvidence(
+          { actor: ACTOR, person: LOOKUP_PERSON, purpose, scopeId },
+          {
+            now: new Date('2026-08-12T10:00:00.000Z'),
+            secret: EVIDENCE_SECRET,
+          },
+        )
 
-    await expect(
-      resolveVerifiedRequirementResponsibilityPerson(
-        'mock-db' as never,
-        'SE5560000001-local1',
-        { retryDelayMs: 0 },
-      ),
-    ).resolves.toEqual(LOCAL_PERSON)
-
-    expect(mocks.getRequirementResponsibilityPerson).toHaveBeenCalledTimes(2)
-    expect(mocks.lookupHsaPerson).not.toHaveBeenCalled()
-  })
-
-  it('fails save validation without HSA lookup when no local row exists', async () => {
-    await expect(
-      resolveVerifiedRequirementResponsibilityPerson(
-        'mock-db' as never,
-        'SE5560000001-missing1',
-        { retryDelayMs: 0 },
-      ),
-    ).rejects.toSatisfy(error => {
-      expect(isRequirementsServiceError(error)).toBe(true)
-      if (isRequirementsServiceError(error)) {
-        expect(error.code).toBe('validation')
-        expect(error.details).toMatchObject({
-          reason: 'requirement_responsibility_person_not_verified',
-        })
-      }
-      return true
-    })
-
-    expect(mocks.getRequirementResponsibilityPerson).toHaveBeenCalledTimes(2)
-    expect(mocks.lookupHsaPerson).not.toHaveBeenCalled()
-  })
+      expect(
+        resolveVerifiedRequirementResponsibilityPerson(
+          verification.evidence,
+          {
+            actor: ACTOR,
+            hsaId: LOOKUP_PERSON.hsaId,
+            purpose,
+            scopeId,
+          },
+          {
+            now: new Date('2026-08-12T10:01:00.000Z'),
+            secret: EVIDENCE_SECRET,
+          },
+        ),
+      ).toMatchObject({ hsaId: LOOKUP_PERSON.hsaId })
+    },
+  )
 
   it('normalizes names and protected-data flags in the verification payload', () => {
     expect(
@@ -199,23 +266,39 @@ describe('responsibility person verification', () => {
     })
   })
 
-  it('resolves multiple verified people after the configured retry delay', async () => {
-    let localReads = 0
-    mocks.getRequirementResponsibilityPerson.mockImplementation(
-      async (_db, hsaId) => {
-        if (hsaId === LOOKUP_PERSON.hsaId) return LOOKUP_PERSON
-        localReads += 1
-        return localReads === 1 ? null : LOCAL_PERSON
-      },
+  it('creates a stable caller fingerprint without retaining raw identity values', () => {
+    const fingerprint = requirementResponsibilityPersonActorFingerprint(ACTOR, {
+      secret: EVIDENCE_SECRET,
+    })
+
+    expect(fingerprint).toMatch(/^afp_[A-Za-z0-9_-]{22}$/u)
+    expect(fingerprint).not.toContain(ACTOR.hsaId)
+    expect(fingerprint).not.toContain(ACTOR.id)
+    expect(
+      requirementResponsibilityPersonActorFingerprint(ACTOR, {
+        secret: EVIDENCE_SECRET,
+      }),
+    ).toBe(fingerprint)
+    expect(
+      requirementResponsibilityPersonActorFingerprint(
+        { ...ACTOR, id: 'different-actor' },
+        { secret: EVIDENCE_SECRET },
+      ),
+    ).not.toBe(fingerprint)
+  })
+
+  it('creates one stable target fingerprint across HSA-id case variants', () => {
+    const lowerCase = requirementResponsibilityPersonTargetFingerprint(
+      'SE5560000001-target1',
+      { secret: EVIDENCE_SECRET },
+    )
+    const mixedCase = requirementResponsibilityPersonTargetFingerprint(
+      'SE5560000001-Target1',
+      { secret: EVIDENCE_SECRET },
     )
 
-    await expect(
-      resolveVerifiedRequirementResponsibilityPeople(
-        'mock-db' as never,
-        ['SE5560000001-local1', 'SE5560000001-sara1'],
-        { retryDelayMs: 1 },
-      ),
-    ).resolves.toEqual([LOCAL_PERSON, LOOKUP_PERSON])
+    expect(mixedCase).toBe(lowerCase)
+    expect(mixedCase).not.toContain('target1')
   })
 
   it('rejects invalid HSA-id input in direct verification', async () => {

--- a/tests/unit/specification-form-modal.test.tsx
+++ b/tests/unit/specification-form-modal.test.tsx
@@ -46,7 +46,7 @@ const hsaIdPrefixPayload = {
 const verificationResponse = (hsaId: string) =>
   okJson({
     evidence: 'signed-evidence',
-    expiresAt: '2026-08-12T10:05:00.000Z',
+    expiresAt: new Date(Date.now() + 300_000).toISOString(),
     person: {
       displayName: 'Rita Reviewer',
       email: 'rita.reviewer@example.test',

--- a/tests/unit/specification-form-modal.test.tsx
+++ b/tests/unit/specification-form-modal.test.tsx
@@ -43,6 +43,28 @@ const hsaIdPrefixPayload = {
   prefixes: [{ id: 1, isDefault: true, label: null, prefix: 'SE5560000001' }],
 }
 
+const verificationResponse = (hsaId: string) =>
+  okJson({
+    evidence: 'signed-evidence',
+    expiresAt: '2026-08-12T10:05:00.000Z',
+    person: {
+      displayName: 'Rita Reviewer',
+      email: 'rita.reviewer@example.test',
+      givenName: 'Rita',
+      hasProtectedPersonalData: false,
+      hsaId,
+      middleName: null,
+      surname: 'Reviewer',
+    },
+  })
+
+async function verifyResponsibleIn(dialog: HTMLElement) {
+  fireEvent.click(
+    within(dialog).getByRole('button', { name: /common\.fetchHsaPerson/ }),
+  )
+  await within(dialog).findByText(/Rita Reviewer/)
+}
+
 async function getEnabledChangeResponsibleButton() {
   const button = screen.getByRole('button', {
     name: /specification\.changeResponsible/,
@@ -427,18 +449,7 @@ describe('SpecificationFormModal', () => {
         return Promise.resolve(okJson(hsaIdPrefixPayload))
       }
       if (url === '/api/requirement-responsibility-people/verify') {
-        return Promise.resolve(
-          okJson({
-            person: {
-              displayName: 'Rita Reviewer',
-              email: 'rita.reviewer@example.test',
-              givenName: 'Rita',
-              hsaId: 'SE5560000001-rita1',
-              middleName: null,
-              surname: 'Reviewer',
-            },
-          }),
-        )
+        return Promise.resolve(verificationResponse('SE5560000001-rita1'))
       }
       return Promise.resolve(okJson({ ok: true }))
     })
@@ -456,6 +467,7 @@ describe('SpecificationFormModal', () => {
       expect(newResponsibleInput).toBeEnabled()
     })
     fireEvent.change(newResponsibleInput, { target: { value: 'rita1' } })
+    await verifyResponsibleIn(dialog)
     fireEvent.click(
       within(dialog).getByRole('button', { name: /common\.fetchHsaPerson/ }),
     )
@@ -631,6 +643,9 @@ describe('SpecificationFormModal', () => {
       if (url === '/api/hsa-id-prefixes') {
         return Promise.resolve(okJson(hsaIdPrefixPayload))
       }
+      if (url === '/api/requirement-responsibility-people/verify') {
+        return Promise.resolve(verificationResponse('SE5560000001-rita1'))
+      }
       if (opts?.method === 'PUT') {
         return Promise.resolve(
           okJson({
@@ -658,6 +673,7 @@ describe('SpecificationFormModal', () => {
       expect(newResponsibleInput).toBeEnabled()
     })
     fireEvent.change(newResponsibleInput, { target: { value: 'rita1' } })
+    await verifyResponsibleIn(dialog)
     fireEvent.click(
       within(dialog).getByRole('button', {
         name: /specification\.changeResponsible/,
@@ -677,7 +693,10 @@ describe('SpecificationFormModal', () => {
         (init as RequestInit | undefined)?.method === 'PUT',
     ) as [string, RequestInit]
     const body = JSON.parse((requestInit.body as string) ?? '{}')
-    expect(body).toEqual({ responsibleHsaId: 'SE5560000001-rita1' })
+    expect(body).toEqual({
+      responsibleHsaId: 'SE5560000001-rita1',
+      verificationEvidence: 'signed-evidence',
+    })
     expect(onResponsibleChanged).toHaveBeenCalledWith(
       expect.objectContaining({
         responsibleDisplayName: 'Rita Reviewer',
@@ -706,6 +725,9 @@ describe('SpecificationFormModal', () => {
       if (url === '/api/hsa-id-prefixes') {
         return Promise.resolve(okJson(hsaIdPrefixPayload))
       }
+      if (url === '/api/requirement-responsibility-people/verify') {
+        return Promise.resolve(verificationResponse('SE5560000001-rita1'))
+      }
       if (
         url === '/api/requirements-specifications/1/responsible' &&
         opts?.method === 'PUT'
@@ -732,6 +754,7 @@ describe('SpecificationFormModal', () => {
       expect(newResponsibleInput).toBeEnabled()
     })
     fireEvent.change(newResponsibleInput, { target: { value: 'rita1' } })
+    await verifyResponsibleIn(dialog)
     fireEvent.click(
       within(dialog).getByRole('button', {
         name: /specification\.changeResponsible/,
@@ -849,6 +872,9 @@ describe('SpecificationFormModal', () => {
       if (url === '/api/hsa-id-prefixes') {
         return Promise.resolve(okJson(hsaIdPrefixPayload))
       }
+      if (url === '/api/requirement-responsibility-people/verify') {
+        return Promise.resolve(verificationResponse('SE5560000001-rita1'))
+      }
       if (opts?.method === 'PUT') {
         return Promise.resolve(
           okJson({
@@ -887,6 +913,7 @@ describe('SpecificationFormModal', () => {
       expect(newResponsibleInput).toBeEnabled()
     })
     fireEvent.change(newResponsibleInput, { target: { value: 'rita1' } })
+    await verifyResponsibleIn(dialog)
     fireEvent.click(
       within(dialog).getByRole('button', {
         name: /specification\.changeResponsible/,

--- a/tests/unit/specifications-client.test.tsx
+++ b/tests/unit/specifications-client.test.tsx
@@ -34,6 +34,22 @@ function okJson(body: unknown) {
   return { ok: true, json: async () => body }
 }
 
+function verifiedPersonResponse(hsaId: string) {
+  return {
+    evidence: 'verified-person-evidence',
+    expiresAt: '2026-08-12T10:05:00.000Z',
+    person: {
+      displayName: 'Rita Reviewer',
+      email: 'rita.reviewer@example.test',
+      givenName: 'Rita',
+      hasProtectedPersonalData: false,
+      hsaId,
+      middleName: null,
+      surname: 'Reviewer',
+    },
+  }
+}
+
 function createDeferred<T>() {
   let resolve!: (value: T) => void
   const promise = new Promise<T>(resolver => {
@@ -1398,6 +1414,14 @@ describe('RequirementsSpecificationsClient', () => {
     fireEvent.change(newResponsibleInput, { target: { value: 'rita1' } })
 
     mockApi((url: string, opts?: RequestInit) => {
+      if (
+        url === '/api/requirement-responsibility-people/verify' &&
+        opts?.method === 'POST'
+      ) {
+        return Promise.resolve(
+          okJson(verifiedPersonResponse('SE5560000001-rita1')),
+        )
+      }
       if (opts?.method === 'PUT') {
         return Promise.resolve(
           okJson({
@@ -1421,6 +1445,16 @@ describe('RequirementsSpecificationsClient', () => {
     })
 
     fireEvent.click(
+      within(dialog).getByRole('button', { name: /common\.fetchHsaPerson/ }),
+    )
+    await waitFor(() => {
+      expect(
+        within(dialog).getByRole('button', {
+          name: /specification\.changeResponsible/,
+        }),
+      ).toBeEnabled()
+    })
+    fireEvent.click(
       within(dialog).getByRole('button', {
         name: /specification\.changeResponsible/,
       }),
@@ -1439,7 +1473,10 @@ describe('RequirementsSpecificationsClient', () => {
     )
     expect(
       JSON.parse(((putCall?.[1] as RequestInit)?.body as string) ?? '{}'),
-    ).toEqual({ responsibleHsaId: 'SE5560000001-rita1' })
+    ).toEqual({
+      responsibleHsaId: 'SE5560000001-rita1',
+      verificationEvidence: 'verified-person-evidence',
+    })
     expect(
       screen.getByRole('textbox', { name: /specification\.name/ }),
     ).toBeInTheDocument()
@@ -1457,6 +1494,14 @@ describe('RequirementsSpecificationsClient', () => {
         )
       if (url === '/api/hsa-id-prefixes')
         return Promise.resolve(okJson(hsaIdPrefixPayload))
+      if (
+        url === '/api/requirement-responsibility-people/verify' &&
+        opts?.method === 'POST'
+      ) {
+        return Promise.resolve(
+          okJson(verifiedPersonResponse('SE5560000001-rita1')),
+        )
+      }
       if (opts?.method === 'PUT') {
         return Promise.resolve(
           okJson({
@@ -1505,6 +1550,16 @@ describe('RequirementsSpecificationsClient', () => {
       expect(newResponsibleInput).toBeEnabled()
     })
     fireEvent.change(newResponsibleInput, { target: { value: 'rita1' } })
+    fireEvent.click(
+      within(dialog).getByRole('button', { name: /common\.fetchHsaPerson/ }),
+    )
+    await waitFor(() => {
+      expect(
+        within(dialog).getByRole('button', {
+          name: /specification\.changeResponsible/,
+        }),
+      ).toBeEnabled()
+    })
     fireEvent.click(
       within(dialog).getByRole('button', {
         name: /specification\.changeResponsible/,

--- a/tests/unit/taxonomy-routes.test.ts
+++ b/tests/unit/taxonomy-routes.test.ts
@@ -1,6 +1,16 @@
 import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { conflictError, validationError } from '@/lib/requirements/errors'
+import { clearInMemoryThrottleForTests } from '@/lib/observability/throttle'
+import type { ActorContext } from '@/lib/requirements/auth'
+import {
+  conflictError,
+  serviceUnavailableError,
+  validationError,
+} from '@/lib/requirements/errors'
+import {
+  createRequirementResponsibilityPersonVerificationEvidence,
+  type RequirementResponsibilityPersonVerificationPurpose,
+} from '@/lib/requirements/responsibility-person-verification'
 
 /* ── shared request DB mocks ─────────────────────────────────────── */
 
@@ -59,8 +69,13 @@ const auditState = vi.hoisted(() => ({
 }))
 
 const actionAuditState = vi.hoisted(() => ({
+  recordActionAuditEvent: vi.fn(async () => undefined),
   recordAllowedActionAuditEvent: vi.fn(async () => undefined),
   recordDeniedActionAuditEvent: vi.fn(async () => undefined),
+}))
+
+const securityAuditState = vi.hoisted(() => ({
+  recordSecurityEvent: vi.fn(),
 }))
 
 const requirementsRuntimeState = vi.hoisted(() => {
@@ -146,9 +161,18 @@ vi.mock('@/lib/admin/privileged-audit', () => ({
 }))
 
 vi.mock('@/lib/audit/action-audit', () => ({
+  recordActionAuditEvent: actionAuditState.recordActionAuditEvent,
   recordAllowedActionAuditEvent: actionAuditState.recordAllowedActionAuditEvent,
   recordDeniedActionAuditEvent: actionAuditState.recordDeniedActionAuditEvent,
 }))
+
+vi.mock('@/lib/auth/audit', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/auth/audit')>()
+  return {
+    ...actual,
+    recordSecurityEvent: securityAuditState.recordSecurityEvent,
+  }
+})
 
 vi.mock('@/lib/audit/requirement-selection-cleanup-audit', () => ({
   recordRequirementSelectionCleanupAudit:
@@ -544,6 +568,39 @@ function specificationCreateBody(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function verificationEvidence(
+  hsaId: string,
+  purpose: RequirementResponsibilityPersonVerificationPurpose,
+  scopeId?: number,
+) {
+  return createRequirementResponsibilityPersonVerificationEvidence({
+    actor: authState.context.actor as ActorContext,
+    person: {
+      email: `${hsaId.toLowerCase()}@example.test`,
+      givenName: 'Verified',
+      hasProtectedPersonalData: false,
+      hsaId,
+      middleName: null,
+      surname: 'Person',
+    },
+    purpose,
+    scopeId,
+  }).evidence
+}
+
+function coAuthorAssignmentBody(
+  coAuthorHsaIds: string[],
+  purpose: RequirementResponsibilityPersonVerificationPurpose,
+  scopeId: number,
+) {
+  return {
+    coAuthorHsaIds,
+    verificationEvidence: coAuthorHsaIds.map(hsaId =>
+      verificationEvidence(hsaId, purpose, scopeId),
+    ),
+  }
+}
+
 async function expectInvalidRequest(
   response: Response,
   path?: string,
@@ -561,11 +618,76 @@ async function expectInvalidRequest(
   }
 }
 
+describe('responsibility assignment evidence contract', () => {
+  it.each([
+    [
+      'requirement area owner',
+      () =>
+        postReqArea(
+          jsonReq('POST', {
+            name: 'Evidence area',
+            ownerHsaId: 'SE5560000001-owner1',
+            prefix: 'EVI',
+          }),
+        ),
+    ],
+    [
+      'requirement area co-author',
+      () =>
+        putRequirementAreaCoAuthors(
+          jsonReq('PUT', { coAuthorHsaIds: ['SE5560000001-coa1'] }),
+          makeParams('1'),
+        ),
+    ],
+    [
+      'requirement package lead',
+      () =>
+        putRequirementPackage(
+          jsonReq('PUT', { leadHsaId: 'SE5560000001-lead1' }),
+          makeParams('1'),
+        ),
+    ],
+    [
+      'requirement package co-author',
+      () =>
+        putRequirementPackageCoAuthors(
+          jsonReq('PUT', { coAuthorHsaIds: ['SE5560000001-coa1'] }),
+          makeParams('1'),
+        ),
+    ],
+    [
+      'specification responsible',
+      () =>
+        putSpecResponsible(
+          jsonReq('PUT', { responsibleHsaId: 'SE5560000001-resp1' }),
+          makeParams('1'),
+        ),
+    ],
+    [
+      'specification co-author',
+      () =>
+        putSpecCoAuthors(
+          jsonReq('PUT', { coAuthorHsaIds: ['SE5560000001-coa1'] }),
+          makeParams('1'),
+        ),
+    ],
+  ] as const)(
+    'requires verification evidence for %s assignment',
+    async (_label, request) => {
+      const response = await request()
+
+      expect(response.status).toBe(400)
+      await expectInvalidRequest(response, 'verificationEvidence')
+    },
+  )
+})
+
 /* ── tests ───────────────────────────────────────────────────────── */
 
 describe('requirement responsibility person verify route', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    clearInMemoryThrottleForTests()
     authState.context.actor = {
       displayName: 'Route Tester',
       hsaId: 'SE5560000001-route',
@@ -617,7 +739,7 @@ describe('requirement responsibility person verify route', () => {
     ])
   })
 
-  it('allows Admin to refresh-verify a requirement area owner HSA-id', async () => {
+  it('returns short-lived evidence without storing a refreshed area owner', async () => {
     authState.context.actor.roles = ['Admin']
 
     const r = await postRequirementResponsibilityPersonVerify(
@@ -630,6 +752,8 @@ describe('requirement responsibility person verify route', () => {
 
     expect(r.status).toBe(200)
     await expect(r.json()).resolves.toEqual({
+      evidence: expect.any(String),
+      expiresAt: expect.stringMatching(/Z$/u),
       person: expect.objectContaining({
         displayName: 'Test Person',
         hsaId: 'SE5560000001-owner1',
@@ -640,10 +764,7 @@ describe('requirement responsibility person verify route', () => {
     )
     expect(
       responsibilityPersonState.upsertRequirementResponsibilityPerson,
-    ).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ hsaId: 'SE5560000001-owner1' }),
-    )
+    ).not.toHaveBeenCalled()
   })
 
   it('reuses a local responsibility person without HSA lookup on blur mode', async () => {
@@ -668,6 +789,8 @@ describe('requirement responsibility person verify route', () => {
 
     expect(r.status).toBe(200)
     await expect(r.json()).resolves.toEqual({
+      evidence: expect.any(String),
+      expiresAt: expect.stringMatching(/Z$/u),
       person: expect.objectContaining({
         displayName: 'Local Owner',
         email: 'local.owner@example.test',
@@ -678,6 +801,144 @@ describe('requirement responsibility person verify route', () => {
     expect(
       responsibilityPersonState.upsertRequirementResponsibilityPerson,
     ).not.toHaveBeenCalled()
+  })
+
+  it('throttles one target and target cycling with the same stable response contract', async () => {
+    authState.context.actor.roles = ['Admin']
+    const requestVerification = (hsaId: string) =>
+      postRequirementResponsibilityPersonVerify(
+        jsonReq('POST', {
+          hsaId,
+          mode: 'refresh',
+          purpose: 'requirement_area_owner',
+        }),
+      )
+
+    for (let index = 0; index < 10; index += 1) {
+      expect((await requestVerification('SE5560000001-owner1')).status).toBe(
+        200,
+      )
+    }
+    const targetThrottled = await requestVerification('SE5560000001-owner1')
+    expect(targetThrottled.status).toBe(429)
+    expect(targetThrottled.headers.get('Retry-After')).toMatch(/^\d+$/u)
+    const targetBody = await targetThrottled.json()
+    expect(targetBody).toEqual({
+      code: 'hsa_verification_throttled',
+      error: 'Too many HSA verification requests.',
+      retryAfterSeconds: expect.any(Number),
+    })
+    expect(hsaLookupState.lookupHsaPerson).toHaveBeenCalledTimes(10)
+
+    clearInMemoryThrottleForTests()
+    hsaLookupState.lookupHsaPerson.mockClear()
+    for (let index = 0; index < 50; index += 1) {
+      expect(
+        (await requestVerification(`SE5560000001-cycle${index}`)).status,
+      ).toBe(200)
+    }
+    const actorThrottled = await requestVerification('SE5560000001-cycle50')
+    expect(actorThrottled.status).toBe(429)
+    await expect(actorThrottled.json()).resolves.toEqual({
+      ...targetBody,
+      retryAfterSeconds: expect.any(Number),
+    })
+    expect(hsaLookupState.lookupHsaPerson).toHaveBeenCalledTimes(50)
+  })
+
+  it('throttles one target across actors without case-variant bypasses', async () => {
+    authState.context.actor.roles = ['Admin']
+    const requestVerification = (hsaId: string) =>
+      postRequirementResponsibilityPersonVerify(
+        jsonReq('POST', {
+          hsaId,
+          mode: 'refresh',
+          purpose: 'requirement_area_owner',
+        }),
+      )
+
+    for (let index = 0; index < 10; index += 1) {
+      authState.context.actor.id = `actor-${index}`
+      authState.context.actor.hsaId = `SE5560000001-actor${index}`
+      const target =
+        index % 2 === 0 ? 'SE5560000001-Target1' : 'SE5560000001-target1'
+      expect((await requestVerification(target)).status).toBe(200)
+    }
+
+    authState.context.actor.id = 'actor-10'
+    authState.context.actor.hsaId = 'SE5560000001-actor10'
+    const response = await requestVerification('SE5560000001-target1')
+
+    expect(response.status).toBe(429)
+    expect(hsaLookupState.lookupHsaPerson).toHaveBeenCalledTimes(10)
+  })
+
+  it.each([
+    {
+      error: null,
+      outcome: 'success',
+      status: 200,
+    },
+    {
+      error: validationError('not found', {
+        reason: 'hsa_lookup_not_found',
+      }),
+      outcome: 'not_found',
+      status: 400,
+    },
+    {
+      error: conflictError('conflict', { reason: 'hsa_lookup_conflict' }),
+      outcome: 'conflict',
+      status: 409,
+    },
+    {
+      error: serviceUnavailableError('provider failed', {
+        reason: 'hsa_lookup_unavailable',
+      }),
+      outcome: 'provider_failure',
+      status: 503,
+    },
+  ])('audits sanitized $outcome verification outcomes', async testCase => {
+    authState.context.actor.roles = ['Admin']
+    authState.context.actor.hsaId = 'SE5560000001-sensitive1'
+    authState.context.actor.id = 'SE5560000001-sensitive1'
+    if (testCase.error) {
+      hsaLookupState.lookupHsaPerson.mockRejectedValueOnce(testCase.error)
+    }
+
+    const response = await postRequirementResponsibilityPersonVerify(
+      jsonReq('POST', {
+        hsaId: 'SE5560000001-sensitive1',
+        mode: 'refresh',
+        purpose: 'requirement_area_owner',
+      }),
+    )
+
+    expect(response.status).toBe(testCase.status)
+    expect(actionAuditState.recordActionAuditEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'requirement_responsibility_person.verify',
+        actorClientId: expect.stringMatching(/^afp_[A-Za-z0-9_-]{22}$/u),
+        actorDisplayName: null,
+        actorHsaId: null,
+        details: expect.objectContaining({ outcome: testCase.outcome }),
+        targetId: expect.stringMatching(/^hfp_[A-Za-z0-9_-]{22}$/u),
+      }),
+    )
+    expect(securityAuditState.recordSecurityEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ outcome: testCase.outcome }),
+        event: 'requirements.hsa_verification.completed',
+      }),
+    )
+    const auditPayload = JSON.stringify({
+      action: actionAuditState.recordActionAuditEvent.mock.calls.at(-1),
+      security: securityAuditState.recordSecurityEvent.mock.calls.at(-1),
+    })
+    expect(auditPayload).not.toContain('SE5560000001-sensitive1')
+    expect(auditPayload).not.toContain('Test Person')
+    expect(auditPayload).not.toContain('@example.test')
   })
 
   it('rejects non-Admin requirement area owner verification before HSA lookup', async () => {
@@ -774,6 +1035,43 @@ describe('requirement responsibility person verify route', () => {
 
     expect(r.status).toBe(403)
     expect(hsaLookupState.lookupHsaPerson).not.toHaveBeenCalled()
+  })
+
+  it('requires scope for requirement package co-author verification', async () => {
+    const response = await postRequirementResponsibilityPersonVerify(
+      jsonReq('POST', {
+        hsaId: 'SE5560000001-coa1',
+        mode: 'refresh',
+        purpose: 'requirement_package_co_author',
+      }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(hsaLookupState.lookupHsaPerson).not.toHaveBeenCalled()
+  })
+
+  it('only allows an unscoped package lead verification for the actor', async () => {
+    const denied = await postRequirementResponsibilityPersonVerify(
+      jsonReq('POST', {
+        hsaId: 'SE5560000001-other1',
+        mode: 'refresh',
+        purpose: 'requirement_package_lead',
+      }),
+    )
+    expect(denied.status).toBe(403)
+    expect(hsaLookupState.lookupHsaPerson).not.toHaveBeenCalled()
+
+    const allowed = await postRequirementResponsibilityPersonVerify(
+      jsonReq('POST', {
+        hsaId: 'SE5560000001-route',
+        mode: 'refresh',
+        purpose: 'requirement_package_lead',
+      }),
+    )
+    expect(allowed.status).toBe(200)
+    expect(hsaLookupState.lookupHsaPerson).toHaveBeenCalledWith(
+      'SE5560000001-route',
+    )
   })
 
   it('checks specification assignment manager permission before scoped responsible verification lookup', async () => {
@@ -1236,6 +1534,14 @@ describe('specification-item-statuses catalog routes', () => {
 describe('requirement-areas routes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    authState.context.actor = {
+      displayName: 'Ada Admin',
+      hsaId: 'SE5560000001-admin1',
+      id: 'admin-sub',
+      isAuthenticated: true,
+      roles: ['Admin'],
+      source: 'oidc',
+    }
   })
 
   it('GET returns areas', async () => {
@@ -1244,11 +1550,16 @@ describe('requirement-areas routes', () => {
     expect(j.areas).toHaveLength(1)
   })
   it('POST creates with 201', async () => {
+    const evidence = verificationEvidence(
+      'SE5560000001-ta1',
+      'requirement_area_owner',
+    )
     const r = await postReqArea(
-      new Request('http://l', {
-        method: 'POST',
-        body: '{"name":"Test area","prefix":"TA","ownerHsaId":"SE5560000001-ta1"}',
-        headers: { 'Content-Type': 'application/json' },
+      jsonReq('POST', {
+        name: 'Test area',
+        ownerHsaId: 'SE5560000001-ta1',
+        prefix: 'TA',
+        verificationEvidence: evidence,
       }),
     )
     expect(r.status).toBe(201)
@@ -1303,7 +1614,14 @@ describe('requirement-areas/[id] routes', () => {
       makeParams('1'),
     )
     const putResponse = await putRequirementAreaCoAuthors(
-      jsonReq('PUT', { coAuthorHsaIds: ['SE5560000001-coa1'] }),
+      jsonReq(
+        'PUT',
+        coAuthorAssignmentBody(
+          ['SE5560000001-coa1'],
+          'requirement_area_co_author',
+          1,
+        ),
+      ),
       makeParams('1'),
     )
 
@@ -1341,7 +1659,10 @@ describe('requirement-areas/[id] routes', () => {
       makeParams('1'),
     )
     const missingPut = await putRequirementAreaCoAuthors(
-      jsonReq('PUT', { coAuthorHsaIds: [] }),
+      jsonReq(
+        'PUT',
+        coAuthorAssignmentBody([], 'requirement_area_co_author', 404),
+      ),
       makeParams('404'),
     )
 
@@ -1353,11 +1674,30 @@ describe('requirement-areas/[id] routes', () => {
   it('PUT area co-authors reports a concurrent disappearance', async () => {
     mockReplaceRequirementAreaCoAuthors.mockResolvedValueOnce(null)
     const response = await putRequirementAreaCoAuthors(
-      jsonReq('PUT', { coAuthorHsaIds: [] }),
+      jsonReq(
+        'PUT',
+        coAuthorAssignmentBody([], 'requirement_area_co_author', 1),
+      ),
       makeParams('1'),
     )
 
     expect(response.status).toBe(404)
+  })
+  it('rejects oversized requirement area co-author lists', async () => {
+    const response = await putRequirementAreaCoAuthors(
+      jsonReq('PUT', {
+        coAuthorHsaIds: Array.from(
+          { length: 201 },
+          (_value, index) => `SE5560000001-coa${index}`,
+        ),
+        verificationEvidence: [],
+      }),
+      makeParams('1'),
+    )
+
+    expect(response.status).toBe(400)
+    await expectInvalidRequest(response, 'coAuthorHsaIds')
+    expect(mockReplaceRequirementAreaCoAuthors).not.toHaveBeenCalled()
   })
   it('falls back to stable actor identifiers for area co-author changes', async () => {
     authState.context.actor.displayName = ' '
@@ -1367,7 +1707,10 @@ describe('requirement-areas/[id] routes', () => {
       requirementAreaId: 1,
     })
     const response = await putRequirementAreaCoAuthors(
-      jsonReq('PUT', { coAuthorHsaIds: [] }),
+      jsonReq(
+        'PUT',
+        coAuthorAssignmentBody([], 'requirement_area_co_author', 1),
+      ),
       makeParams('1'),
     )
     expect(response.status).toBe(200)
@@ -1433,7 +1776,14 @@ describe('requirement-areas/[id] routes', () => {
     )
 
     const r = await putReqArea(
-      jsonReq('PUT', { ownerHsaId: 'SE5560000001-coa1' }),
+      jsonReq('PUT', {
+        ownerHsaId: 'SE5560000001-coa1',
+        verificationEvidence: verificationEvidence(
+          'SE5560000001-coa1',
+          'requirement_area_owner',
+          1,
+        ),
+      }),
       makeParams('1'),
     )
 
@@ -2016,6 +2366,11 @@ describe('requirement-specifications routes', () => {
     const r = await putSpecResponsible(
       jsonReq('PUT', {
         responsibleHsaId: 'SE5560000001-rita1',
+        verificationEvidence: verificationEvidence(
+          'SE5560000001-rita1',
+          'requirements_specification_responsible',
+          1,
+        ),
       }),
       makeParams('1'),
     )
@@ -2075,6 +2430,11 @@ describe('requirement-specifications routes', () => {
     const r = await putSpecResponsible(
       jsonReq('PUT', {
         responsibleHsaId: 'SE5560000001-coa1',
+        verificationEvidence: verificationEvidence(
+          'SE5560000001-coa1',
+          'requirements_specification_responsible',
+          1,
+        ),
       }),
       makeParams('1'),
     )
@@ -2101,9 +2461,14 @@ describe('requirement-specifications routes', () => {
     )
 
     const r = await putSpecCoAuthors(
-      jsonReq('PUT', {
-        coAuthorHsaIds: ['SE5560000001-coa1'],
-      }),
+      jsonReq(
+        'PUT',
+        coAuthorAssignmentBody(
+          ['SE5560000001-coa1'],
+          'requirements_specification_co_author',
+          1,
+        ),
+      ),
       makeParams('1'),
     )
 
@@ -2118,6 +2483,22 @@ describe('requirement-specifications routes', () => {
         ],
       }),
     )
+  })
+  it('rejects oversized specification co-author lists', async () => {
+    const response = await putSpecCoAuthors(
+      jsonReq('PUT', {
+        coAuthorHsaIds: Array.from(
+          { length: 201 },
+          (_value, index) => `SE5560000001-coa${index}`,
+        ),
+        verificationEvidence: [],
+      }),
+      makeParams('1'),
+    )
+
+    expect(response.status).toBe(400)
+    await expectInvalidRequest(response, 'coAuthorHsaIds')
+    expect(mockReplaceSpecificationCoAuthors).not.toHaveBeenCalled()
   })
   it('GET lists specification co-authors and enforces assignment permission', async () => {
     mockListSpecificationCoAuthors.mockResolvedValueOnce([
@@ -2156,7 +2537,10 @@ describe('requirement-specifications routes', () => {
       .mockResolvedValueOnce(null)
 
     const r = await putSpecCoAuthors(
-      jsonReq('PUT', { coAuthorHsaIds: [] }),
+      jsonReq(
+        'PUT',
+        coAuthorAssignmentBody([], 'requirements_specification_co_author', 404),
+      ),
       makeParams('404'),
     )
 
@@ -2169,7 +2553,10 @@ describe('requirement-specifications routes', () => {
     )
 
     const r = await putSpecCoAuthors(
-      jsonReq('PUT', { coAuthorHsaIds: [] }),
+      jsonReq(
+        'PUT',
+        coAuthorAssignmentBody([], 'requirements_specification_co_author', 1),
+      ),
       makeParams('1'),
     )
 
@@ -2180,7 +2567,10 @@ describe('requirement-specifications routes', () => {
     mockReplaceSpecificationCoAuthors.mockResolvedValueOnce(null)
 
     const r = await putSpecCoAuthors(
-      jsonReq('PUT', { coAuthorHsaIds: [] }),
+      jsonReq(
+        'PUT',
+        coAuthorAssignmentBody([], 'requirements_specification_co_author', 1),
+      ),
       makeParams('1'),
     )
 
@@ -2199,7 +2589,10 @@ describe('requirement-specifications routes', () => {
       })
 
       const r = await putSpecCoAuthors(
-        jsonReq('PUT', { coAuthorHsaIds: [] }),
+        jsonReq(
+          'PUT',
+          coAuthorAssignmentBody([], 'requirements_specification_co_author', 1),
+        ),
         makeParams('1'),
       )
 
@@ -2223,7 +2616,14 @@ describe('requirement-specifications routes', () => {
     )
 
     const r = await putSpecResponsible(
-      jsonReq('PUT', { responsibleHsaId: 'SE5560000001-rita1' }),
+      jsonReq('PUT', {
+        responsibleHsaId: 'SE5560000001-rita1',
+        verificationEvidence: verificationEvidence(
+          'SE5560000001-rita1',
+          'requirements_specification_responsible',
+          1,
+        ),
+      }),
       makeParams('1'),
     )
 
@@ -2236,7 +2636,14 @@ describe('requirement-specifications routes', () => {
       .mockResolvedValueOnce(null)
 
     const r = await putSpecResponsible(
-      jsonReq('PUT', { responsibleHsaId: 'SE5560000001-rita1' }),
+      jsonReq('PUT', {
+        responsibleHsaId: 'SE5560000001-rita1',
+        verificationEvidence: verificationEvidence(
+          'SE5560000001-rita1',
+          'requirements_specification_responsible',
+          404,
+        ),
+      }),
       makeParams('404'),
     )
 
@@ -2247,7 +2654,14 @@ describe('requirement-specifications routes', () => {
     mockUpdateSpecResponsible.mockResolvedValueOnce(null)
 
     const r = await putSpecResponsible(
-      jsonReq('PUT', { responsibleHsaId: 'SE5560000001-rita1' }),
+      jsonReq('PUT', {
+        responsibleHsaId: 'SE5560000001-rita1',
+        verificationEvidence: verificationEvidence(
+          'SE5560000001-rita1',
+          'requirements_specification_responsible',
+          1,
+        ),
+      }),
       makeParams('1'),
     )
 
@@ -2525,7 +2939,14 @@ describe('requirement-packages routes', () => {
     })
 
     const r = await putRequirementPackage(
-      jsonReq('PUT', { leadHsaId: 'SE5560000001-coa1' }),
+      jsonReq('PUT', {
+        leadHsaId: 'SE5560000001-coa1',
+        verificationEvidence: verificationEvidence(
+          'SE5560000001-coa1',
+          'requirement_package_lead',
+          1,
+        ),
+      }),
       makeParams('1'),
     )
 
@@ -2595,7 +3016,10 @@ describe('requirement-packages routes', () => {
     )
     mockGetRequirementPackageById.mockResolvedValueOnce(null)
     const missingPut = await putRequirementPackageCoAuthors(
-      jsonReq('PUT', { coAuthorHsaIds: [] }),
+      jsonReq(
+        'PUT',
+        coAuthorAssignmentBody([], 'requirement_package_co_author', 404),
+      ),
       makeParams('404'),
     )
     expect(invalid.status).toBe(400)
@@ -2607,7 +3031,10 @@ describe('requirement-packages routes', () => {
     authState.context.actor.id = ''
     mockReplaceRequirementPackageCoAuthors.mockResolvedValueOnce(null)
     const disappeared = await putRequirementPackageCoAuthors(
-      jsonReq('PUT', { coAuthorHsaIds: [] }),
+      jsonReq(
+        'PUT',
+        coAuthorAssignmentBody([], 'requirement_package_co_author', 1),
+      ),
       makeParams('1'),
     )
     expect(disappeared.status).toBe(404)
@@ -2617,7 +3044,10 @@ describe('requirement-packages routes', () => {
       requirementPackageId: 1,
     })
     const success = await putRequirementPackageCoAuthors(
-      jsonReq('PUT', { coAuthorHsaIds: [] }),
+      jsonReq(
+        'PUT',
+        coAuthorAssignmentBody([], 'requirement_package_co_author', 1),
+      ),
       makeParams('1'),
     )
     expect(success.status).toBe(200)
@@ -2647,9 +3077,14 @@ describe('requirement-packages routes', () => {
     )
 
     const r = await putRequirementPackageCoAuthors(
-      jsonReq('PUT', {
-        coAuthorHsaIds: ['SE5560000001-coa1'],
-      }),
+      jsonReq(
+        'PUT',
+        coAuthorAssignmentBody(
+          ['SE5560000001-coa1'],
+          'requirement_package_co_author',
+          1,
+        ),
+      ),
       makeParams('1'),
     )
 

--- a/tests/unit/taxonomy-routes.test.ts
+++ b/tests/unit/taxonomy-routes.test.ts
@@ -1,6 +1,9 @@
 import { NextRequest } from 'next/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { clearInMemoryThrottleForTests } from '@/lib/observability/throttle'
+import {
+  clearInMemoryThrottleForTests,
+  getInMemoryThrottleBucketCountForTests,
+} from '@/lib/observability/throttle'
 import type { ActorContext } from '@/lib/requirements/auth'
 import {
   conflictError,
@@ -837,6 +840,11 @@ describe('requirement responsibility person verify route', () => {
         (await requestVerification(`SE5560000001-cycle${index}`)).status,
       ).toBe(200)
     }
+    const bucketCountBeforeDenial = getInMemoryThrottleBucketCountForTests()
+    const dbCallsBeforeDenial =
+      routeState.getRequestSqlServerDataSource.mock.calls.length
+    const actionAuditCallsBeforeDenial =
+      actionAuditState.recordActionAuditEvent.mock.calls.length
     const actorThrottled = await requestVerification('SE5560000001-cycle50')
     expect(actorThrottled.status).toBe(429)
     await expect(actorThrottled.json()).resolves.toEqual({
@@ -844,6 +852,20 @@ describe('requirement responsibility person verify route', () => {
       retryAfterSeconds: expect.any(Number),
     })
     expect(hsaLookupState.lookupHsaPerson).toHaveBeenCalledTimes(50)
+    expect(getInMemoryThrottleBucketCountForTests()).toBe(
+      bucketCountBeforeDenial,
+    )
+    expect(routeState.getRequestSqlServerDataSource).toHaveBeenCalledTimes(
+      dbCallsBeforeDenial,
+    )
+    expect(actionAuditState.recordActionAuditEvent).toHaveBeenCalledTimes(
+      actionAuditCallsBeforeDenial,
+    )
+    expect(securityAuditState.recordSecurityEvent).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ outcome: 'throttled' }),
+      }),
+    )
   })
 
   it('throttles one target across actors without case-variant bypasses', async () => {
@@ -939,6 +961,39 @@ describe('requirement responsibility person verify route', () => {
     expect(auditPayload).not.toContain('SE5560000001-sensitive1')
     expect(auditPayload).not.toContain('Test Person')
     expect(auditPayload).not.toContain('@example.test')
+  })
+
+  it('keeps a successful verification response when action audit persistence fails', async () => {
+    authState.context.actor.roles = ['Admin']
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    actionAuditState.recordActionAuditEvent.mockRejectedValueOnce(
+      new Error('audit unavailable'),
+    )
+
+    const response = await postRequirementResponsibilityPersonVerify(
+      jsonReq('POST', {
+        hsaId: 'SE5560000001-owner1',
+        mode: 'refresh',
+        purpose: 'requirement_area_owner',
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      evidence: expect.any(String),
+      person: { hsaId: 'SE5560000001-owner1' },
+    })
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('verification action audit event'),
+      expect.objectContaining({
+        error: expect.objectContaining({ message: 'audit unavailable' }),
+      }),
+    )
+    expect(securityAuditState.recordSecurityEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ outcome: 'success' }),
+      }),
+    )
   })
 
   it('rejects non-Admin requirement area owner verification before HSA lookup', async () => {


### PR DESCRIPTION
## Description

Make HSA-based responsibility assignments privacy-preserving and atomic.

- Keep successful HSA lookups read-only and return short-lived, signed assignment evidence bound to the actor, target, purpose, scope, and resolved person.
- Require that evidence when assigning area, package, and specification responsibilities, and commit person creation and assignment in one transaction.
- Add stable actor and target-fingerprint throttling, privacy-safe audit events, protected-person disclosure guidance, and sensitive response policies.
- Cover enumeration resistance, evidence tampering and expiry, transaction rollback, and all supported assignment types.

## Related Issues

Closes #475

## Reviewer Notes

Validation completed:

- Full unit suite: 6,696 passed, 86 skipped across 476 passing files and 2 skipped files.
- Codecov patch coverage: 86.77%, above the 85% target.
- HSA verification utility coverage: 94.31% lines, 94.04% branches, and 100% functions.
- Focused final-delta suite: 208 passed.
- Selected Playwright authentication flows: 7 passed.
- Type checking, linting, spelling, Markdown linting, and formatting passed.
- Standards and specification reviews found no remaining hard failures or acceptance-criteria gaps.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
After deployment, verify responsibility assignment workflows for areas, packages, and specifications. HSA lookup no longer persists a person immediately; the final assignment must present the short-lived evidence returned by verification, after which person creation and assignment are committed atomically.

Update any automation that calls these internal verification and assignment endpoints to forward the returned evidence. Verification is now rate limited, and audit records use target fingerprints and outcomes instead of raw target HSA IDs or personal data. Brief support and privacy teams on the protected-person handling guidance shown in the assignment workflow.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/990)
<!-- Reviewable:end -->
