### PR TITLE
docs: persist operator upgrade notes from #1035

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -254,6 +254,18 @@ a database restore, run transient cleanup before evidence reads are enabled so
 expired evidence does not become operationally available.
 <!-- operator-upgrade:source pr-1024 end -->
 
+<!-- operator-upgrade:source pr-1035 start -->
+Before the upgrade, inject unique authentication secrets into the production
+application configuration. For bundled Keycloak, also set temporary bootstrap
+administrator credentials and separate application and MCP realm client
+secrets. Make sure that the application client secret matches the application
+configuration.
+During rollout, the deployment preflight rejects blank or shipped placeholder
+credentials before services start. The application image also stops if these
+placeholders remain. If you rotate the session secret, all active browser
+sessions become invalid. Plan this action for a low-traffic period and verify
+sign-in after deployment.
+<!-- operator-upgrade:source pr-1035 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #1035
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/31939067768

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1036)
<!-- Reviewable:end -->
