### PR TITLE
docs: persist operator upgrade notes from #1037

### DIFF
--- a/app/[locale]/specifications/[specificationId]/requirements-specification-detail-client.tsx
+++ b/app/[locale]/specifications/[specificationId]/requirements-specification-detail-client.tsx
@@ -565,6 +565,10 @@ export default function KravunderlagDetailClient({
     specificationItemsContinuationError,
     setSpecificationItemsContinuationError,
   ] = useState<'continuation' | 'recovery' | null>(null)
+  const [
+    restoreSpecificationItemsRetryFocus,
+    setRestoreSpecificationItemsRetryFocus,
+  ] = useState(false)
   const [specificationItemsAnnouncement, setSpecificationItemsAnnouncement] =
     useState<string | null>(null)
   const [availableRows, setAvailableRows] = useState<RequirementRow[]>(
@@ -1138,10 +1142,8 @@ export default function KravunderlagDetailClient({
   const loadFirstSpecificationItemsPage = useCallback(
     async ({
       recoveringInvalidCursor = false,
-      restoreRetryFocusOnFailure = false,
     }: {
       recoveringInvalidCursor?: boolean
-      restoreRetryFocusOnFailure?: boolean
     } = {}) => {
       const requestId = ++specificationItemsRequestIdRef.current
       specificationItemsAbortRef.current?.abort()
@@ -1196,11 +1198,6 @@ export default function KravunderlagDetailClient({
           setSpecificationItemsContinuationError('recovery')
         } else {
           setSpecificationItemsError(message)
-        }
-        if (restoreRetryFocusOnFailure) {
-          requestAnimationFrame(() =>
-            specificationItemsRetryRef.current?.focus(),
-          )
         }
         return false
       } finally {
@@ -1346,18 +1343,31 @@ export default function KravunderlagDetailClient({
   const retrySpecificationItems = useCallback(async () => {
     if (specificationItemsContinuationError === 'continuation') {
       await loadMoreSpecificationItems()
-      requestAnimationFrame(() => specificationItemsRetryRef.current?.focus())
+      setRestoreSpecificationItemsRetryFocus(true)
       return
     }
     await loadFirstSpecificationItemsPage({
       recoveringInvalidCursor:
         specificationItemsContinuationError === 'recovery',
-      restoreRetryFocusOnFailure: true,
     })
+    setRestoreSpecificationItemsRetryFocus(true)
   }, [
     loadFirstSpecificationItemsPage,
     loadMoreSpecificationItems,
     specificationItemsContinuationError,
+  ])
+
+  useEffect(() => {
+    if (!restoreSpecificationItemsRetryFocus) return
+
+    if (specificationItemsError || specificationItemsContinuationError) {
+      specificationItemsRetryRef.current?.focus()
+    }
+    setRestoreSpecificationItemsRetryFocus(false)
+  }, [
+    restoreSpecificationItemsRetryFocus,
+    specificationItemsContinuationError,
+    specificationItemsError,
   ])
 
   const needsReferenceUsageLoadError = t('loadSpecificationItemsFailed')

--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -266,6 +266,11 @@ placeholders remain. If you rotate the session secret, all active browser
 sessions become invalid. Plan this action for a low-traffic period and verify
 sign-in after deployment.
 <!-- operator-upgrade:source pr-1035 end -->
+
+<!-- operator-upgrade:source pr-1037 start -->
+Before rollout, validate the responsibility assignments for requirements specifications and requirement areas. Direct reads of child resources now use the access rules of their parent resource.
+Tell API consumers and support staff that an existing child resource can now return `403` when the user cannot read its parent. A missing resource still returns `404`. Published requirement information remains readable according to the existing policy. Sensitive child responses are not cached. No configuration or data migration is required.
+<!-- operator-upgrade:source pr-1037 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #1037
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/31945772708

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1039)
<!-- Reviewable:end -->
