### PR TITLE
Bound MCP specification requirement additions

### DIFF
--- a/app/api/requirements-specifications/[id]/items/route.ts
+++ b/app/api/requirements-specifications/[id]/items/route.ts
@@ -8,7 +8,6 @@ import {
   secureMutationRoute,
 } from '@/lib/http/secure-mutation-route'
 import {
-  ARRAY_INPUT_MAX_ITEMS,
   idParamSchema,
   nullableBoundedDbStringSchema,
   nullableBusinessTextSchema,
@@ -16,6 +15,7 @@ import {
   parseSearchParams,
   positiveIntegerSchema,
   routeSegmentSchema,
+  uniquePositiveIntegerArraySchema,
 } from '@/lib/http/validation'
 import { isRequirementsServiceError } from '@/lib/requirements/errors'
 import { toHttpErrorPayload } from '@/lib/requirements/http-errors'
@@ -31,13 +31,7 @@ const ADD_REQUIREMENTS_ERROR = 'Failed to add requirements'
 
 const specificationParamSchema = idParamSchema
 
-const requirementIdsSchema = z
-  .array(positiveIntegerSchema)
-  .min(1)
-  .max(ARRAY_INPUT_MAX_ITEMS)
-  .refine(values => new Set(values).size === values.length, {
-    message: 'Expected unique positive integers',
-  })
+const requirementIdsSchema = uniquePositiveIntegerArraySchema().min(1)
 
 const itemRefsSchema = z
   .array(routeSegmentSchema)

--- a/docs/integrations/mcp-server-contributor-guide.md
+++ b/docs/integrations/mcp-server-contributor-guide.md
@@ -338,12 +338,12 @@ requirements_get_specification_items.items[kind == "library"].id -> requirementI
 
 ### `requirements_add_to_specification`
 
-Links requirements to a specification. Accepts numeric `specificationId`.
-Requirements without a published
-version are skipped and returned in `skippedIds` rather than causing an error —
-this lets an agent batch-add requirements without needing to pre-filter by
-publish state. `needsReferenceId` links the added items to an existing
-specification-local needs reference. `needsReferenceText` creates a new
+Links from 1 through 200 unique requirements to a specification. Accepts
+numeric `specificationId`. Requirements without a published version are
+skipped and returned in `skippedIds` rather than causing an error — this lets
+an agent batch-add requirements without needing to pre-filter by publish state.
+`needsReferenceId` links the added items to an existing specification-local
+needs reference. `needsReferenceText` creates a new
 `specification_needs_references` row, with optional
 `needsReferenceDescription`, and links it to all added items. The tool rejects
 duplicate `needsReferenceText` values inside the same specification. Use the

--- a/docs/integrations/mcp-server-user-guide.md
+++ b/docs/integrations/mcp-server-user-guide.md
@@ -107,11 +107,11 @@ agents can use it reliably.
   unique requirement. Use a returned `areas[].id` as
   `requirementAreaId` for `requirements_graduate_local_requirement`.
 - `requirements_add_to_specification`
-  Link one or more requirements to a specification. Requirements must have a
-  published version; those without are skipped and returned in `skippedIds`.
-  Optionally attach an existing `needsReferenceId`, or create a new
-  `needsReferenceText` with an optional `needsReferenceDescription`, for all
-  added items. New needs-reference text must be unique inside the
+  Link from 1 through 200 unique requirements to a specification. Requirements
+  must have a published version; those without are skipped and returned in
+  `skippedIds`. Optionally attach an existing `needsReferenceId`, or create a
+  new `needsReferenceText` with an optional `needsReferenceDescription`, for
+  all added items. New needs-reference text must be unique inside the
   specification. Use `specificationId` to identify the specification. Copy
   requirement IDs from:
 

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -15,6 +15,10 @@ import {
 import type { McpRuntimeSettings } from '@/lib/dal/ai-settings'
 import type { SqlServerDatabase } from '@/lib/db'
 import {
+  ARRAY_INPUT_MAX_ITEMS,
+  uniquePositiveIntegerArraySchema,
+} from '@/lib/http/validation'
+import {
   createRequestContext,
   type RequestContext,
 } from '@/lib/requirements/auth'
@@ -2595,7 +2599,7 @@ export function createKravhanteringMcpServer(
         openWorldHint: false,
         readOnlyHint: false,
       },
-      description: `Link one or more requirements to a requirements specification. Requirements must have a published version; those without are skipped and returned in skippedIds. Optionally attach an existing needsReferenceId or create a new needsReferenceText plus needsReferenceDescription for all added items. Identify the specification with specificationId. ${specificationIdCopyPath} ${addRequirementIdsCopyPath}`,
+      description: `Link up to ${ARRAY_INPUT_MAX_ITEMS} unique requirements to a requirements specification. Requirements must have a published version; those without are skipped and returned in skippedIds. Optionally attach an existing needsReferenceId or create a new needsReferenceText plus needsReferenceDescription for all added items. Identify the specification with specificationId. ${specificationIdCopyPath} ${addRequirementIdsCopyPath}`,
       inputSchema: z
         .object({
           locale: ResponseLocaleSchema,
@@ -2626,11 +2630,10 @@ export function createKravhanteringMcpServer(
             .describe(
               `Numeric ID of the requirements specification. ${specificationIdCopyPath}`,
             ),
-          requirementIds: z
-            .array(z.number().int().positive())
+          requirementIds: uniquePositiveIntegerArraySchema()
             .min(1)
             .describe(
-              `Numeric requirement IDs (not uniqueId strings) to add to the specification. ${addRequirementIdsCopyPath}`,
+              `One to ${ARRAY_INPUT_MAX_ITEMS} unique numeric requirement IDs (not uniqueId strings) to add to the specification. ${addRequirementIdsCopyPath}`,
             ),
           responseFormat: z.enum(['json', 'markdown']).default('markdown'),
         })

--- a/lib/requirements/service-specifications.ts
+++ b/lib/requirements/service-specifications.ts
@@ -13,12 +13,20 @@ import {
 } from '@/lib/dal/requirements-specifications'
 import type { SqlServerDatabase } from '@/lib/db'
 import {
+  ARRAY_INPUT_MAX_ITEMS,
+  uniquePositiveIntegerArraySchema,
+} from '@/lib/http/validation'
+import {
   type AuthorizationService,
   type RequestContext,
   type RequirementsAction,
   requireHumanActorSnapshot,
 } from '@/lib/requirements/auth'
-import { forbiddenError, notFoundError } from '@/lib/requirements/errors'
+import {
+  forbiddenError,
+  notFoundError,
+  validationError,
+} from '@/lib/requirements/errors'
 import {
   DEFAULT_REQUIREMENT_SORT,
   type FilterValues,
@@ -63,6 +71,72 @@ interface SpecificationWorkflowDependencies {
   authorization: AuthorizationService
   db: SqlServerDatabase
   logger: RequirementsLogger
+}
+
+interface RequirementPublishedVersionLookup {
+  publishedVersionId: number | null
+  requirementId: number
+}
+
+const addToSpecificationRequirementIdsSchema =
+  uniquePositiveIntegerArraySchema().min(1)
+const PUBLISHED_VERSION_LOOKUP_CONCURRENCY = 8
+
+function assertValidAddToSpecificationRequirementIds(
+  requirementIds: number[],
+): void {
+  if (
+    addToSpecificationRequirementIdsSchema.safeParse(requirementIds).success
+  ) {
+    return
+  }
+
+  throw validationError(
+    `Expected 1 to ${ARRAY_INPUT_MAX_ITEMS} unique positive requirement IDs`,
+    {
+      maxItems: ARRAY_INPUT_MAX_ITEMS,
+      reason: 'invalid_requirement_ids',
+    },
+  )
+}
+
+async function resolveRequirementPublishedVersions(
+  db: SqlServerDatabase,
+  requirementIds: number[],
+): Promise<RequirementPublishedVersionLookup[]> {
+  const results = new Array<RequirementPublishedVersionLookup>(
+    requirementIds.length,
+  )
+  let nextIndex = 0
+
+  async function worker(): Promise<void> {
+    while (nextIndex < requirementIds.length) {
+      const index = nextIndex
+      nextIndex += 1
+      const requirementId = requirementIds[index]
+      if (requirementId === undefined) continue
+      results[index] = {
+        publishedVersionId: await getPublishedVersionIdForRequirement(
+          db,
+          requirementId,
+        ),
+        requirementId,
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      {
+        length: Math.min(
+          PUBLISHED_VERSION_LOOKUP_CONCURRENCY,
+          requirementIds.length,
+        ),
+      },
+      () => worker(),
+    ),
+  )
+  return results
 }
 
 function getSpecificationReferenceLabel(
@@ -514,6 +588,7 @@ export function createSpecificationWorkflow({
     async addToSpecification(context, input: AddToSpecificationInput) {
       const responseFormat = input.responseFormat ?? 'markdown'
       const locale = input.locale ?? 'en'
+      assertValidAddToSpecificationRequirementIds(input.requirementIds)
 
       await authorize(
         authorization,
@@ -535,17 +610,17 @@ export function createSpecificationWorkflow({
         },
         async () => {
           const specificationId = await resolveSpecificationIdOrThrow(input)
-          const versionResults = await Promise.all(
-            input.requirementIds.map(async id => ({
-              id,
-              versionId: await getPublishedVersionIdForRequirement(db, id),
-            })),
-          )
-          const succeeded = versionResults.filter(r => r.versionId != null) as {
-            id: number
-            versionId: number
+          const publishedVersionLookups =
+            await resolveRequirementPublishedVersions(db, input.requirementIds)
+          const succeeded = publishedVersionLookups.filter(
+            lookup => lookup.publishedVersionId != null,
+          ) as {
+            publishedVersionId: number
+            requirementId: number
           }[]
-          const skipped = versionResults.filter(r => r.versionId == null)
+          const skipped = publishedVersionLookups.filter(
+            lookup => lookup.publishedVersionId == null,
+          )
 
           let addedCount = 0
           if (succeeded.length > 0) {
@@ -553,7 +628,7 @@ export function createSpecificationWorkflow({
               db,
               specificationId,
               {
-                requirementIds: succeeded.map(r => r.id),
+                requirementIds: succeeded.map(result => result.requirementId),
                 needsReferenceDescription: input.needsReferenceDescription,
                 needsReferenceId: input.needsReferenceId,
                 needsReferenceText: input.needsReferenceText,
@@ -567,13 +642,13 @@ export function createSpecificationWorkflow({
               locale,
               operation: 'add_to_specification',
               requirementCount: input.requirementIds.length,
-              requirementIds: succeeded.map(r => r.id),
+              requirementIds: succeeded.map(result => result.requirementId),
               specificationId,
             })
           }
 
           const ref = getSpecificationReferenceLabel(input, specificationId)
-          const skippedIds = skipped.map(r => r.id)
+          const skippedIds = skipped.map(result => result.requirementId)
           const lines: string[] = [
             translateServiceMessage(
               locale,

--- a/tests/unit/mcp-http.test.ts
+++ b/tests/unit/mcp-http.test.ts
@@ -66,6 +66,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { addMcpMaxRequestBytesSteps } from '@/lib/ai/generation-availability'
 import { McpAuthError, verifyMcpBearerToken } from '@/lib/auth/mcp-token'
+import { ARRAY_INPUT_MAX_ITEMS } from '@/lib/http/validation'
 import {
   handleRequirementsMcpRequest,
   MCP_DEFAULT_REQUEST_BYTES,
@@ -1320,6 +1321,49 @@ describe('handleRequirementsMcpRequest', () => {
 
     expect(fakeService.addToSpecification).not.toHaveBeenCalled()
     expect(fakeService.removeFromSpecification).not.toHaveBeenCalled()
+
+    await client.close()
+    await transport.close()
+  })
+
+  it('bounds unique add-to-specification requirement IDs before mutation delegation', async () => {
+    const { client, transport } = await createClient()
+    const fakeService = serviceState.getService.mock.results[0]?.value
+    const maximumRequirementIds = Array.from(
+      { length: ARRAY_INPUT_MAX_ITEMS },
+      (_, index) => index + 1,
+    )
+
+    const maximumResult = await client.callTool({
+      arguments: {
+        requirementIds: maximumRequirementIds,
+        specificationId: 7,
+      },
+      name: 'requirements_add_to_specification',
+    })
+    const overMaximumResult = await client.callTool({
+      arguments: {
+        requirementIds: [...maximumRequirementIds, ARRAY_INPUT_MAX_ITEMS + 1],
+        specificationId: 7,
+      },
+      name: 'requirements_add_to_specification',
+    })
+    const duplicateResult = await client.callTool({
+      arguments: {
+        requirementIds: [1, 1],
+        specificationId: 7,
+      },
+      name: 'requirements_add_to_specification',
+    })
+
+    expect(maximumResult.isError).not.toBe(true)
+    expect(overMaximumResult.isError).toBe(true)
+    expect(duplicateResult.isError).toBe(true)
+    expect(fakeService.addToSpecification).toHaveBeenCalledTimes(1)
+    expect(fakeService.addToSpecification).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ requirementIds: maximumRequirementIds }),
+    )
 
     await client.close()
     await transport.close()

--- a/tests/unit/requirements-service.test.ts
+++ b/tests/unit/requirements-service.test.ts
@@ -166,6 +166,7 @@ vi.mock('@/lib/dal/requirements', () => ({
   transitionStatus: mocks.transitionStatus,
 }))
 
+import { ARRAY_INPUT_MAX_ITEMS } from '@/lib/http/validation'
 import { createRequirementsService } from '@/lib/requirements/service'
 import {
   buildRequirementViewUri,
@@ -1743,6 +1744,69 @@ describe('createRequirementsService', () => {
       lines: ['Added 1 requirement to specification 7.'],
       title: 'Requirements Added to Specification',
     })
+  })
+
+  it.each([
+    ['an empty collection', []],
+    ['duplicate IDs', [10, 10]],
+    [
+      'more than the shared item limit',
+      Array.from(
+        { length: ARRAY_INPUT_MAX_ITEMS + 1 },
+        (_, index) => index + 1,
+      ),
+    ],
+  ])(
+    'rejects %s before add-to-specification database work',
+    async (_case, requirementIds) => {
+      const service = createTestRequirementsService()
+
+      await expect(
+        service.addToSpecification(makeContext(), {
+          requirementIds,
+          specificationId: 7,
+        }),
+      ).rejects.toMatchObject({ code: 'validation' })
+
+      expect(mocks.getPublishedVersionIdForRequirement).not.toHaveBeenCalled()
+      expect(
+        mocks.linkRequirementsToSpecificationAtomically,
+      ).not.toHaveBeenCalled()
+    },
+  )
+
+  it('keeps published-version lookup concurrency fixed at the maximum collection size', async () => {
+    let activeLookups = 0
+    let peakConcurrentLookups = 0
+    mocks.getPublishedVersionIdForRequirement.mockImplementation(
+      async requirementId => {
+        activeLookups += 1
+        peakConcurrentLookups = Math.max(peakConcurrentLookups, activeLookups)
+        await new Promise<void>(resolve => queueMicrotask(resolve))
+        activeLookups -= 1
+        return requirementId + 1_000
+      },
+    )
+    mocks.linkRequirementsToSpecificationAtomically.mockResolvedValue(
+      ARRAY_INPUT_MAX_ITEMS,
+    )
+    const service = createTestRequirementsService()
+    const requirementIds = Array.from(
+      { length: ARRAY_INPUT_MAX_ITEMS },
+      (_, index) => index + 1,
+    )
+
+    const result = await service.addToSpecification(makeContext(), {
+      requirementIds,
+      specificationId: 7,
+    })
+
+    expect(result.addedCount).toBe(ARRAY_INPUT_MAX_ITEMS)
+    expect(peakConcurrentLookups).toBeGreaterThan(0)
+    expect(peakConcurrentLookups).toBeLessThanOrEqual(8)
+    expect(mocks.getPublishedVersionIdForRequirement).toHaveBeenCalledTimes(
+      ARRAY_INPUT_MAX_ITEMS,
+    )
   })
 
   it('uses actual deleted specification link counts in removeFromSpecification', async () => {


### PR DESCRIPTION
## Description

Bound requirement membership additions consistently across MCP, REST, and the
shared requirements service. Add-to-specification requests now accept 1–200
unique positive requirement IDs, reject invalid collections before database
work, and resolve published versions with fixed lookup concurrency.

The MCP callable contract and both integration guides document the new limit.
Focused tests cover the maximum, over-limit, duplicate, shared-service, and
bounded-concurrency cases.

## Related Issues

Fixes #823

## Reviewer Notes

- `npm run check`
- 7,245 Vitest tests passed; 86 skipped.
- 35 HSA support tests passed.
- Final Standards and Spec reviews reported no findings.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
Before upgrade, notify owners of MCP integrations that add requirements to a
requirements specification. Each request now accepts 1–200 unique requirement
IDs. Clients must remove duplicate IDs and split larger batches. Invalid
requests are rejected before database work starts.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1059)
<!-- Reviewable:end -->
