### PR TITLE
docs: persist operator upgrade notes from #1042

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -271,6 +271,11 @@ sign-in after deployment.
 Before rollout, validate the responsibility assignments for requirements specifications and requirement areas. Direct reads of child resources now use the access rules of their parent resource.
 Tell API consumers and support staff that an existing child resource can now return `403` when the user cannot read its parent. A missing resource still returns `404`. Published requirement information remains readable according to the existing policy. Sensitive child responses are not cached. No configuration or data migration is required.
 <!-- operator-upgrade:source pr-1037 end -->
+
+<!-- operator-upgrade:source pr-1042 start -->
+Before rollout, inform requirement-area authors and Reviewers that they can no longer change requirement applications or saved requirement-selection answers unless they are also the responsible author or a co-author of the requirements specification. Administrators remain allowed.
+After rollout, verify that denied attempts return `403` and that the action log and security audit log receive denial evidence.
+<!-- operator-upgrade:source pr-1042 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #1042
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/31963357242

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1055)
<!-- Reviewable:end -->
