### PR TITLE
docs: persist operator upgrade notes from #1059

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -287,6 +287,13 @@ rollout validation, confirm assigned-author access, the Administrator bypass,
 and authorization-denial audit evidence. No data migration or configuration
 change is required.
 <!-- operator-upgrade:source pr-1056 end -->
+
+<!-- operator-upgrade:source pr-1059 start -->
+Before upgrade, notify owners of MCP integrations that add requirements to a
+requirements specification. Each request now accepts 1–200 unique requirement
+IDs. Clients must remove duplicate IDs and split larger batches. Invalid
+requests are rejected before database work starts.
+<!-- operator-upgrade:source pr-1059 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #1059
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/32047796882

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1060)
<!-- Reviewable:end -->
