### PR TITLE
Enforce requirement-area authorship for every requirement-selection mutation

### DIFF
--- a/app/[locale]/requirements/stewardship/requirement-selection-questions-client.tsx
+++ b/app/[locale]/requirements/stewardship/requirement-selection-questions-client.tsx
@@ -53,6 +53,7 @@ interface RequirementArea {
   description: string | null
   id: number
   name: string
+  permissions: { canAuthor: boolean }
   prefix: string
 }
 
@@ -130,6 +131,7 @@ interface RequirementSelectionQuestion {
   id: number
   isActive: boolean
   isArchived: boolean
+  permissions: { canManage: boolean }
   questionCode: string
   selectionType: SelectionType
   sortOrder: number
@@ -1446,6 +1448,11 @@ export default function RequirementSelectionQuestionsClient() {
     })
   }, [areaFilter, questionSearch, questions, statusFilter])
 
+  const authorableAreas = useMemo(
+    () => areas.filter(area => area.permissions.canAuthor),
+    [areas],
+  )
+
   const isQuestionReorderFiltered =
     questionSearch.trim().length > 0 || statusFilter !== ''
 
@@ -2626,7 +2633,7 @@ export default function RequirementSelectionQuestionsClient() {
             value={questionForm.areaId}
           >
             <option value="">-</option>
-            {areas.map(area => (
+            {(isEditingQuestion ? areas : authorableAreas).map(area => (
               <option key={area.id} value={area.id}>
                 {area.prefix} {area.name}
               </option>
@@ -3581,17 +3588,21 @@ export default function RequirementSelectionQuestionsClient() {
         <FloatingActionRail
           anchorRef={listAnchorRef}
           developerModeContext="requirementSelectionQuestions"
-          items={[
-            {
-              ariaLabel: copy.createQuestion,
-              developerModeValue: 'new requirement selection question',
-              disabled: submitting,
-              icon: <Plus aria-hidden="true" className="h-4 w-4" />,
-              id: 'create',
-              onClick: openQuestionForm,
-              variant: 'primary',
-            },
-          ]}
+          items={
+            authorableAreas.length > 0
+              ? [
+                  {
+                    ariaLabel: copy.createQuestion,
+                    developerModeValue: 'new requirement selection question',
+                    disabled: submitting,
+                    icon: <Plus aria-hidden="true" className="h-4 w-4" />,
+                    id: 'create',
+                    onClick: openQuestionForm,
+                    variant: 'primary' as const,
+                  },
+                ]
+              : []
+          }
         />
         <FormModal
           closeDisabled={submitting}
@@ -3751,6 +3762,7 @@ export default function RequirementSelectionQuestionsClient() {
                       const hierarchyCount =
                         hierarchyBadgeCounts.get(question.id) ?? 0
                       const questionReorderEnabled =
+                        question.permissions.canManage &&
                         !submitting &&
                         !isQuestionReorderFiltered &&
                         group.questions.length > 1
@@ -3797,59 +3809,65 @@ export default function RequirementSelectionQuestionsClient() {
                                 : ''
                             }`}
                           >
-                            <button
-                              aria-describedby={`kuf-question-reorder-hint-${question.id}`}
-                              aria-label={copy.reorderQuestion}
-                              className="inline-flex min-h-16 w-11 shrink-0 touch-none select-none self-stretch items-center justify-center border-r border-secondary-200 p-0 text-secondary-700 transition-colors hover:bg-secondary-50 hover:text-secondary-950 disabled:cursor-not-allowed disabled:opacity-40 dark:border-secondary-800 dark:text-secondary-200 dark:hover:bg-secondary-800 dark:hover:text-secondary-50"
-                              data-question-drag-handle="true"
-                              disabled={!questionReorderEnabled}
-                              onKeyDown={event =>
-                                handleQuestionReorderKeyDown(
-                                  event,
-                                  group.questions,
-                                  question,
-                                )
-                              }
-                              onPointerCancel={
-                                handleQuestionDragHandlePointerCancel
-                              }
-                              onPointerDown={event =>
-                                handleQuestionDragHandlePointerDown(
-                                  event,
-                                  group.questions,
-                                  question,
-                                )
-                              }
-                              onPointerMove={
-                                handleQuestionDragHandlePointerMove
-                              }
-                              onPointerUp={handleQuestionDragHandlePointerUp}
-                              title={questionReorderHint}
-                              type="button"
-                              {...devMarker({
-                                context: 'requirementSelectionQuestions',
-                                name: 'question reorder handle',
-                                value: question.questionCode,
-                              })}
-                            >
-                              <span
-                                aria-hidden="true"
-                                className="flex h-full min-h-16 w-full cursor-grab items-center justify-center active:cursor-grabbing"
-                                data-question-drag-handle="true"
-                                role="presentation"
-                              >
-                                <GripVertical
-                                  aria-hidden="true"
-                                  className="h-4 w-4"
-                                />
-                              </span>
-                            </button>
-                            <span
-                              className="sr-only"
-                              id={`kuf-question-reorder-hint-${question.id}`}
-                            >
-                              {questionReorderHint}
-                            </span>
+                            {question.permissions.canManage ? (
+                              <>
+                                <button
+                                  aria-describedby={`kuf-question-reorder-hint-${question.id}`}
+                                  aria-label={copy.reorderQuestion}
+                                  className="inline-flex min-h-16 w-11 shrink-0 touch-none select-none self-stretch items-center justify-center border-r border-secondary-200 p-0 text-secondary-700 transition-colors hover:bg-secondary-50 hover:text-secondary-950 disabled:cursor-not-allowed disabled:opacity-40 dark:border-secondary-800 dark:text-secondary-200 dark:hover:bg-secondary-800 dark:hover:text-secondary-50"
+                                  data-question-drag-handle="true"
+                                  disabled={!questionReorderEnabled}
+                                  onKeyDown={event =>
+                                    handleQuestionReorderKeyDown(
+                                      event,
+                                      group.questions,
+                                      question,
+                                    )
+                                  }
+                                  onPointerCancel={
+                                    handleQuestionDragHandlePointerCancel
+                                  }
+                                  onPointerDown={event =>
+                                    handleQuestionDragHandlePointerDown(
+                                      event,
+                                      group.questions,
+                                      question,
+                                    )
+                                  }
+                                  onPointerMove={
+                                    handleQuestionDragHandlePointerMove
+                                  }
+                                  onPointerUp={
+                                    handleQuestionDragHandlePointerUp
+                                  }
+                                  title={questionReorderHint}
+                                  type="button"
+                                  {...devMarker({
+                                    context: 'requirementSelectionQuestions',
+                                    name: 'question reorder handle',
+                                    value: question.questionCode,
+                                  })}
+                                >
+                                  <span
+                                    aria-hidden="true"
+                                    className="flex h-full min-h-16 w-full cursor-grab items-center justify-center active:cursor-grabbing"
+                                    data-question-drag-handle="true"
+                                    role="presentation"
+                                  >
+                                    <GripVertical
+                                      aria-hidden="true"
+                                      className="h-4 w-4"
+                                    />
+                                  </span>
+                                </button>
+                                <span
+                                  className="sr-only"
+                                  id={`kuf-question-reorder-hint-${question.id}`}
+                                >
+                                  {questionReorderHint}
+                                </span>
+                              </>
+                            ) : null}
                             <button
                               aria-controls={detailsId}
                               aria-expanded={isExpanded}
@@ -3958,129 +3976,132 @@ export default function RequirementSelectionQuestionsClient() {
                                     {question.helpText}
                                   </p>
                                 )}
-                                <div className="mt-3 flex flex-wrap gap-2">
-                                  <button
-                                    className="inline-flex min-h-10 items-center gap-1 rounded-lg border px-3 text-sm disabled:opacity-50"
-                                    disabled={submitting}
-                                    onClick={() =>
-                                      openQuestionEditForm(question)
-                                    }
-                                    type="button"
-                                  >
-                                    <Pencil
-                                      aria-hidden="true"
-                                      className="h-4 w-4"
-                                    />
-                                    {copy.edit}
-                                  </button>
-                                  <button
-                                    className="inline-flex min-h-10 items-center gap-1 rounded-lg border px-3 text-sm disabled:opacity-50"
-                                    disabled={submitting}
-                                    onClick={() =>
-                                      openVisibilityPanel(question)
-                                    }
-                                    type="button"
-                                  >
-                                    <Eye
-                                      aria-hidden="true"
-                                      className="h-4 w-4"
-                                    />
-                                    {copy.visibilityButtonText}
-                                  </button>
-                                  <button
-                                    className="inline-flex min-h-10 items-center gap-1 rounded-lg border px-3 text-sm disabled:opacity-50"
-                                    disabled={submitting}
-                                    onClick={() =>
-                                      questionAction(
-                                        question,
-                                        question.isActive
-                                          ? 'deactivate'
-                                          : 'activate',
-                                      )
-                                    }
-                                    type="button"
-                                  >
-                                    {question.isActive ? (
-                                      <PauseCircle
+                                {question.permissions.canManage ? (
+                                  <div className="mt-3 flex flex-wrap gap-2">
+                                    <button
+                                      className="inline-flex min-h-10 items-center gap-1 rounded-lg border px-3 text-sm disabled:opacity-50"
+                                      disabled={submitting}
+                                      onClick={() =>
+                                        openQuestionEditForm(question)
+                                      }
+                                      type="button"
+                                    >
+                                      <Pencil
                                         aria-hidden="true"
                                         className="h-4 w-4"
                                       />
-                                    ) : (
-                                      <CheckCircle2
+                                      {copy.edit}
+                                    </button>
+                                    <button
+                                      className="inline-flex min-h-10 items-center gap-1 rounded-lg border px-3 text-sm disabled:opacity-50"
+                                      disabled={submitting}
+                                      onClick={() =>
+                                        openVisibilityPanel(question)
+                                      }
+                                      type="button"
+                                    >
+                                      <Eye
                                         aria-hidden="true"
                                         className="h-4 w-4"
                                       />
-                                    )}
-                                    {question.isActive
-                                      ? copy.deactivate
-                                      : copy.activate}
-                                  </button>
-                                  <button
-                                    className="inline-flex min-h-10 items-center gap-1 rounded-lg border px-3 text-sm disabled:opacity-50"
-                                    disabled={submitting}
-                                    onClick={event =>
-                                      questionAction(
-                                        question,
-                                        question.isArchived
-                                          ? 'reactivate'
-                                          : 'archive',
-                                        event.currentTarget,
-                                      )
-                                    }
-                                    type="button"
-                                  >
-                                    {question.isArchived ? (
-                                      <RotateCcw
+                                      {copy.visibilityButtonText}
+                                    </button>
+                                    <button
+                                      className="inline-flex min-h-10 items-center gap-1 rounded-lg border px-3 text-sm disabled:opacity-50"
+                                      disabled={submitting}
+                                      onClick={() =>
+                                        questionAction(
+                                          question,
+                                          question.isActive
+                                            ? 'deactivate'
+                                            : 'activate',
+                                        )
+                                      }
+                                      type="button"
+                                    >
+                                      {question.isActive ? (
+                                        <PauseCircle
+                                          aria-hidden="true"
+                                          className="h-4 w-4"
+                                        />
+                                      ) : (
+                                        <CheckCircle2
+                                          aria-hidden="true"
+                                          className="h-4 w-4"
+                                        />
+                                      )}
+                                      {question.isActive
+                                        ? copy.deactivate
+                                        : copy.activate}
+                                    </button>
+                                    <button
+                                      className="inline-flex min-h-10 items-center gap-1 rounded-lg border px-3 text-sm disabled:opacity-50"
+                                      disabled={submitting}
+                                      onClick={event =>
+                                        questionAction(
+                                          question,
+                                          question.isArchived
+                                            ? 'reactivate'
+                                            : 'archive',
+                                          event.currentTarget,
+                                        )
+                                      }
+                                      type="button"
+                                    >
+                                      {question.isArchived ? (
+                                        <RotateCcw
+                                          aria-hidden="true"
+                                          className="h-4 w-4"
+                                        />
+                                      ) : (
+                                        <Archive
+                                          aria-hidden="true"
+                                          className="h-4 w-4"
+                                        />
+                                      )}
+                                      {question.isArchived
+                                        ? copy.reactivate
+                                        : copy.archive}
+                                    </button>
+                                    <button
+                                      className="inline-flex min-h-10 items-center gap-1 rounded-lg border px-3 text-sm disabled:opacity-50"
+                                      disabled={submitting}
+                                      onClick={() =>
+                                        questionAction(question, 'duplicate')
+                                      }
+                                      type="button"
+                                    >
+                                      <Copy
                                         aria-hidden="true"
                                         className="h-4 w-4"
                                       />
-                                    ) : (
-                                      <Archive
+                                      {copy.clone}
+                                    </button>
+                                    <button
+                                      className="inline-flex min-h-10 items-center gap-1 rounded-lg border border-red-200 px-3 text-sm text-red-700 disabled:opacity-50 dark:border-red-800 dark:text-red-300"
+                                      disabled={submitting}
+                                      onClick={event =>
+                                        questionAction(
+                                          question,
+                                          'delete',
+                                          event.currentTarget,
+                                        )
+                                      }
+                                      type="button"
+                                    >
+                                      <Trash2
                                         aria-hidden="true"
                                         className="h-4 w-4"
                                       />
-                                    )}
-                                    {question.isArchived
-                                      ? copy.reactivate
-                                      : copy.archive}
-                                  </button>
-                                  <button
-                                    className="inline-flex min-h-10 items-center gap-1 rounded-lg border px-3 text-sm disabled:opacity-50"
-                                    disabled={submitting}
-                                    onClick={() =>
-                                      questionAction(question, 'duplicate')
-                                    }
-                                    type="button"
-                                  >
-                                    <Copy
-                                      aria-hidden="true"
-                                      className="h-4 w-4"
-                                    />
-                                    {copy.clone}
-                                  </button>
-                                  <button
-                                    className="inline-flex min-h-10 items-center gap-1 rounded-lg border border-red-200 px-3 text-sm text-red-700 disabled:opacity-50 dark:border-red-800 dark:text-red-300"
-                                    disabled={submitting}
-                                    onClick={event =>
-                                      questionAction(
-                                        question,
-                                        'delete',
-                                        event.currentTarget,
-                                      )
-                                    }
-                                    type="button"
-                                  >
-                                    <Trash2
-                                      aria-hidden="true"
-                                      className="h-4 w-4"
-                                    />
-                                    {copy.delete}
-                                  </button>
-                                </div>
+                                      {copy.delete}
+                                    </button>
+                                  </div>
+                                ) : null}
                                 {question.answers.length > 0 && (
                                   <ul className="mt-4 divide-y rounded-xl border dark:border-secondary-800">
                                     {question.answers.map(answer => {
                                       const answerReorderEnabled =
+                                        question.permissions.canManage &&
                                         !submitting &&
                                         question.answers.length > 1
                                       const answerDragSurfaceClass =
@@ -4148,54 +4169,64 @@ export default function RequirementSelectionQuestionsClient() {
                               but the whole answer row remains the drop target
                               and visible drag preview.
                             */}
-                                            <button
-                                              aria-describedby={`kuf-answer-reorder-hint-${answer.id}`}
-                                              aria-label={copy.reorderAnswer}
-                                              className={`inline-flex min-h-11 w-8 shrink-0 touch-none select-none self-stretch items-center justify-center rounded-lg border border-secondary-300 p-0 text-secondary-700 transition-colors hover:bg-secondary-50 hover:text-secondary-950 dark:border-secondary-700 dark:text-secondary-200 dark:hover:bg-secondary-800 dark:hover:text-secondary-50 ${
-                                                answerReorderEnabled
-                                                  ? 'cursor-grab active:cursor-grabbing'
-                                                  : 'cursor-not-allowed opacity-40'
-                                              }`}
-                                              data-answer-drag-handle="true"
-                                              disabled={!answerReorderEnabled}
-                                              onKeyDown={event =>
-                                                handleAnswerReorderKeyDown(
-                                                  event,
-                                                  question,
-                                                  answer,
-                                                )
-                                              }
-                                              onPointerCancel={
-                                                clearArmedAnswerDrag
-                                              }
-                                              onPointerDown={() =>
-                                                handleAnswerDragHandlePointerDown(
-                                                  question,
-                                                  answer,
-                                                )
-                                              }
-                                              onPointerUp={clearArmedAnswerDrag}
-                                              title={copy.reorderAnswerHint}
-                                              type="button"
-                                            >
-                                              <span
-                                                aria-hidden="true"
-                                                className="flex h-full min-h-11 w-full cursor-grab items-center justify-center active:cursor-grabbing"
-                                                data-answer-drag-handle="true"
-                                                role="presentation"
-                                              >
-                                                <GripVertical
-                                                  aria-hidden="true"
-                                                  className="h-4 w-4"
-                                                />
-                                              </span>
-                                            </button>
-                                            <span
-                                              className="sr-only"
-                                              id={`kuf-answer-reorder-hint-${answer.id}`}
-                                            >
-                                              {copy.reorderAnswerHint}
-                                            </span>
+                                            {question.permissions.canManage ? (
+                                              <>
+                                                <button
+                                                  aria-describedby={`kuf-answer-reorder-hint-${answer.id}`}
+                                                  aria-label={
+                                                    copy.reorderAnswer
+                                                  }
+                                                  className={`inline-flex min-h-11 w-8 shrink-0 touch-none select-none self-stretch items-center justify-center rounded-lg border border-secondary-300 p-0 text-secondary-700 transition-colors hover:bg-secondary-50 hover:text-secondary-950 dark:border-secondary-700 dark:text-secondary-200 dark:hover:bg-secondary-800 dark:hover:text-secondary-50 ${
+                                                    answerReorderEnabled
+                                                      ? 'cursor-grab active:cursor-grabbing'
+                                                      : 'cursor-not-allowed opacity-40'
+                                                  }`}
+                                                  data-answer-drag-handle="true"
+                                                  disabled={
+                                                    !answerReorderEnabled
+                                                  }
+                                                  onKeyDown={event =>
+                                                    handleAnswerReorderKeyDown(
+                                                      event,
+                                                      question,
+                                                      answer,
+                                                    )
+                                                  }
+                                                  onPointerCancel={
+                                                    clearArmedAnswerDrag
+                                                  }
+                                                  onPointerDown={() =>
+                                                    handleAnswerDragHandlePointerDown(
+                                                      question,
+                                                      answer,
+                                                    )
+                                                  }
+                                                  onPointerUp={
+                                                    clearArmedAnswerDrag
+                                                  }
+                                                  title={copy.reorderAnswerHint}
+                                                  type="button"
+                                                >
+                                                  <span
+                                                    aria-hidden="true"
+                                                    className="flex h-full min-h-11 w-full cursor-grab items-center justify-center active:cursor-grabbing"
+                                                    data-answer-drag-handle="true"
+                                                    role="presentation"
+                                                  >
+                                                    <GripVertical
+                                                      aria-hidden="true"
+                                                      className="h-4 w-4"
+                                                    />
+                                                  </span>
+                                                </button>
+                                                <span
+                                                  className="sr-only"
+                                                  id={`kuf-answer-reorder-hint-${answer.id}`}
+                                                >
+                                                  {copy.reorderAnswerHint}
+                                                </span>
+                                              </>
+                                            ) : null}
                                             <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                                               <div className="min-w-0 sm:flex-1">
                                                 <p className="font-medium">
@@ -4620,100 +4651,103 @@ export default function RequirementSelectionQuestionsClient() {
                                                   </span>
                                                 )}
                                               </div>
-                                              <div className="flex w-full flex-wrap gap-2 sm:w-auto sm:justify-end">
-                                                <button
-                                                  className="inline-flex min-h-11 min-w-11 items-center gap-1.5 rounded-lg border px-2 text-xs disabled:opacity-50"
-                                                  disabled={submitting}
-                                                  onClick={() =>
-                                                    editAnswer(answer)
-                                                  }
-                                                  type="button"
-                                                >
-                                                  <Pencil
-                                                    aria-hidden="true"
-                                                    className="h-4 w-4"
-                                                  />
-                                                  {copy.edit}
-                                                </button>
-                                                <button
-                                                  className="inline-flex min-h-11 min-w-11 items-center gap-1.5 rounded-lg border px-2 text-xs disabled:opacity-50"
-                                                  disabled={submitting}
-                                                  onClick={() =>
-                                                    answerAction(
-                                                      question,
-                                                      answer,
-                                                      answer.isActive
-                                                        ? 'deactivate'
-                                                        : 'activate',
-                                                    )
-                                                  }
-                                                  type="button"
-                                                >
-                                                  {answer.isActive ? (
-                                                    <PauseCircle
+                                              {question.permissions
+                                                .canManage ? (
+                                                <div className="flex w-full flex-wrap gap-2 sm:w-auto sm:justify-end">
+                                                  <button
+                                                    className="inline-flex min-h-11 min-w-11 items-center gap-1.5 rounded-lg border px-2 text-xs disabled:opacity-50"
+                                                    disabled={submitting}
+                                                    onClick={() =>
+                                                      editAnswer(answer)
+                                                    }
+                                                    type="button"
+                                                  >
+                                                    <Pencil
                                                       aria-hidden="true"
                                                       className="h-4 w-4"
                                                     />
-                                                  ) : (
-                                                    <CheckCircle2
+                                                    {copy.edit}
+                                                  </button>
+                                                  <button
+                                                    className="inline-flex min-h-11 min-w-11 items-center gap-1.5 rounded-lg border px-2 text-xs disabled:opacity-50"
+                                                    disabled={submitting}
+                                                    onClick={() =>
+                                                      answerAction(
+                                                        question,
+                                                        answer,
+                                                        answer.isActive
+                                                          ? 'deactivate'
+                                                          : 'activate',
+                                                      )
+                                                    }
+                                                    type="button"
+                                                  >
+                                                    {answer.isActive ? (
+                                                      <PauseCircle
+                                                        aria-hidden="true"
+                                                        className="h-4 w-4"
+                                                      />
+                                                    ) : (
+                                                      <CheckCircle2
+                                                        aria-hidden="true"
+                                                        className="h-4 w-4"
+                                                      />
+                                                    )}
+                                                    {answer.isActive
+                                                      ? copy.deactivate
+                                                      : copy.activate}
+                                                  </button>
+                                                  <button
+                                                    className="inline-flex min-h-11 min-w-11 items-center gap-1.5 rounded-lg border px-2 text-xs disabled:opacity-50"
+                                                    disabled={submitting}
+                                                    onClick={event =>
+                                                      answerAction(
+                                                        question,
+                                                        answer,
+                                                        answer.isArchived
+                                                          ? 'reactivate'
+                                                          : 'archive',
+                                                        event.currentTarget,
+                                                      )
+                                                    }
+                                                    type="button"
+                                                  >
+                                                    {answer.isArchived ? (
+                                                      <RotateCcw
+                                                        aria-hidden="true"
+                                                        className="h-4 w-4"
+                                                      />
+                                                    ) : (
+                                                      <Archive
+                                                        aria-hidden="true"
+                                                        className="h-4 w-4"
+                                                      />
+                                                    )}
+                                                    {answer.isArchived
+                                                      ? copy.reactivate
+                                                      : copy.archive}
+                                                  </button>
+                                                  <button
+                                                    className="inline-flex min-h-11 min-w-11 items-center gap-1.5 rounded-lg border border-red-200 px-2 text-xs text-red-700 disabled:opacity-50 dark:border-red-800 dark:text-red-300"
+                                                    disabled={submitting}
+                                                    onClick={event =>
+                                                      answerAction(
+                                                        question,
+                                                        answer,
+                                                        'delete',
+                                                        event.currentTarget,
+                                                      )
+                                                    }
+                                                    type="button"
+                                                  >
+                                                    <Trash2
                                                       aria-hidden="true"
                                                       className="h-4 w-4"
                                                     />
-                                                  )}
-                                                  {answer.isActive
-                                                    ? copy.deactivate
-                                                    : copy.activate}
-                                                </button>
-                                                <button
-                                                  className="inline-flex min-h-11 min-w-11 items-center gap-1.5 rounded-lg border px-2 text-xs disabled:opacity-50"
-                                                  disabled={submitting}
-                                                  onClick={event =>
-                                                    answerAction(
-                                                      question,
-                                                      answer,
-                                                      answer.isArchived
-                                                        ? 'reactivate'
-                                                        : 'archive',
-                                                      event.currentTarget,
-                                                    )
-                                                  }
-                                                  type="button"
-                                                >
-                                                  {answer.isArchived ? (
-                                                    <RotateCcw
-                                                      aria-hidden="true"
-                                                      className="h-4 w-4"
-                                                    />
-                                                  ) : (
-                                                    <Archive
-                                                      aria-hidden="true"
-                                                      className="h-4 w-4"
-                                                    />
-                                                  )}
-                                                  {answer.isArchived
-                                                    ? copy.reactivate
-                                                    : copy.archive}
-                                                </button>
-                                                <button
-                                                  className="inline-flex min-h-11 min-w-11 items-center gap-1.5 rounded-lg border border-red-200 px-2 text-xs text-red-700 disabled:opacity-50 dark:border-red-800 dark:text-red-300"
-                                                  disabled={submitting}
-                                                  onClick={event =>
-                                                    answerAction(
-                                                      question,
-                                                      answer,
-                                                      'delete',
-                                                      event.currentTarget,
-                                                    )
-                                                  }
-                                                  type="button"
-                                                >
-                                                  <Trash2
-                                                    aria-hidden="true"
-                                                    className="h-4 w-4"
-                                                  />
-                                                  {copy.delete}
-                                                </button>
-                                              </div>
+                                                    {copy.delete}
+                                                  </button>
+                                                </div>
+                                              ) : null}
                                             </div>
                                           </div>
                                         </li>
@@ -4721,31 +4755,35 @@ export default function RequirementSelectionQuestionsClient() {
                                     })}
                                   </ul>
                                 )}
-                                <div
-                                  className={
-                                    question.answers.length > 0
-                                      ? 'mt-3'
-                                      : 'mt-4'
-                                  }
-                                >
-                                  <button
-                                    className="inline-flex min-h-11 min-w-11 items-center gap-1.5 rounded-lg border px-3 text-sm font-medium text-secondary-800 transition-colors hover:bg-secondary-50 disabled:opacity-50 dark:border-secondary-700 dark:text-secondary-100 dark:hover:bg-secondary-800"
-                                    disabled={submitting}
-                                    onClick={() => openAnswerForm(question)}
-                                    type="button"
-                                    {...devMarker({
-                                      context: 'requirementSelectionQuestions',
-                                      name: 'button',
-                                      value: 'new requirement selection answer',
-                                    })}
+                                {question.permissions.canManage ? (
+                                  <div
+                                    className={
+                                      question.answers.length > 0
+                                        ? 'mt-3'
+                                        : 'mt-4'
+                                    }
                                   >
-                                    <Plus
-                                      aria-hidden="true"
-                                      className="h-4 w-4"
-                                    />
-                                    {copy.addAnswer}
-                                  </button>
-                                </div>
+                                    <button
+                                      className="inline-flex min-h-11 min-w-11 items-center gap-1.5 rounded-lg border px-3 text-sm font-medium text-secondary-800 transition-colors hover:bg-secondary-50 disabled:opacity-50 dark:border-secondary-700 dark:text-secondary-100 dark:hover:bg-secondary-800"
+                                      disabled={submitting}
+                                      onClick={() => openAnswerForm(question)}
+                                      type="button"
+                                      {...devMarker({
+                                        context:
+                                          'requirementSelectionQuestions',
+                                        name: 'button',
+                                        value:
+                                          'new requirement selection answer',
+                                      })}
+                                    >
+                                      <Plus
+                                        aria-hidden="true"
+                                        className="h-4 w-4"
+                                      />
+                                      {copy.addAnswer}
+                                    </button>
+                                  </div>
+                                ) : null}
                               </div>
                               {visibilityPanelQuestionId === question.id ? (
                                 <aside

--- a/app/api/requirement-selection-questions/[id]/_state.ts
+++ b/app/api/requirement-selection-questions/[id]/_state.ts
@@ -6,10 +6,8 @@ import {
   setRequirementSelectionQuestionState,
 } from '@/lib/dal/requirement-selection-questions'
 import { getRequestSqlServerDataSource } from '@/lib/db'
-import {
-  authenticatedMutationPolicy,
-  secureMutationRoute,
-} from '@/lib/http/secure-mutation-route'
+import { secureMutationRoute } from '@/lib/http/secure-mutation-route'
+import { requirementSelectionQuestionPolicy } from '../_authorization'
 import { questionRouteParamsSchema } from '../_schemas'
 
 export function questionStateRoute(
@@ -17,27 +15,25 @@ export function questionStateRoute(
 ) {
   return secureMutationRoute({
     paramsSchema: questionRouteParamsSchema,
-    policy: authenticatedMutationPolicy(
-      `requirement_selection_question.${operation}`,
-    ),
-    handler: async ({ context, params }) => {
-      const db = await getRequestSqlServerDataSource()
+    policy: requirementSelectionQuestionPolicy(operation),
+    handler: async ({ context, db, params }) => {
+      const activeDb = db ?? (await getRequestSqlServerDataSource())
       const questionId = await resolveRequirementSelectionQuestionId(
-        db,
+        activeDb,
         params.id,
       )
       if (questionId == null) {
         return NextResponse.json({ error: 'Not found' }, { status: 404 })
       }
       const question = (await setRequirementSelectionQuestionState(
-        db,
+        activeDb,
         questionId,
         operation,
       )) as RequirementSelectionQuestionRow | null
       if (!question) {
         return NextResponse.json({ error: 'Not found' }, { status: 404 })
       }
-      await recordAllowedActionAuditEvent(db, context, {
+      await recordAllowedActionAuditEvent(activeDb, context, {
         action: `requirement_selection_question.${operation}`,
         targetId: question.id,
         targetKind: 'requirement_selection_question',

--- a/app/api/requirement-selection-questions/[id]/answers/[answerId]/_state.ts
+++ b/app/api/requirement-selection-questions/[id]/answers/[answerId]/_state.ts
@@ -5,10 +5,8 @@ import {
   setRequirementSelectionAnswerState,
 } from '@/lib/dal/requirement-selection-questions'
 import { getRequestSqlServerDataSource } from '@/lib/db'
-import {
-  authenticatedMutationPolicy,
-  secureMutationRoute,
-} from '@/lib/http/secure-mutation-route'
+import { secureMutationRoute } from '@/lib/http/secure-mutation-route'
+import { requirementSelectionAnswerPolicy } from '../../../_authorization'
 import { answerRouteParamsSchema } from '../../../_schemas'
 
 export function answerStateRoute(
@@ -16,20 +14,18 @@ export function answerStateRoute(
 ) {
   return secureMutationRoute({
     paramsSchema: answerRouteParamsSchema,
-    policy: authenticatedMutationPolicy(
-      `requirement_selection_answer.${operation}`,
-    ),
-    handler: async ({ context, params }) => {
-      const db = await getRequestSqlServerDataSource()
+    policy: requirementSelectionAnswerPolicy(`answer.${operation}`),
+    handler: async ({ context, db, params }) => {
+      const activeDb = db ?? (await getRequestSqlServerDataSource())
       const questionId = await resolveRequirementSelectionQuestionId(
-        db,
+        activeDb,
         params.id,
       )
       if (questionId == null) {
         return NextResponse.json({ error: 'Not found' }, { status: 404 })
       }
       const question = await setRequirementSelectionAnswerState(
-        db,
+        activeDb,
         questionId,
         params.answerId,
         operation,
@@ -37,7 +33,7 @@ export function answerStateRoute(
       if (!question) {
         return NextResponse.json({ error: 'Not found' }, { status: 404 })
       }
-      await recordAllowedActionAuditEvent(db, context, {
+      await recordAllowedActionAuditEvent(activeDb, context, {
         action: `requirement_selection_answer.${operation}`,
         details: { questionId },
         targetId: params.answerId,

--- a/app/api/requirement-selection-questions/[id]/answers/[answerId]/route.ts
+++ b/app/api/requirement-selection-questions/[id]/answers/[answerId]/route.ts
@@ -6,27 +6,25 @@ import {
   updateRequirementSelectionAnswer,
 } from '@/lib/dal/requirement-selection-questions'
 import { getRequestSqlServerDataSource } from '@/lib/db'
-import {
-  authenticatedMutationPolicy,
-  secureMutationRoute,
-} from '@/lib/http/secure-mutation-route'
+import { secureMutationRoute } from '@/lib/http/secure-mutation-route'
+import { requirementSelectionAnswerPolicy } from '../../../_authorization'
 import { answerRouteParamsSchema, answerUpdateSchema } from '../../../_schemas'
 
 export const PUT = secureMutationRoute({
   bodySchema: answerUpdateSchema,
   paramsSchema: answerRouteParamsSchema,
-  policy: authenticatedMutationPolicy('requirement_selection_answer.update'),
-  handler: async ({ body, context, params }) => {
-    const db = await getRequestSqlServerDataSource()
+  policy: requirementSelectionAnswerPolicy('answer.update'),
+  handler: async ({ body, context, db, params }) => {
+    const activeDb = db ?? (await getRequestSqlServerDataSource())
     const questionId = await resolveRequirementSelectionQuestionId(
-      db,
+      activeDb,
       params.id,
     )
     if (questionId == null) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
     const question = await updateRequirementSelectionAnswer(
-      db,
+      activeDb,
       questionId,
       params.answerId,
       body,
@@ -34,7 +32,7 @@ export const PUT = secureMutationRoute({
     if (!question) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
-    await recordAllowedActionAuditEvent(db, context, {
+    await recordAllowedActionAuditEvent(activeDb, context, {
       action: 'requirement_selection_answer.update',
       details: {
         answerId: params.answerId,
@@ -50,18 +48,18 @@ export const PUT = secureMutationRoute({
 
 export const DELETE = secureMutationRoute({
   paramsSchema: answerRouteParamsSchema,
-  policy: authenticatedMutationPolicy('requirement_selection_answer.delete'),
-  handler: async ({ context, params }) => {
-    const db = await getRequestSqlServerDataSource()
+  policy: requirementSelectionAnswerPolicy('answer.delete'),
+  handler: async ({ context, db, params }) => {
+    const activeDb = db ?? (await getRequestSqlServerDataSource())
     const questionId = await resolveRequirementSelectionQuestionId(
-      db,
+      activeDb,
       params.id,
     )
     if (questionId == null) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
     const result = await deleteRequirementSelectionAnswer(
-      db,
+      activeDb,
       questionId,
       params.answerId,
     )
@@ -74,7 +72,7 @@ export const DELETE = secureMutationRoute({
         { status: 409 },
       )
     }
-    await recordAllowedActionAuditEvent(db, context, {
+    await recordAllowedActionAuditEvent(activeDb, context, {
       action: 'requirement_selection_answer.delete',
       details: { questionId },
       targetId: params.answerId,

--- a/app/api/requirement-selection-questions/[id]/answers/route.ts
+++ b/app/api/requirement-selection-questions/[id]/answers/route.ts
@@ -5,34 +5,32 @@ import {
   resolveRequirementSelectionQuestionId,
 } from '@/lib/dal/requirement-selection-questions'
 import { getRequestSqlServerDataSource } from '@/lib/db'
-import {
-  authenticatedMutationPolicy,
-  secureMutationRoute,
-} from '@/lib/http/secure-mutation-route'
+import { secureMutationRoute } from '@/lib/http/secure-mutation-route'
+import { requirementSelectionQuestionPolicy } from '../../_authorization'
 import { answerSchema, questionRouteParamsSchema } from '../../_schemas'
 
 export const POST = secureMutationRoute({
   bodySchema: answerSchema,
   paramsSchema: questionRouteParamsSchema,
-  policy: authenticatedMutationPolicy('requirement_selection_answer.create'),
-  handler: async ({ body, context, params }) => {
-    const db = await getRequestSqlServerDataSource()
+  policy: requirementSelectionQuestionPolicy('answer.create'),
+  handler: async ({ body, context, db, params }) => {
+    const activeDb = db ?? (await getRequestSqlServerDataSource())
     const questionId = await resolveRequirementSelectionQuestionId(
-      db,
+      activeDb,
       params.id,
     )
     if (questionId == null) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
     const question = await createRequirementSelectionAnswer(
-      db,
+      activeDb,
       questionId,
       body,
     )
     if (!question) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
-    await recordAllowedActionAuditEvent(db, context, {
+    await recordAllowedActionAuditEvent(activeDb, context, {
       action: 'requirement_selection_answer.create',
       details: { questionId },
       targetId: params.id,

--- a/app/api/requirement-selection-questions/[id]/answers/route.ts
+++ b/app/api/requirement-selection-questions/[id]/answers/route.ts
@@ -33,7 +33,7 @@ export const POST = secureMutationRoute({
     await recordAllowedActionAuditEvent(activeDb, context, {
       action: 'requirement_selection_answer.create',
       details: { questionId },
-      targetId: params.id,
+      targetId: questionId,
       targetKind: 'requirement_selection_question',
       targetUniqueId: question.questionCode,
     })

--- a/app/api/requirement-selection-questions/[id]/duplicate/route.ts
+++ b/app/api/requirement-selection-questions/[id]/duplicate/route.ts
@@ -5,34 +5,30 @@ import {
   resolveRequirementSelectionQuestionId,
 } from '@/lib/dal/requirement-selection-questions'
 import { getRequestSqlServerDataSource } from '@/lib/db'
-import {
-  authenticatedMutationPolicy,
-  secureMutationRoute,
-} from '@/lib/http/secure-mutation-route'
+import { secureMutationRoute } from '@/lib/http/secure-mutation-route'
+import { requirementSelectionQuestionPolicy } from '../../_authorization'
 import { questionRouteParamsSchema } from '../../_schemas'
 
 export const POST = secureMutationRoute({
   paramsSchema: questionRouteParamsSchema,
-  policy: authenticatedMutationPolicy(
-    'requirement_selection_question.duplicate',
-  ),
-  handler: async ({ context, params }) => {
-    const db = await getRequestSqlServerDataSource()
+  policy: requirementSelectionQuestionPolicy('duplicate'),
+  handler: async ({ context, db, params }) => {
+    const activeDb = db ?? (await getRequestSqlServerDataSource())
     const sourceQuestionId = await resolveRequirementSelectionQuestionId(
-      db,
+      activeDb,
       params.id,
     )
     if (sourceQuestionId == null) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
     const question = await duplicateRequirementSelectionQuestion(
-      db,
+      activeDb,
       sourceQuestionId,
     )
     if (!question) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
-    await recordAllowedActionAuditEvent(db, context, {
+    await recordAllowedActionAuditEvent(activeDb, context, {
       action: 'requirement_selection_question.duplicate',
       details: { sourceQuestionId },
       targetId: question.id,

--- a/app/api/requirement-selection-questions/[id]/route.ts
+++ b/app/api/requirement-selection-questions/[id]/route.ts
@@ -7,11 +7,9 @@ import {
   updateRequirementSelectionQuestion,
 } from '@/lib/dal/requirement-selection-questions'
 import { getRequestSqlServerDataSource } from '@/lib/db'
-import {
-  authenticatedMutationPolicy,
-  secureMutationRoute,
-} from '@/lib/http/secure-mutation-route'
+import { secureMutationRoute } from '@/lib/http/secure-mutation-route'
 import { parseRouteParams } from '@/lib/http/validation'
+import { requirementSelectionQuestionPolicy } from '../_authorization'
 import { questionRouteParamsSchema, questionUpdateSchema } from '../_schemas'
 
 type Params = Promise<{ id: string }>
@@ -36,25 +34,25 @@ export async function GET(
 export const PUT = secureMutationRoute({
   bodySchema: questionUpdateSchema,
   paramsSchema: questionRouteParamsSchema,
-  policy: authenticatedMutationPolicy('requirement_selection_question.update'),
-  handler: async ({ body, context, params }) => {
-    const db = await getRequestSqlServerDataSource()
+  policy: requirementSelectionQuestionPolicy('update'),
+  handler: async ({ body, context, db, params }) => {
+    const activeDb = db ?? (await getRequestSqlServerDataSource())
     const questionId = await resolveRequirementSelectionQuestionId(
-      db,
+      activeDb,
       params.id,
     )
     if (questionId == null) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
     const question = await updateRequirementSelectionQuestion(
-      db,
+      activeDb,
       questionId,
       body,
     )
     if (!question) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
-    await recordAllowedActionAuditEvent(db, context, {
+    await recordAllowedActionAuditEvent(activeDb, context, {
       action: 'requirement_selection_question.update',
       details: { changedFields: Object.keys(body) },
       targetId: question.id,
@@ -67,17 +65,20 @@ export const PUT = secureMutationRoute({
 
 export const DELETE = secureMutationRoute({
   paramsSchema: questionRouteParamsSchema,
-  policy: authenticatedMutationPolicy('requirement_selection_question.delete'),
-  handler: async ({ context, params }) => {
-    const db = await getRequestSqlServerDataSource()
+  policy: requirementSelectionQuestionPolicy('delete'),
+  handler: async ({ context, db, params }) => {
+    const activeDb = db ?? (await getRequestSqlServerDataSource())
     const questionId = await resolveRequirementSelectionQuestionId(
-      db,
+      activeDb,
       params.id,
     )
     if (questionId == null) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
-    const result = await deleteRequirementSelectionQuestion(db, questionId)
+    const result = await deleteRequirementSelectionQuestion(
+      activeDb,
+      questionId,
+    )
     if (result === 'not_found') {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
@@ -87,7 +88,7 @@ export const DELETE = secureMutationRoute({
         { status: 409 },
       )
     }
-    await recordAllowedActionAuditEvent(db, context, {
+    await recordAllowedActionAuditEvent(activeDb, context, {
       action: 'requirement_selection_question.delete',
       targetId: questionId,
       targetKind: 'requirement_selection_question',

--- a/app/api/requirement-selection-questions/[id]/visibility/route.ts
+++ b/app/api/requirement-selection-questions/[id]/visibility/route.ts
@@ -6,10 +6,8 @@ import {
   resolveRequirementSelectionQuestionId,
 } from '@/lib/dal/requirement-selection-questions'
 import { getRequestSqlServerDataSource } from '@/lib/db'
-import {
-  authenticatedMutationPolicy,
-  secureMutationRoute,
-} from '@/lib/http/secure-mutation-route'
+import { secureMutationRoute } from '@/lib/http/secure-mutation-route'
+import { requirementSelectionQuestionPolicy } from '../../_authorization'
 import {
   questionRouteParamsSchema,
   visibilityUpdateSchema,
@@ -18,27 +16,25 @@ import {
 export const PUT = secureMutationRoute({
   bodySchema: visibilityUpdateSchema,
   paramsSchema: questionRouteParamsSchema,
-  policy: authenticatedMutationPolicy(
-    'requirement_selection_question.visibility.update',
-  ),
-  handler: async ({ body, context, params }) => {
-    const db = await getRequestSqlServerDataSource()
+  policy: requirementSelectionQuestionPolicy('visibility.update'),
+  handler: async ({ body, context, db, params }) => {
+    const activeDb = db ?? (await getRequestSqlServerDataSource())
     const questionId = await resolveRequirementSelectionQuestionId(
-      db,
+      activeDb,
       params.id,
     )
     if (questionId == null) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
     const question = await replaceRequirementSelectionQuestionVisibilityGroups(
-      db,
+      activeDb,
       questionId,
       body.groups,
     )
     if (!question) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
-    await recordAllowedActionAuditEvent(db, context, {
+    await recordAllowedActionAuditEvent(activeDb, context, {
       action: 'requirement_selection_question.visibility.update',
       details: {
         groupCount: body.groups.length,
@@ -47,7 +43,10 @@ export const PUT = secureMutationRoute({
       targetKind: 'requirement_selection_question',
       targetUniqueId: question.questionCode,
     })
-    const refreshed = await getRequirementSelectionQuestionById(db, question.id)
+    const refreshed = await getRequirementSelectionQuestionById(
+      activeDb,
+      question.id,
+    )
     return NextResponse.json(refreshed ?? question)
   },
 })

--- a/app/api/requirement-selection-questions/_authorization.ts
+++ b/app/api/requirement-selection-questions/_authorization.ts
@@ -1,0 +1,42 @@
+import type { MutationPolicy } from '@/lib/http/secure-mutation-route'
+import { requirementsMutationPolicy } from '@/lib/http/secure-mutation-route'
+
+interface RequirementSelectionQuestionParams {
+  id: number | string
+}
+
+interface RequirementSelectionAnswerParams
+  extends RequirementSelectionQuestionParams {
+  answerId: number
+}
+
+export function requirementSelectionQuestionCreatePolicy<
+  TBody extends { areaId: number },
+>(): MutationPolicy<TBody, undefined> {
+  return requirementsMutationPolicy(({ body }) => ({
+    areaId: body.areaId,
+    kind: 'manage_requirement_selection_question',
+    operation: 'create',
+  }))
+}
+
+export function requirementSelectionQuestionPolicy<TBody = unknown>(
+  operation: string,
+): MutationPolicy<TBody, RequirementSelectionQuestionParams> {
+  return requirementsMutationPolicy(({ params }) => ({
+    kind: 'manage_requirement_selection_question',
+    operation,
+    questionId: params.id,
+  }))
+}
+
+export function requirementSelectionAnswerPolicy<TBody = unknown>(
+  operation: string,
+): MutationPolicy<TBody, RequirementSelectionAnswerParams> {
+  return requirementsMutationPolicy(({ params }) => ({
+    answerId: params.answerId,
+    kind: 'manage_requirement_selection_question',
+    operation,
+    questionId: params.id,
+  }))
+}

--- a/app/api/requirement-selection-questions/route.ts
+++ b/app/api/requirement-selection-questions/route.ts
@@ -1,19 +1,19 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { recordAllowedActionAuditEvent } from '@/lib/audit/action-audit'
+import { listAreaIdsActorCanAuthor } from '@/lib/dal/requirement-areas'
 import {
   createRequirementSelectionQuestion,
   listRequirementSelectionQuestions,
 } from '@/lib/dal/requirement-selection-questions'
 import { getRequestSqlServerDataSource } from '@/lib/db'
-import {
-  authenticatedMutationPolicy,
-  secureMutationRoute,
-} from '@/lib/http/secure-mutation-route'
+import { secureMutationRoute } from '@/lib/http/secure-mutation-route'
 import {
   positiveIntegerStringSchema,
   queryBooleanSchema,
 } from '@/lib/http/validation'
+import { createRequestContext } from '@/lib/requirements/auth'
+import { requirementSelectionQuestionCreatePolicy } from './_authorization'
 import { questionCreateSchema } from './_schemas'
 
 const querySchema = z
@@ -25,6 +25,7 @@ const querySchema = z
 
 export async function GET(request: Request) {
   const db = await getRequestSqlServerDataSource()
+  const context = await createRequestContext(request, 'rest')
   const query = querySchema.parse(
     Object.fromEntries(new URL(request.url).searchParams.entries()),
   )
@@ -32,16 +33,27 @@ export async function GET(request: Request) {
     areaId: query.areaId,
     includeArchived: query.includeArchived,
   })
-  return NextResponse.json({ questions })
+  const isAdmin = context.actor.roles.includes('Admin')
+  const authoredAreaIds = isAdmin
+    ? null
+    : new Set(await listAreaIdsActorCanAuthor(db, context.actor.hsaId))
+  return NextResponse.json({
+    questions: questions.map(question => ({
+      ...question,
+      permissions: {
+        canManage: isAdmin || authoredAreaIds?.has(question.areaId) === true,
+      },
+    })),
+  })
 }
 
 export const POST = secureMutationRoute({
   bodySchema: questionCreateSchema,
-  policy: authenticatedMutationPolicy('requirement_selection_question.create'),
-  handler: async ({ body, context }) => {
-    const db = await getRequestSqlServerDataSource()
-    const question = await createRequirementSelectionQuestion(db, body)
-    await recordAllowedActionAuditEvent(db, context, {
+  policy: requirementSelectionQuestionCreatePolicy(),
+  handler: async ({ body, context, db }) => {
+    const activeDb = db ?? (await getRequestSqlServerDataSource())
+    const question = await createRequirementSelectionQuestion(activeDb, body)
+    await recordAllowedActionAuditEvent(activeDb, context, {
       action: 'requirement_selection_question.create',
       details: {
         areaId: question.areaId,

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -876,6 +876,7 @@
     "kravbibliotekets",
     "kravbiblioteksförvaltning",
     "kravbiblioteksförvaltningen",
+    "kravbiblioteksförvaltningens",
     "kravbiblioteksdelen",
     "kravbiblioteksnära",
     "kravbibliotekssammanhang",

--- a/docs/adr/0003-kravurvalsfragor-som-filter-i-kravbiblioteksforvaltningen.md
+++ b/docs/adr/0003-kravurvalsfragor-som-filter-i-kravbiblioteksforvaltningen.md
@@ -4,13 +4,13 @@ Status: Antagen 2026-05-31.
 
 Kravurvalsfrågor är kravområdesägt innehåll i kravbiblioteksförvaltningen, inte
 referensdata i Admin Center och inte ett nytt flöde för att lägga till krav.
-Målbilden för behörigheter är att kravområdesägare,
-kravområdesmedförfattare och användare med `Admin` underhåller frågorna, medan
-kravunderlagsansvariga och kravunderlagsmedförfattare besvarar dem i ett
-kravunderlag. Den första implementationen kräver medvetet bara autentisering
-för dessa nya skrivningar tills det uppdragsbaserade RBAC-arbetet finns på
-plats; det är en tillfällig implementationsbegränsning, inte domänens
-behörighetsmodell.
+Kravområdesägare, kravområdesmedförfattare och användare med `Admin`
+underhåller frågorna, medan kravunderlagsansvariga och
+kravunderlagsmedförfattare besvarar dem i ett kravunderlag. Alla skrivningar
+av frågor, svar, synlighetsvillkor, ordning och livscykel kontrolleras mot
+frågans lagrade kravområde. Vid skapande kontrolleras det begärda
+kravområdet. Ett kravurvalssvar måste dessutom tillhöra den angivna frågan
+innan en ändring får genomföras.
 
 Valda kravurvalssvar bevarar kravurvalssammanhanget för kravunderlaget och kan
 bilda ett kravurvalsfilter över den befintliga listan `Available

--- a/docs/adr/0012-uppdragsbaserad-rbac.md
+++ b/docs/adr/0012-uppdragsbaserad-rbac.md
@@ -45,10 +45,15 @@ kravunderlag returnerar `404`. Kravunderlagsansvarig och
 kravunderlagsmedförfattare får ändra kravunderlagets innehåll; bara
 kravunderlagsansvarig och `Admin` får ändra kravunderlagets uppdrag.
 
-Kravurvalsfrågor hör till kravområdet. Sparade kravurvalssvar hör till
-kravunderlaget. Förbättringsförslag kan skapas och ändras av inloggade
-användare, medan lösning eller beslut att avvisa kräver författare i
-kravområdet eller `Admin`. Egen lösning högriskloggas.
+Kravurvalsfrågor och deras förvaltade svar hör till kravområdet. Alla
+förvaltningsskrivningar använder frågans lagrade kravområde och kräver
+kravområdesägare, kravområdesmedförfattare eller `Admin`. Ett svar slås upp
+tillsammans med sin lagrade fråga innan ändringen, så ett anrop kan inte flytta
+behörighetskontrollen genom att ange en annan frågeidentifierare. Sparade
+kravurvalssvar i ett kravunderlag hör däremot till kravunderlaget.
+Förbättringsförslag kan skapas och ändras av inloggade användare, medan
+lösning eller beslut att avvisa kräver författare i kravområdet eller `Admin`.
+Egen lösning högriskloggas.
 
 AI-assisterat författande styrs av den generella autentiserings- och
 auktoriseringsgränsen och har ingen separat AI-behörighet i nuvarande modell.

--- a/docs/governance/behörigheter.md
+++ b/docs/governance/behörigheter.md
@@ -224,6 +224,15 @@ arkiveringsflöden kräver däremot `Reviewer`; `Admin` räcker inte ensamt för
 sådana beslut. En `Reviewer` får besluta om sitt eget förslag eller avsteg,
 men tjänsten loggar detta som en högriskhändelse.
 
+För kravurvalsfrågor omfattar författarbehörigheten skapande, redigering,
+duplicering, ordning, synlighetsvillkor, svar och livscykel. Vid skapande
+kontrolleras det begärda kravområdet. Övriga åtgärder slår upp frågans lagrade
+kravområde, och svar måste tillhöra den angivna frågan. Ett nekat anrop ger
+`403` före domänskrivning och tillåten åtgärdsloggning. Nekandet lämnar
+auktoriseringsevidens utan fråga-, svars- eller annan känslig fritext. Den som
+får läsa men inte författa ser en skrivskyddad förvaltningsyta utan
+mutationskontroller.
+
 Förbättringsförslag kan skapas och ändras av inloggade användare. Att lösa ett
 förslag eller besluta att avvisa det kräver författarbehörighet i kravområdet
 eller `Admin`. Egen lösning loggas som högriskhändelse.

--- a/docs/governance/manuella-testfall.md
+++ b/docs/governance/manuella-testfall.md
@@ -572,11 +572,14 @@ upp, men fel föräldrakombination ger 403 även för `Admin`.
 1. Utför en tillåten granskningsåtgärd.
 1. Läs ett enskilt kravunderlagsavsteg via dess direkta API-identifierare och
    försök kombinera ett lokalt krav med fel befintligt kravunderlag.
+1. Öppna kravbiblioteksförvaltningens kravurvalsfrågor och expandera en fråga.
 1. Försök öppna Admincenter, dataskydd och ansvarstilldelnings-API.
 
 **Förväntat resultat:** Rita kan utföra granskningsarbete men nekas Admin,
 dataskydd och ansvarsstyrning. Underresursen kan läsas efter föräldrauppslag,
-men fel föräldrakombination ger 403 även för `Reviewer`.
+men fel föräldrakombination ger 403 även för `Reviewer`. Kravurvalsfrågorna
+kan läsas, men ytan visar inga kontroller för att skapa, ändra, ordna,
+duplicera, arkivera eller ta bort frågor eller svar.
 
 <a id="authz-10-dataskyddshandlaggare"></a>
 

--- a/docs/governance/requirements-ui-behaviour.md
+++ b/docs/governance/requirements-ui-behaviour.md
@@ -832,6 +832,11 @@ down.
 
 ## Requirement Selection Question Stewardship
 
+- The server marks each question with whether the current actor may manage its
+  stored requirement area. Requirement-area owners, co-authors and `Admin` see
+  the applicable create, edit, reorder, visibility, answer and lifecycle
+  controls. Other users keep the read-only question, hierarchy and requirement
+  preview surfaces, but are not offered mutation controls.
 - The stewardship route loads only the selected workspace's client code.
   Direct query links, remembered selection, workspace switching, and browser
   back/forward navigation resolve the selected workspace before rendering, so

--- a/lib/requirements/assignment-authorization.ts
+++ b/lib/requirements/assignment-authorization.ts
@@ -56,6 +56,12 @@ export interface AssignmentLookup {
       { kind: 'manage_requirement_applications' }
     >,
   ): Promise<number>
+  resolveRequirementSelectionQuestionArea(
+    action: Extract<
+      RequirementsAction,
+      { kind: 'manage_requirement_selection_question' }
+    >,
+  ): Promise<number>
   resolveRequirementTarget(
     input: RequirementReference,
   ): Promise<RequirementTarget>
@@ -125,6 +131,7 @@ function isAssignmentLookup(value: unknown): value is AssignmentLookup {
     'isRequirementAreaAuthor' in value &&
     'isSpecificationAuthor' in value &&
     'resolveRequirementApplicationMutationTarget' in value &&
+    'resolveRequirementSelectionQuestionArea' in value &&
     'resolveRequirementTarget' in value &&
     'resolveSpecificationChildTarget' in value &&
     'resolveSuggestionRequirementTarget' in value
@@ -570,6 +577,56 @@ export class SqlAssignmentLookup implements AssignmentLookup {
     })
   }
 
+  async resolveRequirementSelectionQuestionArea(
+    action: Extract<
+      RequirementsAction,
+      { kind: 'manage_requirement_selection_question' }
+    >,
+  ): Promise<number> {
+    if (action.operation === 'create') {
+      if (action.areaId != null) return action.areaId
+      throw validationError('Missing requirement selection question area', {
+        reason: 'missing_requirement_selection_question_area',
+      })
+    }
+    if (action.questionId == null) {
+      throw validationError('Missing requirement selection question target', {
+        reason: 'missing_requirement_selection_question_target',
+      })
+    }
+
+    const db = await this.getDb()
+    const questionIdIsNumeric =
+      typeof action.questionId === 'number' || /^\d+$/.test(action.questionId)
+    const questionPredicate = questionIdIsNumeric
+      ? 'question.id = @0'
+      : 'question.question_code = @0'
+    const answerJoin =
+      action.answerId == null
+        ? ''
+        : `INNER JOIN requirement_selection_answers answer
+          ON answer.question_id = question.id AND answer.id = @1`
+    const parameters =
+      action.answerId == null
+        ? [action.questionId]
+        : [action.questionId, action.answerId]
+    const rows = (await db.query(
+      `
+        SELECT TOP (1) question.area_id AS areaId
+        FROM requirement_selection_questions question
+        ${answerJoin}
+        WHERE ${questionPredicate}
+      `,
+      parameters,
+    )) as Array<Record<string, unknown>>
+    const areaId = firstNumber(rows, 'areaId')
+    if (areaId != null) return areaId
+    throw notFoundError('Requirement selection question target not found', {
+      answerId: action.answerId,
+      questionId: action.questionId,
+    })
+  }
+
   async resolveRfiQuestionSuggestionArea(
     action: Extract<
       RequirementsAction,
@@ -636,6 +693,12 @@ export class AssignmentBasedAuthorizationService
         await this.lookup.resolveRequirementApplicationMutationTarget(action)
       if (hasRole(context, 'Admin')) return
       return this.assertSpecificationAuthor(context, specificationId)
+    }
+    if (action.kind === 'manage_requirement_selection_question') {
+      const areaId =
+        await this.lookup.resolveRequirementSelectionQuestionArea(action)
+      if (hasRole(context, 'Admin')) return
+      return this.assertAreaAuthor(context, areaId)
     }
 
     if (hasRole(context, 'Admin') && !this.isReviewerOnlyAction(action)) {

--- a/lib/requirements/auth.ts
+++ b/lib/requirements/auth.ts
@@ -230,6 +230,13 @@ export type RequirementsAction =
       questionId?: number
     }
   | {
+      answerId?: number
+      areaId?: number
+      kind: 'manage_requirement_selection_question'
+      operation: string
+      questionId?: number | string
+    }
+  | {
       kind: 'manage_specification_rfi'
       operation: string
       specificationId?: number

--- a/lib/requirements/security-audit.ts
+++ b/lib/requirements/security-audit.ts
@@ -167,6 +167,14 @@ function actionAuditDetail(
         operation: action.operation,
         specificationId: action.specificationId,
       }
+    case 'manage_requirement_selection_question':
+      return {
+        actionKind: action.kind,
+        answerId: action.answerId,
+        areaId: action.areaId,
+        operation: action.operation,
+        questionId: action.questionId,
+      }
     case 'get_requirement':
       return {
         actionKind: action.kind,

--- a/tests/integration/authorization/09-reviewer.spec.ts
+++ b/tests/integration/authorization/09-reviewer.spec.ts
@@ -50,10 +50,16 @@ test('AUTHZ-09/AUTH-10/AUTH-11: Reviewers can read broadly without privileged ad
       await expect(
         page.getByRole('heading', { level: 1, name: 'Kravurvalsfrågor' }),
       ).toHaveText('Kravurvalsfrågor')
-      await page
-        .getByRole('button', { name: /KUF\d+/ })
+      const questionDisclosure = page
+        .getByRole('button', { expanded: false, name: /KUF\d+/ })
         .first()
-        .click()
+      const detailsId = await questionDisclosure.getAttribute('aria-controls')
+      expect(detailsId).not.toBeNull()
+      await questionDisclosure.click()
+      await expect(
+        page.getByRole('button', { expanded: true, name: /KUF\d+/ }).first(),
+      ).toHaveAttribute('aria-controls', detailsId ?? '')
+      await expect(page.locator(`[id="${detailsId}"]`)).toBeVisible()
       for (const mutationName of [
         'Skapa kravurvalsfråga',
         'Ändra frågeordning',

--- a/tests/integration/authorization/09-reviewer.spec.ts
+++ b/tests/integration/authorization/09-reviewer.spec.ts
@@ -45,6 +45,33 @@ test('AUTHZ-09/AUTH-10/AUTH-11: Reviewers can read broadly without privileged ad
     ).toBeVisible()
     await expect(page.getByRole('tab')).toHaveCount(0)
 
+    await test.step('reviewer sees read-only requirement-selection questions', async () => {
+      await page.goto('/sv/requirements/stewardship?tab=questions')
+      await expect(
+        page.getByRole('heading', { level: 1, name: 'Kravurvalsfrågor' }),
+      ).toHaveText('Kravurvalsfrågor')
+      await page
+        .getByRole('button', { name: /KUF\d+/ })
+        .first()
+        .click()
+      for (const mutationName of [
+        'Skapa kravurvalsfråga',
+        'Ändra frågeordning',
+        'Redigera',
+        'Synlighetsvillkor',
+        'Inaktivera',
+        'Arkivera',
+        'Kopiera',
+        'Ta bort',
+        'Ändra svarsordning',
+        'Lägg till svar',
+      ]) {
+        await expect(
+          page.getByRole('button', { name: mutationName, exact: true }),
+        ).toHaveCount(0)
+      }
+    })
+
     const specificationsResponse = await reviewer.get(
       '/api/requirements-specifications',
     )

--- a/tests/unit/requirement-selection-question-routes.test.ts
+++ b/tests/unit/requirement-selection-question-routes.test.ts
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => {
     getRequirementSelectionQuestionByIdentifier: vi.fn(),
     getRequestSqlServerDataSource: vi.fn(async () => db),
     getSpecificationById: vi.fn(),
+    listAreaIdsActorCanAuthor: vi.fn(),
     listRequirementSelectionQuestions: vi.fn(),
     recordAllowedActionAuditEvent: vi.fn(),
     recordDeniedActionAuditEvent: vi.fn(),
@@ -72,6 +73,10 @@ vi.mock('@/lib/audit/action-audit', () => ({
 
 vi.mock('@/lib/dal/requirements-specifications', () => ({
   getSpecificationById: mocks.getSpecificationById,
+}))
+
+vi.mock('@/lib/dal/requirement-areas', () => ({
+  listAreaIdsActorCanAuthor: mocks.listAreaIdsActorCanAuthor,
 }))
 
 vi.mock('@/lib/dal/requirement-selection-questions', () => ({
@@ -162,8 +167,11 @@ function answerParams(id = '11', answerId = '101') {
 describe('requirement selection question routes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.assertAuthorized.mockReset()
+    mocks.assertAuthorized.mockResolvedValue(undefined)
     mocks.context.actor.displayName = 'Selection Steward'
     mocks.context.actor.id = 'selection-steward'
+    mocks.context.actor.roles = ['RequirementsEditor']
     mocks.createRequirementSelectionAnswer.mockResolvedValue(question)
     mocks.createRequirementSelectionQuestion.mockResolvedValue(question)
     mocks.deleteRequirementSelectionAnswer.mockResolvedValue('deleted')
@@ -179,6 +187,7 @@ describe('requirement selection question routes', () => {
     )
     mocks.getSpecificationById.mockResolvedValue({ id: 7 })
     mocks.listRequirementSelectionQuestions.mockResolvedValue([question])
+    mocks.listAreaIdsActorCanAuthor.mockResolvedValue([5])
     mocks.recordAllowedActionAuditEvent.mockResolvedValue(undefined)
     mocks.recordDeniedActionAuditEvent.mockResolvedValue(undefined)
     mocks.replaceRequirementSelectionQuestionVisibilityGroups.mockResolvedValue(
@@ -203,7 +212,12 @@ describe('requirement selection question routes', () => {
     )
     expect(listResponse.status).toBe(200)
     await expect(listResponse.json()).resolves.toEqual({
-      questions: [question],
+      questions: [
+        {
+          ...question,
+          permissions: { canManage: true },
+        },
+      ],
     })
     expect(mocks.listRequirementSelectionQuestions).toHaveBeenCalledWith(
       mocks.db,
@@ -227,6 +241,36 @@ describe('requirement selection question routes', () => {
         targetUniqueId: 'INF-SQ001',
       }),
     )
+  })
+
+  it('marks foreign-area questions read-only and gives Admin the authoring bypass', async () => {
+    mocks.listAreaIdsActorCanAuthor.mockResolvedValueOnce([])
+
+    const foreignResponse = await listQuestions(
+      request('/api/requirement-selection-questions?includeArchived=true'),
+    )
+    await expect(foreignResponse.json()).resolves.toEqual({
+      questions: [
+        {
+          ...question,
+          permissions: { canManage: false },
+        },
+      ],
+    })
+
+    mocks.context.actor.roles = ['Admin']
+    const adminResponse = await listQuestions(
+      request('/api/requirement-selection-questions?includeArchived=true'),
+    )
+    await expect(adminResponse.json()).resolves.toEqual({
+      questions: [
+        {
+          ...question,
+          permissions: { canManage: true },
+        },
+      ],
+    })
+    expect(mocks.listAreaIdsActorCanAuthor).toHaveBeenCalledTimes(1)
   })
 
   it('returns a question by stable identifier and rejects invalid or missing identifiers', async () => {
@@ -729,6 +773,201 @@ describe('requirement selection question routes', () => {
     )
     expect(mocks.replaceSavedAnswers).not.toHaveBeenCalled()
   })
+
+  it.each([
+    {
+      action: {
+        areaId: 5,
+        kind: 'manage_requirement_selection_question',
+        operation: 'create',
+      },
+      label: 'question creation',
+      run: () =>
+        createQuestion(
+          request('/api/requirement-selection-questions', 'POST', {
+            areaId: 5,
+            selectionType: 'single',
+            text: 'Sensitive denied question text',
+          }),
+        ),
+    },
+    ...(
+      [
+        ['update', updateQuestion, 'PUT', { text: 'Denied question update' }],
+        ['delete', deleteQuestion, 'DELETE', undefined],
+      ] as const
+    ).map(([operation, route, method, body]) => ({
+      action: {
+        kind: 'manage_requirement_selection_question',
+        operation,
+        questionId: '11',
+      },
+      label: `question ${operation}`,
+      run: () =>
+        route(
+          request('/api/requirement-selection-questions/11', method, body),
+          questionParams(),
+        ),
+    })),
+    {
+      action: {
+        kind: 'manage_requirement_selection_question',
+        operation: 'duplicate',
+        questionId: '11',
+      },
+      label: 'question duplication',
+      run: () =>
+        duplicateQuestion(
+          request('/api/requirement-selection-questions/11/duplicate', 'POST'),
+          questionParams(),
+        ),
+    },
+    {
+      action: {
+        kind: 'manage_requirement_selection_question',
+        operation: 'visibility.update',
+        questionId: '11',
+      },
+      label: 'question visibility',
+      run: () =>
+        updateVisibility(
+          request('/api/requirement-selection-questions/11/visibility', 'PUT', {
+            groups: [],
+          }),
+          questionParams(),
+        ),
+    },
+    ...(
+      [
+        ['activate', activateQuestion],
+        ['archive', archiveQuestion],
+        ['deactivate', deactivateQuestion],
+        ['reactivate', reactivateQuestion],
+      ] as const
+    ).map(([operation, route]) => ({
+      action: {
+        kind: 'manage_requirement_selection_question',
+        operation,
+        questionId: '11',
+      },
+      label: `question ${operation}`,
+      run: () =>
+        route(
+          request(
+            `/api/requirement-selection-questions/11/${operation}`,
+            'POST',
+          ),
+          questionParams(),
+        ),
+    })),
+    {
+      action: {
+        kind: 'manage_requirement_selection_question',
+        operation: 'answer.create',
+        questionId: '11',
+      },
+      label: 'answer creation',
+      run: () =>
+        createAnswer(
+          request('/api/requirement-selection-questions/11/answers', 'POST', {
+            text: 'Sensitive denied answer text',
+          }),
+          questionParams(),
+        ),
+    },
+    ...(
+      [
+        [
+          'answer.update',
+          updateAnswer,
+          'PUT',
+          { text: 'Denied answer update' },
+        ],
+        ['answer.delete', deleteAnswer, 'DELETE', undefined],
+      ] as const
+    ).map(([operation, route, method, body]) => ({
+      action: {
+        answerId: 101,
+        kind: 'manage_requirement_selection_question',
+        operation,
+        questionId: '11',
+      },
+      label: operation,
+      run: () =>
+        route(
+          request(
+            '/api/requirement-selection-questions/11/answers/101',
+            method,
+            body,
+          ),
+          answerParams(),
+        ),
+    })),
+    ...(
+      [
+        ['activate', activateAnswer],
+        ['archive', archiveAnswer],
+        ['deactivate', deactivateAnswer],
+        ['reactivate', reactivateAnswer],
+      ] as const
+    ).map(([operation, route]) => ({
+      action: {
+        answerId: 101,
+        kind: 'manage_requirement_selection_question',
+        operation: `answer.${operation}`,
+        questionId: '11',
+      },
+      label: `answer ${operation}`,
+      run: () =>
+        route(
+          request(
+            `/api/requirement-selection-questions/11/answers/101/${operation}`,
+            'POST',
+          ),
+          answerParams(),
+        ),
+    })),
+  ])(
+    'denies $label before every domain write and records redacted evidence',
+    async ({ action, run }) => {
+      mocks.assertAuthorized.mockRejectedValueOnce(
+        forbiddenError('Requirement area author assignment is required', {
+          reason: 'requirement_area_author_required',
+        }),
+      )
+
+      const response = await run()
+
+      expect(response.status).toBe(403)
+      expect(mocks.assertAuthorized).toHaveBeenCalledWith(action, mocks.context)
+      for (const domainWrite of [
+        mocks.createRequirementSelectionQuestion,
+        mocks.updateRequirementSelectionQuestion,
+        mocks.deleteRequirementSelectionQuestion,
+        mocks.duplicateRequirementSelectionQuestion,
+        mocks.setRequirementSelectionQuestionState,
+        mocks.replaceRequirementSelectionQuestionVisibilityGroups,
+        mocks.createRequirementSelectionAnswer,
+        mocks.updateRequirementSelectionAnswer,
+        mocks.deleteRequirementSelectionAnswer,
+        mocks.setRequirementSelectionAnswerState,
+      ]) {
+        expect(domainWrite).not.toHaveBeenCalled()
+      }
+      expect(mocks.recordAllowedActionAuditEvent).not.toHaveBeenCalled()
+      expect(mocks.recordDeniedActionAuditEvent).toHaveBeenCalledWith(
+        mocks.db,
+        mocks.context,
+        expect.objectContaining({
+          action: 'requirements.authorization.denied',
+          denialReason: 'requirement_area_author_required',
+          details: expect.not.objectContaining({
+            text: expect.anything(),
+          }),
+        }),
+      )
+    },
+  )
 
   it('returns hidden selections for the confirmation conflict', async () => {
     mocks.replaceSavedAnswers.mockRejectedValueOnce(

--- a/tests/unit/requirement-selection-question-routes.test.ts
+++ b/tests/unit/requirement-selection-question-routes.test.ts
@@ -489,6 +489,7 @@ describe('requirement selection question routes', () => {
       expect.objectContaining({
         action: 'requirement_selection_answer.create',
         details: { questionId: 11 },
+        targetId: 11,
         targetUniqueId: 'INF-SQ001',
       }),
     )

--- a/tests/unit/requirement-selection-questions-client.test.tsx
+++ b/tests/unit/requirement-selection-questions-client.test.tsx
@@ -110,6 +110,7 @@ interface TestQuestion {
   id: number
   isActive: boolean
   isArchived: boolean
+  permissions: { canManage: boolean }
   questionCode: string
   selectionType: 'multiple' | 'single'
   sortOrder: number
@@ -121,6 +122,7 @@ const sampleArea = {
   description: 'Controls authentication and authorization requirements.',
   id: 1,
   name: 'Security',
+  permissions: { canAuthor: true },
   prefix: 'SEC',
 }
 const samplePackage = {
@@ -144,6 +146,7 @@ const sampleQuestion: TestQuestion = {
   id: 11,
   isActive: true,
   isArchived: false,
+  permissions: { canManage: true },
   questionCode: 'SEC-KUF001',
   selectionType: 'single',
   sortOrder: 0,
@@ -523,6 +526,7 @@ describe('RequirementSelectionQuestionsClient', () => {
       description: 'Architecture ownership.',
       id: 2,
       name: 'Architecture',
+      permissions: { canAuthor: true },
       prefix: 'ARK',
     }
     const architectureQuestion: TestQuestion = {
@@ -600,6 +604,58 @@ describe('RequirementSelectionQuestionsClient', () => {
     expect(
       screen.getByRole('button', { name: 'Add answer' }),
     ).toBeInTheDocument()
+  })
+
+  it('keeps foreign-area questions readable without offering mutation controls', async () => {
+    const readOnlyArea = {
+      ...sampleArea,
+      permissions: { canAuthor: false },
+    }
+    const readOnlyQuestion = {
+      ...sampleQuestion,
+      answers: [sampleAnswer],
+      permissions: { canManage: false },
+    }
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/requirement-areas') {
+        return okJson({ areas: [readOnlyArea] })
+      }
+      if (url === '/api/requirement-packages') {
+        return okJson({ requirementPackages: [samplePackage] })
+      }
+      if (url === '/api/requirement-selection-questions?includeArchived=true') {
+        return okJson({ questions: [readOnlyQuestion] })
+      }
+      return okJson({})
+    })
+
+    render(<RequirementSelectionQuestionsClient />)
+
+    expect(await screen.findByText(readOnlyQuestion.text)).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', {
+        name: 'Create requirement selection question',
+      }),
+    ).not.toBeInTheDocument()
+    const questionCard = expandQuestion(readOnlyQuestion.text)
+    expect(
+      within(questionCard).getByText(sampleAnswer.text),
+    ).toBeInTheDocument()
+    for (const buttonName of [
+      'Reorder question',
+      'Edit',
+      'Visibility conditions',
+      'Deactivate',
+      'Archive',
+      'Clone',
+      'Delete',
+      'Reorder answer',
+      'Add answer',
+    ]) {
+      expect(
+        within(questionCard).queryByRole('button', { name: buttonName }),
+      ).not.toBeInTheDocument()
+    }
   })
 
   it('opens a read-only hierarchy modal from a separate badge without expanding the question row', async () => {

--- a/tests/unit/requirements-assignment-authorization.test.ts
+++ b/tests/unit/requirements-assignment-authorization.test.ts
@@ -1046,7 +1046,6 @@ describe('AssignmentBasedAuthorizationService', () => {
 
     for (const context of [
       makeContext([], 'SE5560000001-unassigned'),
-      makeContext([], 'SE5560000001-foreign-area-author'),
       makeContext(['Reviewer'], 'SE5560000001-reviewer'),
     ]) {
       await expect(
@@ -1059,6 +1058,22 @@ describe('AssignmentBasedAuthorizationService', () => {
         details: { reason: 'requirement_area_author_required' },
       })
     }
+
+    const foreignAreaAuthor = makeService({
+      areaAuthor: areaId => areaId === 8,
+    })
+    await expect(
+      foreignAreaAuthor.service.assertAuthorized(
+        action,
+        makeContext([], 'SE5560000001-foreign-area-author'),
+      ),
+    ).rejects.toMatchObject({
+      code: 'forbidden',
+      details: { reason: 'requirement_area_author_required' },
+    })
+    expect(
+      foreignAreaAuthor.lookup.isRequirementAreaAuthor,
+    ).toHaveBeenCalledWith(7, 'SE5560000001-foreign-area-author')
 
     const admin = makeService({ areaAuthor: false })
     await expect(

--- a/tests/unit/requirements-assignment-authorization.test.ts
+++ b/tests/unit/requirements-assignment-authorization.test.ts
@@ -66,6 +66,7 @@ function makeLookup(
     areaAuthor?: boolean | ((areaId: number) => boolean)
     deviation?: Partial<DeviationTarget>
     requirement?: Partial<RequirementTarget>
+    requirementSelectionAreaId?: number
     specAuthor?: boolean
     specificationId?: number
     suggestionAreaId?: number
@@ -88,6 +89,10 @@ function makeLookup(
     ),
     resolveRequirementApplicationMutationTarget: vi.fn(
       async () => options.specificationId ?? 42,
+    ),
+    resolveRequirementSelectionQuestionArea: vi.fn(
+      async () =>
+        options.requirementSelectionAreaId ?? options.requirement?.areaId ?? 7,
     ),
     resolveSpecificationId: vi.fn(
       async (input: { specificationId?: number }) =>
@@ -976,6 +981,94 @@ describe('AssignmentBasedAuthorizationService', () => {
       ),
     ).resolves.toBeUndefined()
   })
+
+  it.each<{
+    action: Extract<
+      RequirementsAction,
+      { kind: 'manage_requirement_selection_question' }
+    >
+    label: string
+  }>([
+    {
+      action: {
+        areaId: 7,
+        kind: 'manage_requirement_selection_question',
+        operation: 'create',
+      },
+      label: 'question creation',
+    },
+    ...[
+      'update',
+      'delete',
+      'duplicate',
+      'visibility.update',
+      'activate',
+      'archive',
+      'deactivate',
+      'reactivate',
+      'answer.create',
+    ].map(operation => ({
+      action: {
+        kind: 'manage_requirement_selection_question' as const,
+        operation,
+        questionId: 'SEC-KUF001',
+      },
+      label: operation,
+    })),
+    ...[
+      'answer.update',
+      'answer.delete',
+      'answer.activate',
+      'answer.archive',
+      'answer.deactivate',
+      'answer.reactivate',
+    ].map(operation => ({
+      action: {
+        answerId: 13,
+        kind: 'manage_requirement_selection_question' as const,
+        operation,
+        questionId: 'SEC-KUF001',
+      },
+      label: operation,
+    })),
+  ])('enforces the assignment role matrix for $label', async ({ action }) => {
+    const assignedAuthor = makeService({ areaAuthor: true })
+    await expect(
+      assignedAuthor.service.assertAuthorized(action, makeContext([])),
+    ).resolves.toBeUndefined()
+    expect(
+      assignedAuthor.lookup.resolveRequirementSelectionQuestionArea,
+    ).toHaveBeenCalledWith(action)
+    expect(assignedAuthor.lookup.isRequirementAreaAuthor).toHaveBeenCalledWith(
+      7,
+      'SE5560000001-user1',
+    )
+
+    for (const context of [
+      makeContext([], 'SE5560000001-unassigned'),
+      makeContext([], 'SE5560000001-foreign-area-author'),
+      makeContext(['Reviewer'], 'SE5560000001-reviewer'),
+    ]) {
+      await expect(
+        makeService({ areaAuthor: false }).service.assertAuthorized(
+          action,
+          context,
+        ),
+      ).rejects.toMatchObject({
+        code: 'forbidden',
+        details: { reason: 'requirement_area_author_required' },
+      })
+    }
+
+    const admin = makeService({ areaAuthor: false })
+    await expect(
+      admin.service.assertAuthorized(action, makeContext(['Admin'], '')),
+    ).resolves.toBeUndefined()
+    expect(
+      admin.lookup.resolveRequirementSelectionQuestionArea,
+    ).toHaveBeenCalledWith(action)
+    expect(admin.lookup.isRequirementAreaAuthor).not.toHaveBeenCalled()
+  })
 })
 
 describe('SqlAssignmentLookup', () => {
@@ -1587,5 +1680,63 @@ describe('SqlAssignmentLookup', () => {
         },
       ),
     ).rejects.toMatchObject({ code: 'not_found' })
+  })
+
+  it('resolves requirement-selection question and nested-answer areas from stored ownership', async () => {
+    const byCode = makeDb([[{ areaId: 7 }]])
+    await expect(
+      new SqlAssignmentLookup(
+        byCode.db,
+      ).resolveRequirementSelectionQuestionArea({
+        kind: 'manage_requirement_selection_question',
+        operation: 'update',
+        questionId: 'SEC-KUF001',
+      }),
+    ).resolves.toBe(7)
+    expect(byCode.query).toHaveBeenCalledWith(
+      expect.stringContaining('question.question_code = @0'),
+      ['SEC-KUF001'],
+    )
+
+    const nestedAnswer = makeDb([[{ areaId: 8 }]])
+    await expect(
+      new SqlAssignmentLookup(
+        nestedAnswer.db,
+      ).resolveRequirementSelectionQuestionArea({
+        answerId: 13,
+        kind: 'manage_requirement_selection_question',
+        operation: 'answer.update',
+        questionId: 11,
+      }),
+    ).resolves.toBe(8)
+    expect(nestedAnswer.query).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'answer.question_id = question.id AND answer.id = @1',
+      ),
+      [11, 13],
+    )
+  })
+
+  it('rejects missing or mismatched requirement-selection mutation targets', async () => {
+    const lookup = new SqlAssignmentLookup(makeDb([[]]).db)
+    await expect(
+      lookup.resolveRequirementSelectionQuestionArea({
+        answerId: 99,
+        kind: 'manage_requirement_selection_question',
+        operation: 'answer.delete',
+        questionId: 11,
+      }),
+    ).rejects.toMatchObject({ code: 'not_found' })
+
+    await expect(
+      new SqlAssignmentLookup(
+        makeDb().db,
+      ).resolveRequirementSelectionQuestionArea({
+        kind: 'manage_requirement_selection_question',
+        operation: 'update',
+      }),
+    ).rejects.toMatchObject({
+      details: { reason: 'missing_requirement_selection_question_target' },
+    })
   })
 })

--- a/tests/unit/requirements-security-audit.test.ts
+++ b/tests/unit/requirements-security-audit.test.ts
@@ -165,6 +165,12 @@ describe('requirements security audit', () => {
       specificationId: 1,
     },
     {
+      answerId: 3,
+      kind: 'manage_requirement_selection_question',
+      operation: 'answer.update',
+      questionId: 2,
+    },
+    {
       kind: 'list_graduation_target_areas',
       localRequirementId: 2,
       specificationId: 1,


### PR DESCRIPTION
## Description

Enforce requirement-area authorship for every requirement-selection question
and answer mutation. Identifier-based operations resolve the stored requirement
area, nested answers must belong to the targeted question, and authorization
denials occur before domain writes or allowed-action audit entries.

The stewardship UI now exposes mutation controls only for requirement-area
owners, co-authors, and Administrators. Other authenticated users retain the
read-only question, hierarchy, and requirement preview surfaces.

## Related Issues

Fixes #462

## Reviewer Notes

- `npm run check` passed: 7,226 tests passed and 86 skipped.
- Final type-check and 229 focused authorization, route, audit, and UI tests passed.
- The Reviewer authorization Playwright scenario passed.
- Standards and specification reviews completed with no remaining findings.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
Before the upgrade, verify that requirement-area owner and co-author assignments
are current. After the upgrade, only these assigned authors and Administrators
can create or change requirement-selection questions and answers. Other
authenticated users have read-only access.

Communicate this permission change to requirement-library maintainers. During
rollout validation, confirm assigned-author access, the Administrator bypass,
and authorization-denial audit evidence. No data migration or configuration
change is required.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1056)
<!-- Reviewable:end -->
