### PR TITLE
fix: bound AI generation request bodies

### DIFF
--- a/app/api/ai/generate-requirement-import/route.ts
+++ b/app/api/ai/generate-requirement-import/route.ts
@@ -25,7 +25,6 @@ import {
 import { getAiGenerationAvailability } from '@/lib/dal/ai-settings'
 import { getApplicationSettings } from '@/lib/dal/application-settings'
 import { getRequestSqlServerDataSource } from '@/lib/db'
-import { readBoundedJsonRequest } from '@/lib/http/bounded-json-request'
 import {
   AI_PROVIDER_UNAVAILABLE_MESSAGE,
   logSanitizedError,
@@ -34,7 +33,7 @@ import {
   requirementsMutationPolicy,
   secureMutationRoute,
 } from '@/lib/http/secure-mutation-route'
-import { invalidJsonResponse, parseWithSchema } from '@/lib/http/validation'
+import { readBoundedJsonWithSchema } from '@/lib/http/validation'
 import { recordCapacityEvent } from '@/lib/observability/capacity'
 import {
   applyResponseCorrelationHeaders,
@@ -102,30 +101,17 @@ type GenerateRequirementImportBody = z.infer<
   typeof generateRequirementImportSchema
 >
 
-async function readGenerateRequirementImportBody(request: Request) {
-  const bounded = await readBoundedJsonRequest(request, {
-    maxBytes: AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES,
-  })
-  if (!bounded.ok) {
-    return {
-      ok: false as const,
-      response:
-        bounded.code === 'invalid_json'
-          ? invalidJsonResponse()
-          : NextResponse.json(
-              {
-                code: 'ai_request_bytes_exceeded',
-                details: {
-                  maxBytes: AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES,
-                },
-                error: 'AI generation request exceeds the allowed size.',
-              },
-              { status: 413 },
-            ),
-    }
-  }
-
-  return parseWithSchema(generateRequirementImportSchema, bounded.data)
+function aiRequestBytesExceededResponse(): NextResponse {
+  return NextResponse.json(
+    {
+      code: 'ai_request_bytes_exceeded',
+      details: {
+        maxBytes: AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES,
+      },
+      error: 'AI generation request exceeds the allowed size.',
+    },
+    { status: 413 },
+  )
 }
 
 function createStreamRecorder(
@@ -233,7 +219,11 @@ function imageMetadataForSafety(
 }
 
 export const POST = secureMutationRoute<GenerateRequirementImportBody>({
-  bodyReader: ({ request }) => readGenerateRequirementImportBody(request),
+  bodyReader: ({ request }) =>
+    readBoundedJsonWithSchema(request, generateRequirementImportSchema, {
+      maxBytes: AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES,
+      requestBytesExceededResponse: aiRequestBytesExceededResponse,
+    }),
   policy: requirementsMutationPolicy<GenerateRequirementImportBody>(
     ({ body }) => requirementImportScopeAction(body),
   ),

--- a/app/api/ai/generate-requirement-import/route.ts
+++ b/app/api/ai/generate-requirement-import/route.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import {
   type GenerationStats,
@@ -24,6 +25,7 @@ import {
 import { getAiGenerationAvailability } from '@/lib/dal/ai-settings'
 import { getApplicationSettings } from '@/lib/dal/application-settings'
 import { getRequestSqlServerDataSource } from '@/lib/db'
+import { readBoundedJsonRequest } from '@/lib/http/bounded-json-request'
 import {
   AI_PROVIDER_UNAVAILABLE_MESSAGE,
   logSanitizedError,
@@ -32,6 +34,7 @@ import {
   requirementsMutationPolicy,
   secureMutationRoute,
 } from '@/lib/http/secure-mutation-route'
+import { invalidJsonResponse, parseWithSchema } from '@/lib/http/validation'
 import { recordCapacityEvent } from '@/lib/observability/capacity'
 import {
   applyResponseCorrelationHeaders,
@@ -71,6 +74,7 @@ import {
 
 const AI_GENERATE_REQUIREMENT_IMPORT_OPERATION =
   'ai.generate-requirement-import'
+export const AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES = 42 * 1024 * 1024
 const STREAMED_REASONING_SAFETY_CONTEXT_CHARS = 1000
 
 const generateRequirementImportSchema = aiRequirementImportBaseBodySchema
@@ -97,6 +101,32 @@ const generateRequirementImportSchema = aiRequirementImportBaseBodySchema
 type GenerateRequirementImportBody = z.infer<
   typeof generateRequirementImportSchema
 >
+
+async function readGenerateRequirementImportBody(request: Request) {
+  const bounded = await readBoundedJsonRequest(request, {
+    maxBytes: AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES,
+  })
+  if (!bounded.ok) {
+    return {
+      ok: false as const,
+      response:
+        bounded.code === 'invalid_json'
+          ? invalidJsonResponse()
+          : NextResponse.json(
+              {
+                code: 'ai_request_bytes_exceeded',
+                details: {
+                  maxBytes: AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES,
+                },
+                error: 'AI generation request exceeds the allowed size.',
+              },
+              { status: 413 },
+            ),
+    }
+  }
+
+  return parseWithSchema(generateRequirementImportSchema, bounded.data)
+}
 
 function createStreamRecorder(
   context: RequestCorrelationIds,
@@ -202,8 +232,8 @@ function imageMetadataForSafety(
   })
 }
 
-export const POST = secureMutationRoute({
-  bodySchema: generateRequirementImportSchema,
+export const POST = secureMutationRoute<GenerateRequirementImportBody>({
+  bodyReader: ({ request }) => readGenerateRequirementImportBody(request),
   policy: requirementsMutationPolicy<GenerateRequirementImportBody>(
     ({ body }) => requirementImportScopeAction(body),
   ),

--- a/app/api/ai/requirement-import-shared.ts
+++ b/app/api/ai/requirement-import-shared.ts
@@ -138,8 +138,10 @@ export const imageDataUrlSchema = z.string().max(MAX_AI_IMAGE_DATA_URL_LENGTH)
 
 const BASE64_PAYLOAD_PATTERN =
   /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+const BASE64_ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
 
-function normalizeBase64Payload(base64Data: string): string | null {
+function canonicalizeBase64Payload(base64Data: string): string | null {
   if (base64Data.length === 0 || /\s/.test(base64Data)) return null
   const remainder = base64Data.length % 4
   if (remainder === 1) return null
@@ -147,7 +149,22 @@ function normalizeBase64Payload(base64Data: string): string | null {
     remainder === 0
       ? base64Data
       : base64Data.padEnd(base64Data.length + 4 - remainder, '=')
-  return BASE64_PAYLOAD_PATTERN.test(normalized) ? normalized : null
+  if (!BASE64_PAYLOAD_PATTERN.test(normalized)) return null
+
+  const padBitIndex = normalized.endsWith('==')
+    ? normalized.length - 3
+    : normalized.endsWith('=')
+      ? normalized.length - 2
+      : -1
+  if (padBitIndex === -1) return normalized
+
+  const sextet = BASE64_ALPHABET.indexOf(normalized[padBitIndex])
+  const canonicalSextet = normalized.endsWith('==')
+    ? sextet & 0b11_0000
+    : sextet & 0b11_1100
+  if (sextet === canonicalSextet) return normalized
+
+  return `${normalized.slice(0, padBitIndex)}${BASE64_ALPHABET[canonicalSextet]}${normalized.slice(padBitIndex + 1)}`
 }
 
 function countBase64Bytes(base64Data: string): number {
@@ -164,7 +181,7 @@ function validateImageDataUrl(
   context: RefinementCtx,
   locale: RequirementImportLocale,
   path: Array<number | string>,
-): { mime: string; payload: string } | null {
+): string | null {
   const mimeMatch = dataUrl.match(/^data:([^;]+);base64,/)
   if (
     !mimeMatch ||
@@ -181,8 +198,8 @@ function validateImageDataUrl(
   }
 
   const base64Data = dataUrl.slice(dataUrl.indexOf(',') + 1)
-  const normalizedBase64Data = normalizeBase64Payload(base64Data)
-  if (!normalizedBase64Data) {
+  const canonicalBase64Data = canonicalizeBase64Payload(base64Data)
+  if (!canonicalBase64Data) {
     context.addIssue({
       code: 'custom',
       message: getPromptMessage(locale, ['ai', 'imageSchemaErrorBase64']),
@@ -191,14 +208,14 @@ function validateImageDataUrl(
     return null
   }
 
-  if (countBase64Bytes(normalizedBase64Data) > MAX_AI_IMAGE_BYTES) {
+  if (countBase64Bytes(canonicalBase64Data) > MAX_AI_IMAGE_BYTES) {
     context.addIssue({
       code: 'custom',
       message: getPromptMessage(locale, ['ai', 'imageSchemaErrorSize']),
       path,
     })
   }
-  return { mime: mimeMatch[1], payload: normalizedBase64Data }
+  return canonicalBase64Data
 }
 
 export function validateRequirementImportImages(
@@ -209,19 +226,17 @@ export function validateRequirementImportImages(
   context: RefinementCtx,
 ): void {
   const locale = requirementImportLocale(body)
-  const uniquePayloadsByMime = new Map<string, Set<string>>()
+  const uniquePayloads = new Set<string>()
   for (const [index, image] of (body.images ?? []).entries()) {
     const path = ['images', index, 'dataUrl']
-    const normalizedImage = validateImageDataUrl(
+    const canonicalPayload = validateImageDataUrl(
       image.dataUrl,
       context,
       locale,
       path,
     )
-    if (normalizedImage === null) continue
-    const uniquePayloads =
-      uniquePayloadsByMime.get(normalizedImage.mime) ?? new Set<string>()
-    if (uniquePayloads.has(normalizedImage.payload)) {
+    if (canonicalPayload === null) continue
+    if (uniquePayloads.has(canonicalPayload)) {
       context.addIssue({
         code: 'custom',
         message: getPromptMessage(locale, ['ai', 'imageSchemaErrorDuplicate']),
@@ -229,8 +244,7 @@ export function validateRequirementImportImages(
       })
       continue
     }
-    uniquePayloads.add(normalizedImage.payload)
-    uniquePayloadsByMime.set(normalizedImage.mime, uniquePayloads)
+    uniquePayloads.add(canonicalPayload)
   }
 }
 

--- a/app/api/ai/requirement-import-shared.ts
+++ b/app/api/ai/requirement-import-shared.ts
@@ -39,6 +39,8 @@ const ALLOWED_IMAGE_MIMES = [
 
 export const MAX_AI_IMAGE_BYTES = 10 * 1024 * 1024
 export const MAX_AI_IMAGES = 3
+export const MAX_AI_IMAGE_DATA_URL_LENGTH =
+  Math.ceil(MAX_AI_IMAGE_BYTES / 3) * 4 + 'data:image/jpeg;base64,'.length
 export const MAX_AI_INSTRUCTION_LENGTH = 4000
 export const MAX_AI_MODEL_LENGTH = 100
 export const MAX_AI_NEED_LENGTH = 4000
@@ -132,7 +134,7 @@ export async function guardAiInput(args: {
   )
 }
 
-export const imageDataUrlSchema = z.string()
+export const imageDataUrlSchema = z.string().max(MAX_AI_IMAGE_DATA_URL_LENGTH)
 
 const BASE64_PAYLOAD_PATTERN =
   /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
@@ -162,7 +164,7 @@ function validateImageDataUrl(
   context: RefinementCtx,
   locale: RequirementImportLocale,
   path: Array<number | string>,
-): void {
+): { mime: string; payload: string } | null {
   const mimeMatch = dataUrl.match(/^data:([^;]+);base64,/)
   if (
     !mimeMatch ||
@@ -175,7 +177,7 @@ function validateImageDataUrl(
       message: getPromptMessage(locale, ['ai', 'imageSchemaErrorType']),
       path,
     })
-    return
+    return null
   }
 
   const base64Data = dataUrl.slice(dataUrl.indexOf(',') + 1)
@@ -186,7 +188,7 @@ function validateImageDataUrl(
       message: getPromptMessage(locale, ['ai', 'imageSchemaErrorBase64']),
       path,
     })
-    return
+    return null
   }
 
   if (countBase64Bytes(normalizedBase64Data) > MAX_AI_IMAGE_BYTES) {
@@ -196,6 +198,7 @@ function validateImageDataUrl(
       path,
     })
   }
+  return { mime: mimeMatch[1], payload: normalizedBase64Data }
 }
 
 export function validateRequirementImportImages(
@@ -206,12 +209,28 @@ export function validateRequirementImportImages(
   context: RefinementCtx,
 ): void {
   const locale = requirementImportLocale(body)
+  const uniquePayloadsByMime = new Map<string, Set<string>>()
   for (const [index, image] of (body.images ?? []).entries()) {
-    validateImageDataUrl(image.dataUrl, context, locale, [
-      'images',
-      index,
-      'dataUrl',
-    ])
+    const path = ['images', index, 'dataUrl']
+    const normalizedImage = validateImageDataUrl(
+      image.dataUrl,
+      context,
+      locale,
+      path,
+    )
+    if (normalizedImage === null) continue
+    const uniquePayloads =
+      uniquePayloadsByMime.get(normalizedImage.mime) ?? new Set<string>()
+    if (uniquePayloads.has(normalizedImage.payload)) {
+      context.addIssue({
+        code: 'custom',
+        message: getPromptMessage(locale, ['ai', 'imageSchemaErrorDuplicate']),
+        path,
+      })
+      continue
+    }
+    uniquePayloads.add(normalizedImage.payload)
+    uniquePayloadsByMime.set(normalizedImage.mime, uniquePayloads)
   }
 }
 

--- a/components/AiRequirementGenerator.tsx
+++ b/components/AiRequirementGenerator.tsx
@@ -190,6 +190,28 @@ interface SchemaIssue {
   path: string
 }
 
+async function readGenerationResponseMessage(
+  response: Response,
+): Promise<string | null> {
+  const contentType =
+    response.headers?.get?.('content-type')?.toLowerCase() ?? ''
+  if (!contentType.includes('application/json')) {
+    return readResponseMessage(response)
+  }
+
+  const fallbackResponse = response.clone()
+  const body = (await response.json().catch(() => null)) as {
+    issues?: Array<{ message?: unknown }>
+  } | null
+  const issueMessage = body?.issues?.find(
+    issue =>
+      typeof issue.message === 'string' && issue.message.trim().length > 0,
+  )?.message
+  return typeof issueMessage === 'string'
+    ? issueMessage.trim()
+    : readResponseMessage(fallbackResponse)
+}
+
 interface AttachedImage {
   dataUrl: string
   id: string
@@ -1412,7 +1434,7 @@ export default function AiRequirementGenerator({
       })
       if (!response.ok || !response.body) {
         throw new Error(
-          (await readResponseMessage(response)) ?? t('createError'),
+          (await readGenerationResponseMessage(response)) ?? t('createError'),
         )
       }
 

--- a/docs/governance/manuella-testfall.md
+++ b/docs/governance/manuella-testfall.md
@@ -851,8 +851,9 @@ Kontrollera synlig tangentbordsfokus för knappen `Ta bort bild`. Ta bort sedan
 en bifogad bild.
 Starta en generering som får ett terminalt leverantörsfel. Starta en ny
 generering som får ett valideringsfel, välj `Reparera JSON`, låt första
-reparationen misslyckas och låt nästa lyckas. Avbryt slutligen en pågående
-generering genom att stänga dialogen.
+reparationen misslyckas och låt nästa lyckas. Bifoga därefter två bilder med
+samma bildinnehåll men olika filnamn och filtyp och försök generera igen.
+Avbryt slutligen en pågående generering genom att stänga dialogen.
 
 **Förväntat resultat:** De giltiga bilder som ryms ligger kvar och bildfelet
 är knutet till `Välj bilder`; skärmläsaren annonserar en sammanfattad feltext
@@ -862,9 +863,12 @@ flyttas fokus till rubriken `Genereringen misslyckades`, medan fel vid ett nytt
 försök och reparation behåller fokus på åtgärdsknappen. Råresultat,
 valideringsfel, behov, modell och bifogade bilder ligger kvar tills användaren
 ändrar dem. En lyckad reparation annonserar status en gång och flyttar fokus
-till resultatets rubrik. Endast sanerade feltexter visas eller annonseras; rått
-modell- eller leverantörsinnehåll visas inte. Att avbryta genom att stänga
-dialogen ger ingen felannonsering.
+till resultatets rubrik. Bilder med samma avkodade innehåll avvisas innan en ny
+kravkandidat skapas, även när filnamn och MIME-typ skiljer sig. Dialogen
+annonserar `Varje uppladdad bild måste vara unik.`, flyttar fokus till
+`Genereringen misslyckades` och behåller de bifogade bilderna. Endast sanerade
+feltexter visas eller annonseras; rått modell- eller leverantörsinnehåll visas
+inte. Att avbryta genom att stänga dialogen ger ingen felannonsering.
 
 ### REQ-16: Admin Center stänger av AI-kravgenerering
 

--- a/docs/security-privacy/api-security.md
+++ b/docs/security-privacy/api-security.md
@@ -99,7 +99,10 @@ Deferred from this contract:
   contract. They include streaming responses, provider-specific failure modes,
   model capability discovery, prompt construction, image payload validation,
   throttling, and vendor-token boundaries that are covered by focused route,
-  schema, and provider-client tests.
+  schema, and provider-client tests. The requirement-generation route reads at
+  most 42 MiB of JSON before parsing, returns `413` with
+  `ai_request_bytes_exceeded` above that limit, and retains the separate limit
+  of three images at 10 MiB decoded bytes each.
 - Admin catalog and settings mutations remain outside the
   OpenAPI/Schemathesis v1 contract when their assertions depend on Admin-only
   access, CSRF/same-origin enforcement for saves, privileged audit, effective

--- a/docs/security-privacy/api-security.md
+++ b/docs/security-privacy/api-security.md
@@ -102,7 +102,9 @@ Deferred from this contract:
   schema, and provider-client tests. The requirement-generation route reads at
   most 42 MiB of JSON before parsing, returns `413` with
   `ai_request_bytes_exceeded` above that limit, and retains the separate limit
-  of three images at 10 MiB decoded bytes each.
+  of three unique images at 10 MiB decoded bytes each. Image data URLs are
+  schema-bounded to their maximum base64 representation before decoded-size
+  validation.
 - Admin catalog and settings mutations remain outside the
   OpenAPI/Schemathesis v1 contract when their assertions depend on Admin-only
   access, CSRF/same-origin enforcement for saves, privileged audit, effective

--- a/lib/http/validation.ts
+++ b/lib/http/validation.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { type ZodError, type ZodType, z } from 'zod'
 import { isStrictHexColor } from '@/lib/color-contrast'
+import { readBoundedJsonRequest } from '@/lib/http/bounded-json-request'
 import {
   ARRAY_INPUT_MAX_ITEMS,
   BUSINESS_TEXT_MAX_LENGTH,
@@ -25,6 +26,15 @@ export interface InvalidRequestBody {
 export type ValidationResult<T> =
   | { data: T; ok: true }
   | { ok: false; response: NextResponse<InvalidRequestBody> }
+
+export type BoundedValidationResult<T> =
+  | { data: T; ok: true }
+  | { ok: false; response: NextResponse }
+
+export interface ReadBoundedJsonWithSchemaOptions {
+  maxBytes: number
+  requestBytesExceededResponse: () => NextResponse
+}
 
 export const positiveIntegerSchema = z
   .number()
@@ -210,6 +220,27 @@ export async function readJsonWithSchema<T>(
   }
 
   return parseWithSchema(schema, body)
+}
+
+export async function readBoundedJsonWithSchema<T>(
+  request: Request,
+  schema: ZodType<T>,
+  options: ReadBoundedJsonWithSchemaOptions,
+): Promise<BoundedValidationResult<T>> {
+  const bounded = await readBoundedJsonRequest(request, {
+    maxBytes: options.maxBytes,
+  })
+  if (!bounded.ok) {
+    return {
+      ok: false,
+      response:
+        bounded.code === 'invalid_json'
+          ? invalidJsonResponse()
+          : options.requestBytesExceededResponse(),
+    }
+  }
+
+  return parseWithSchema(schema, bounded.data)
 }
 
 export async function parseRouteParams<T>(

--- a/messages/en.json
+++ b/messages/en.json
@@ -2883,6 +2883,7 @@
     "outputSafetyBlocked": "The AI response was blocked by the AI safety filter: {ruleType}. Revise the request and try again.",
     "imageSchemaErrorType": "Unsupported image type. Use PNG, JPEG, GIF or WebP.",
     "imageSchemaErrorBase64": "Image data is not valid base64.",
+    "imageSchemaErrorDuplicate": "Each uploaded image must be unique.",
     "imageSchemaErrorSize": "Image exceeds the 10 MB size limit.",
     "invalidRequirementImportScope": "Library mode requires areaId and specification-local mode requires specificationId.",
     "prompt": {

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -2883,6 +2883,7 @@
     "outputSafetyBlocked": "AI-svaret blockerades av AI-säkerhetsfiltret: {ruleType}. Ändra anropet och försök igen.",
     "imageSchemaErrorType": "Bildtypen stöds inte. Använd PNG, JPEG, GIF eller WebP.",
     "imageSchemaErrorBase64": "Bilddata är inte giltigt base64.",
+    "imageSchemaErrorDuplicate": "Varje uppladdad bild måste vara unik.",
     "imageSchemaErrorSize": "Bilden överskrider gränsen på 10 MB.",
     "invalidRequirementImportScope": "Biblioteksläge kräver areaId och kravunderlagslokalt läge kräver specificationId.",
     "prompt": {

--- a/tests/integration/requirements/ai-assisted-authoring-import-review.spec.ts
+++ b/tests/integration/requirements/ai-assisted-authoring-import-review.spec.ts
@@ -339,24 +339,48 @@ test('REQ-15C: AI-assisted authoring announces failures and supports recovery', 
       return
     }
 
+    if (generationAttempts === 2) {
+      await route.fulfill({
+        body: [
+          'event: validation_error',
+          `data: ${JSON.stringify({
+            issues: [
+              {
+                code: 'invalid_json',
+                message: 'Modellens svar var inte giltig JSON.',
+                path: '$',
+              },
+            ],
+            message: 'Genererad JSON matchade inte importens schema.',
+            rawContent: '{"requirements":',
+          })}`,
+          '',
+          '',
+        ].join('\n'),
+        contentType: 'text/event-stream',
+      })
+      return
+    }
+
+    const requestBody = route.request().postDataJSON() as {
+      images: Array<{ dataUrl: string }>
+    }
+    expect(requestBody.images).toEqual([
+      { dataUrl: 'data:image/png;base64,aW1hZ2U=' },
+      { dataUrl: 'data:image/jpeg;base64,aW1hZ2U=' },
+    ])
     await route.fulfill({
-      body: [
-        'event: validation_error',
-        `data: ${JSON.stringify({
-          issues: [
-            {
-              code: 'invalid_json',
-              message: 'Modellens svar var inte giltig JSON.',
-              path: '$',
-            },
-          ],
-          message: 'Genererad JSON matchade inte importens schema.',
-          rawContent: '{"requirements":',
-        })}`,
-        '',
-        '',
-      ].join('\n'),
-      contentType: 'text/event-stream',
+      ...jsonResponse({
+        error: 'Invalid request',
+        issues: [
+          {
+            code: 'custom',
+            message: 'Varje uppladdad bild måste vara unik.',
+            path: 'images.1.dataUrl',
+          },
+        ],
+      }),
+      status: 400,
     })
   })
 
@@ -505,6 +529,24 @@ test('REQ-15C: AI-assisted authoring announces failures and supports recovery', 
       dialog.getByText('Den genererade JSON:en reparerades.'),
     ).toHaveAttribute('role', 'status')
     await expect(resultsHeading).toBeFocused()
+  })
+
+  await test.step('decoded duplicate image rejection', async () => {
+    await dialog.locator('input[type="file"]').setInputFiles({
+      buffer: Buffer.from('image'),
+      mimeType: 'image/jpeg',
+      name: 'duplicate-diagram.jpg',
+    })
+    await expect(dialog.getByText('duplicate-diagram.jpg')).toBeVisible()
+
+    await generateButton.click()
+
+    await expect(dialog.getByRole('alert')).toContainText(
+      'Varje uppladdad bild måste vara unik.',
+    )
+    await expect(generationFailure).toBeFocused()
+    await expect(dialog.getByText('diagram.png')).toBeVisible()
+    await expect(dialog.getByText('duplicate-diagram.jpg')).toBeVisible()
   })
 })
 

--- a/tests/integration/requirements/ai-assisted-authoring-import-review.spec.ts
+++ b/tests/integration/requirements/ai-assisted-authoring-import-review.spec.ts
@@ -539,7 +539,9 @@ test('REQ-15C: AI-assisted authoring announces failures and supports recovery', 
     })
     await expect(dialog.getByText('duplicate-diagram.jpg')).toBeVisible()
 
-    await generateButton.click()
+    await dialog
+      .getByRole('button', { name: 'Skapa nya kravkandidater' })
+      .click()
 
     await expect(dialog.getByRole('alert')).toContainText(
       'Varje uppladdad bild måste vara unik.',

--- a/tests/unit/ai-generate-requirements-route.test.ts
+++ b/tests/unit/ai-generate-requirements-route.test.ts
@@ -230,13 +230,13 @@ describe('POST /api/ai/generate-requirement-import', () => {
     expect(routeState.generateChatStream).toHaveBeenCalledOnce()
   })
 
-  it('rejects duplicate images before provider work', async () => {
+  it('rejects decoded duplicate images across Base64 aliases and MIME labels', async () => {
     const response = await POST(
       makeRequest({
         areaId: 1,
         images: [
-          { dataUrl: 'data:image/png;base64,YQ' },
           { dataUrl: 'data:image/png;base64,YQ==' },
+          { dataUrl: 'data:image/jpeg;base64,YR==' },
         ],
         locale: 'en',
         mode: 'library',

--- a/tests/unit/ai-generate-requirements-route.test.ts
+++ b/tests/unit/ai-generate-requirements-route.test.ts
@@ -83,6 +83,59 @@ function makeRequest(
   return request
 }
 
+function makePaddedStreamRequest(totalBytes: number): Request {
+  const body = new TextEncoder().encode(
+    JSON.stringify({
+      areaId: 1,
+      locale: 'en',
+      mode: 'library',
+      need: 'secure audit logging',
+    }),
+  )
+  if (totalBytes < body.byteLength) {
+    throw new Error('Stream size must fit the valid JSON body')
+  }
+  let bodySent = false
+  let paddingBytes = totalBytes - body.byteLength
+  const request = new Request(
+    'https://example.test/api/ai/generate-requirement-import',
+    {
+      body: new ReadableStream({
+        pull(controller) {
+          if (!bodySent) {
+            bodySent = true
+            controller.enqueue(body)
+            return
+          }
+          if (paddingBytes === 0) {
+            controller.close()
+            return
+          }
+          const chunkBytes = Math.min(paddingBytes, 1024 * 1024)
+          controller.enqueue(new Uint8Array(chunkBytes).fill(0x20))
+          paddingBytes -= chunkBytes
+        },
+      }),
+      duplex: 'half',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-correlation-id': 'workflow-ai',
+        'x-request-id': 'request-ai',
+      },
+      method: 'POST',
+    } as RequestInit,
+  )
+  attachVerifiedActor(request, {
+    displayName: 'AI User',
+    hsaId: 'SE5560000001-ai1',
+    id: 'ai-user',
+    isAuthenticated: true,
+    roles: ['Admin'],
+    source: 'oidc',
+  })
+  return request
+}
+
 function enableAiForensicCapture(): void {
   routeState.query.mockImplementation((sql: string) => {
     if (sql.includes('INSERT INTO ai_forensic_evidence_events')) {
@@ -134,11 +187,9 @@ describe('POST /api/ai/generate-requirement-import', () => {
     vi.unstubAllEnvs()
   })
 
-  it('rejects an oversized request before consuming its body or starting work', async () => {
-    const request = makeRequest()
-    request.headers.set(
-      'Content-Length',
-      String(AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES + 1),
+  it('rejects an oversized streamed request before starting work', async () => {
+    const request = makePaddedStreamRequest(
+      AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES + 1,
     )
 
     const response = await POST(request)
@@ -151,12 +202,12 @@ describe('POST /api/ai/generate-requirement-import', () => {
       },
       error: 'AI generation request exceeds the allowed size.',
     })
-    expect(request.bodyUsed).toBe(false)
+    expect(request.bodyUsed).toBe(true)
     expect(routeState.getRequestSqlServerDataSource).not.toHaveBeenCalled()
     expect(routeState.generateChatStream).not.toHaveBeenCalled()
   })
 
-  it('accepts a declared request at the transport byte boundary', async () => {
+  it('accepts an actual request at the transport byte boundary', async () => {
     routeState.generateChatStream.mockImplementation(async function* () {
       yield {
         phase: 'done',
@@ -168,10 +219,8 @@ describe('POST /api/ai/generate-requirement-import', () => {
         thinking: '',
       }
     })
-    const request = makeRequest()
-    request.headers.set(
-      'Content-Length',
-      String(AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES),
+    const request = makePaddedStreamRequest(
+      AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES,
     )
 
     const response = await POST(request)
@@ -179,6 +228,33 @@ describe('POST /api/ai/generate-requirement-import', () => {
     expect(response.status).toBe(200)
     expect(await response.text()).toContain('event: done')
     expect(routeState.generateChatStream).toHaveBeenCalledOnce()
+  })
+
+  it('rejects duplicate images before provider work', async () => {
+    const response = await POST(
+      makeRequest({
+        areaId: 1,
+        images: [
+          { dataUrl: 'data:image/png;base64,YQ' },
+          { dataUrl: 'data:image/png;base64,YQ==' },
+        ],
+        locale: 'en',
+        mode: 'library',
+        need: 'secure audit logging',
+      }),
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      issues: [
+        {
+          message: 'Each uploaded image must be unique.',
+          path: 'images.1.dataUrl',
+        },
+      ],
+    })
+    expect(routeState.getRequestSqlServerDataSource).not.toHaveBeenCalled()
+    expect(routeState.generateChatStream).not.toHaveBeenCalled()
   })
 
   it('streams generated requirement import JSON after schema validation', async () => {

--- a/tests/unit/ai-generate-requirements-route.test.ts
+++ b/tests/unit/ai-generate-requirements-route.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { POST } from '@/app/api/ai/generate-requirement-import/route'
+import {
+  AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES,
+  POST,
+} from '@/app/api/ai/generate-requirement-import/route'
 import * as aiSafety from '@/lib/ai/safety'
 import { DEFAULT_APPLICATION_SETTINGS } from '@/lib/application-settings'
 import { clearInMemoryThrottleForTests } from '@/lib/observability/throttle'
@@ -129,6 +132,53 @@ describe('POST /api/ai/generate-requirement-import', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs()
+  })
+
+  it('rejects an oversized request before consuming its body or starting work', async () => {
+    const request = makeRequest()
+    request.headers.set(
+      'Content-Length',
+      String(AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES + 1),
+    )
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(413)
+    await expect(response.json()).resolves.toEqual({
+      code: 'ai_request_bytes_exceeded',
+      details: {
+        maxBytes: AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES,
+      },
+      error: 'AI generation request exceeds the allowed size.',
+    })
+    expect(request.bodyUsed).toBe(false)
+    expect(routeState.getRequestSqlServerDataSource).not.toHaveBeenCalled()
+    expect(routeState.generateChatStream).not.toHaveBeenCalled()
+  })
+
+  it('accepts a declared request at the transport byte boundary', async () => {
+    routeState.generateChatStream.mockImplementation(async function* () {
+      yield {
+        phase: 'done',
+        rawContent: JSON.stringify({
+          requirements: [{ description: 'A bounded requirement.' }],
+          schemaVersion: REQUIREMENTS_IMPORT_SCHEMA_VERSION,
+        }),
+        stats: { totalTokens: 1 },
+        thinking: '',
+      }
+    })
+    const request = makeRequest()
+    request.headers.set(
+      'Content-Length',
+      String(AI_GENERATE_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES),
+    )
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('event: done')
+    expect(routeState.generateChatStream).toHaveBeenCalledOnce()
   })
 
   it('streams generated requirement import JSON after schema validation', async () => {

--- a/tests/unit/ai-requirement-generator.test.tsx
+++ b/tests/unit/ai-requirement-generator.test.tsx
@@ -2698,6 +2698,39 @@ describe('AiRequirementGenerator', () => {
     await waitFor(() => expect(errorSummary).toHaveFocus())
   })
 
+  it('announces the localized request-validation issue returned before streaming', async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/ai/models')) return modelResponse()
+      if (url.startsWith('/api/ai/credits')) return creditResponse()
+      if (url === '/api/ai/generate-requirement-import') {
+        return Response.json(
+          {
+            error: 'Invalid request',
+            issues: [
+              {
+                code: 'custom',
+                message: 'Each uploaded image must be unique.',
+                path: 'images.1.dataUrl',
+              },
+            ],
+          },
+          { status: 400 },
+        )
+      }
+      return Response.json({})
+    })
+
+    await renderOpenGenerator()
+    await userEvent.type(screen.getByLabelText('topicLabel'), 'Grade access')
+    await userEvent.click(
+      screen.getByRole('button', { name: /generateButton/i }),
+    )
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Each uploaded image must be unique.',
+    )
+  })
+
   it.each([
     ['import_content_bytes_exceeded', 'generatedImportContentLimitExceeded'],
     ['import_json_depth_cap_exceeded', 'generatedImportJsonDepthLimitExceeded'],

--- a/tests/unit/http-validation.test.ts
+++ b/tests/unit/http-validation.test.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from 'next/server'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
 import {
@@ -26,6 +27,7 @@ import {
   queryArraySchema,
   queryBooleanSchema,
   queryBooleanStringSchema,
+  readBoundedJsonWithSchema,
   readJsonWithSchema,
   refOrPositiveIntegerSegmentSchema,
   SQL_SERVER_INT_MAX,
@@ -70,6 +72,31 @@ describe('http validation helpers', () => {
           path: '$',
         },
       ],
+    })
+  })
+
+  it('maps bounded JSON overflow before schema parsing', async () => {
+    const result = await readBoundedJsonWithSchema(
+      new Request('http://localhost/api/test', {
+        body: JSON.stringify({ name: 'Ada' }),
+        method: 'POST',
+      }),
+      z.object({ name: z.string() }).strict(),
+      {
+        maxBytes: 5,
+        requestBytesExceededResponse: () =>
+          NextResponse.json(
+            { code: 'request_bytes_exceeded' },
+            { status: 413 },
+          ),
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.response.status).toBe(413)
+    await expect(result.response.json()).resolves.toEqual({
+      code: 'request_bytes_exceeded',
     })
   })
 

--- a/tests/unit/requirement-import-shared.test.ts
+++ b/tests/unit/requirement-import-shared.test.ts
@@ -296,8 +296,8 @@ describe('AI requirement import shared contracts', () => {
         images: [
           { dataUrl: 'data:image/png;base64,YQ' },
           { dataUrl: 'data:image/jpeg;base64,YWI' },
-          { dataUrl: 'data:image/gif;base64,YQ==' },
-          { dataUrl: 'data:image/webp;base64,YWI=' },
+          { dataUrl: 'data:image/gif;base64,YWJjZA==' },
+          { dataUrl: 'data:image/webp;base64,YWJjZGU=' },
         ],
       }).success,
     ).toBe(true)

--- a/tests/unit/requirement-import-shared.test.ts
+++ b/tests/unit/requirement-import-shared.test.ts
@@ -6,7 +6,9 @@ import {
   createUnavailableAiStreamResponse,
   formatAiSafetyBlockedMessage,
   guardAiInput,
+  imageDataUrlSchema,
   isValidRequirementImportScope,
+  MAX_AI_IMAGE_DATA_URL_LENGTH,
   requirementImportDestination,
   requirementImportScopeAction,
   validateRequirementImportImages,
@@ -317,6 +319,13 @@ describe('AI requirement import shared contracts', () => {
         invalid.error.issues.every(issue => issue.path[0] === 'images'),
       ).toBe(true)
     }
+  })
+
+  it('bounds image data URLs before decoded image validation', () => {
+    expect(
+      imageDataUrlSchema.safeParse('x'.repeat(MAX_AI_IMAGE_DATA_URL_LENGTH + 1))
+        .success,
+    ).toBe(false)
   })
 
   it('validates both destination scopes and returns their authorization actions', () => {


### PR DESCRIPTION
## Description

<!-- Optional: what changed and why? -->

- Enforce a 42 MiB streaming request limit before AI generation JSON is materialized.
- Bound image data URLs and reject decoded duplicate images across Base64 aliases and MIME labels before provider work.
- Surface localized request-validation feedback and update focused, Playwright, manual, and security documentation coverage.

## Related Issues

<!-- Fixes #123, Closes #123, or Relates to #123 -->

Fixes #827

## Reviewer Notes

<!-- Optional: screenshots, test notes, rollout notes, or review context. -->

Verification completed:

- `npm run check` — 7,251 tests passed, 86 skipped; all lint, format, spelling, documentation, and HSA checks passed.
- `NEXT_PUBLIC_SITE_URL=https://example.invalid npm run build` — production build, bundle budgets, and standalone dependency checks passed.
- The REQ-15C Playwright scenario and integration chunk manifest load successfully. Full browser execution was not run because the required app, Keycloak, and SQL Server services were unavailable.
- Standards and specification review completed with no actionable findings.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
AI generation clients must keep request bodies at or below 42 MiB and submit no more than three unique images of at most 10 MiB decoded each. Requests above the transport limit now receive HTTP 413. Duplicate decoded images receive HTTP 400 before provider work. Verify that clients and integrations handle these responses during rollout.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1061)
<!-- Reviewable:end -->
