### PR TITLE
docs: persist operator upgrade notes from #990

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -151,6 +151,10 @@ remains usable.
 Before upgrading, create a site-specific readiness probe boundary containing the approved IPv4 and IPv6 monitoring source networks and configure the deployment to use it. The upgrade will refuse to render or install if the boundary is absent or invalid.
 After rollout, verify readiness from an allowed monitoring source, confirm other sources receive an empty denial, and confirm liveness and normal application traffic remain available. Update monitoring expectations for one request per second with a burst of five and generic rate-limit/not-ready responses.
 <!-- operator-upgrade:source pr-987 end -->
+
+<!-- operator-upgrade:source pr-989 start -->
+Before rollout, verify every production HSA lookup, OAuth, and SOAP endpoint uses HTTPS and that discovery returns a token endpoint on the configured issuer's origin. Confirm host firewall, approved egress proxy, DNS, routing, and upstream ACL rules allow only approved HSA destinations.
+<!-- operator-upgrade:source pr-989 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade

--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -155,6 +155,11 @@ After rollout, verify readiness from an allowed monitoring source, confirm other
 <!-- operator-upgrade:source pr-989 start -->
 Before rollout, verify every production HSA lookup, OAuth, and SOAP endpoint uses HTTPS and that discovery returns a token endpoint on the configured issuer's origin. Confirm host firewall, approved egress proxy, DNS, routing, and upstream ACL rules allow only approved HSA destinations.
 <!-- operator-upgrade:source pr-989 end -->
+
+<!-- operator-upgrade:source pr-990 start -->
+After deployment, verify responsibility assignment workflows for areas, packages, and specifications. HSA lookup no longer persists a person immediately; the final assignment must present the short-lived evidence returned by verification, after which person creation and assignment are committed atomically.
+Update any automation that calls these internal verification and assignment endpoints to forward the returned evidence. Verification is now rate limited, and audit records use target fingerprints and outcomes instead of raw target HSA IDs or personal data. Brief support and privacy teams on the protected-person handling guidance shown in the assignment workflow.
+<!-- operator-upgrade:source pr-990 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #990
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/31701390863

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/992)
<!-- Reviewable:end -->
