### PR TITLE
docs: persist operator upgrade notes from #1056

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -276,6 +276,17 @@ Tell API consumers and support staff that an existing child resource can now ret
 Before rollout, inform requirement-area authors and Reviewers that they can no longer change requirement applications or saved requirement-selection answers unless they are also the responsible author or a co-author of the requirements specification. Administrators remain allowed.
 After rollout, verify that denied attempts return `403` and that the action log and security audit log receive denial evidence.
 <!-- operator-upgrade:source pr-1042 end -->
+
+<!-- operator-upgrade:source pr-1056 start -->
+Before the upgrade, verify that requirement-area owner and co-author assignments
+are current. After the upgrade, only these assigned authors and Administrators
+can create or change requirement-selection questions and answers. Other
+authenticated users have read-only access.
+Communicate this permission change to requirement-library maintainers. During
+rollout validation, confirm assigned-author access, the Administrator bypass,
+and authorization-denial audit evidence. No data migration or configuration
+change is required.
+<!-- operator-upgrade:source pr-1056 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #1056
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/31967738826

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1057)
<!-- Reviewable:end -->
