### PR TITLE
fix: bound AI repair request bodies

### DIFF
--- a/.github/instructions/secure-mutation-routes.instructions.md
+++ b/.github/instructions/secure-mutation-routes.instructions.md
@@ -27,8 +27,9 @@ applyTo: "{app/api/**/route.ts,lib/http/secure-mutation-route.ts,tests/unit/secu
 ## Handler Shape
 
 - Use wrapper-provided `context`, `params`, `body`, and `request` in handlers.
-- Validate route params with `paramsSchema`; validate JSON bodies with
-  `bodySchema`.
+- Validate route params with `paramsSchema`. Validate JSON bodies with
+  `bodySchema`, or use `bodyReader` with `readBoundedJsonWithSchema` when a
+  transport byte limit must run before parsing.
 - Do not re-create request context or re-read session state inside a wrapped
   route.
 - Keep HTTP parsing, response status/content type, and REST-only shaping in the

--- a/app/api/ai/repair-requirement-import-json/route.ts
+++ b/app/api/ai/repair-requirement-import-json/route.ts
@@ -56,7 +56,7 @@ import {
 
 const AI_REPAIR_REQUIREMENT_IMPORT_OPERATION =
   'ai.repair-requirement-import-json'
-export const AI_REPAIR_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES = 1024 * 1024
+const AI_REPAIR_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES = 1024 * 1024
 
 const repairRequirementImportJsonSchema = aiRequirementImportBaseBodySchema
   .extend({

--- a/app/api/ai/repair-requirement-import-json/route.ts
+++ b/app/api/ai/repair-requirement-import-json/route.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { generateChat } from '@/lib/ai/openrouter-client'
 import { resolveOpenRouterModelCapabilities } from '@/lib/ai/openrouter-model-catalog'
@@ -27,6 +28,7 @@ import {
   requirementsMutationPolicy,
   secureMutationRoute,
 } from '@/lib/http/secure-mutation-route'
+import { readBoundedJsonWithSchema } from '@/lib/http/validation'
 import { recordCapacityEvent } from '@/lib/observability/capacity'
 import { applyResponseCorrelationHeaders } from '@/lib/observability/request-ids'
 import {
@@ -54,6 +56,7 @@ import {
 
 const AI_REPAIR_REQUIREMENT_IMPORT_OPERATION =
   'ai.repair-requirement-import-json'
+export const AI_REPAIR_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES = 1024 * 1024
 
 const repairRequirementImportJsonSchema = aiRequirementImportBaseBodySchema
   .extend({
@@ -61,7 +64,8 @@ const repairRequirementImportJsonSchema = aiRequirementImportBaseBodySchema
       .array(z.string().trim().min(1).max(MAX_AI_INSTRUCTION_LENGTH))
       .max(25)
       .optional()
-      .default([]),
+      .default([])
+      .transform(errors => [...new Set(errors)]),
     rawJson: z
       .string()
       .trim()
@@ -74,8 +78,25 @@ type RepairRequirementImportJsonBody = z.infer<
   typeof repairRequirementImportJsonSchema
 >
 
-export const POST = secureMutationRoute({
-  bodySchema: repairRequirementImportJsonSchema,
+function aiRepairRequestBytesExceededResponse(): NextResponse {
+  return NextResponse.json(
+    {
+      code: 'ai_request_bytes_exceeded',
+      details: {
+        maxBytes: AI_REPAIR_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES,
+      },
+      error: 'AI repair request exceeds the allowed size.',
+    },
+    { status: 413 },
+  )
+}
+
+export const POST = secureMutationRoute<RepairRequirementImportJsonBody>({
+  bodyReader: ({ request }) =>
+    readBoundedJsonWithSchema(request, repairRequirementImportJsonSchema, {
+      maxBytes: AI_REPAIR_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES,
+      requestBytesExceededResponse: aiRepairRequestBytesExceededResponse,
+    }),
   policy: requirementsMutationPolicy<RepairRequirementImportJsonBody>(
     ({ body }) => requirementImportScopeAction(body),
   ),

--- a/docs/security-privacy/api-security.md
+++ b/docs/security-privacy/api-security.md
@@ -104,7 +104,9 @@ Deferred from this contract:
   `ai_request_bytes_exceeded` above that limit, and retains the separate limit
   of three unique images at 10 MiB decoded bytes each. Image data URLs are
   schema-bounded to their maximum base64 representation before decoded-size
-  validation.
+  validation. The JSON-repair route reads at most 1 MiB before parsing and
+  returns the same stable `413` code above that limit. It also normalizes and
+  deduplicates validation errors before AI safety screening and provider use.
 - Admin catalog and settings mutations remain outside the
   OpenAPI/Schemathesis v1 contract when their assertions depend on Admin-only
   access, CSRF/same-origin enforcement for saves, privileged audit, effective

--- a/tests/unit/ai-repair-requirement-import-json-route.test.ts
+++ b/tests/unit/ai-repair-requirement-import-json-route.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { POST } from '@/app/api/ai/repair-requirement-import-json/route'
+import {
+  AI_REPAIR_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES,
+  POST,
+} from '@/app/api/ai/repair-requirement-import-json/route'
 import {
   AiProviderCallerCancelledError,
   createAiProviderError,
@@ -22,6 +25,7 @@ const routeState = vi.hoisted(() => ({
   query: vi.fn(),
   resolveOpenRouterModelCapabilities: vi.fn(),
 }))
+const EXPECTED_AI_REPAIR_MAX_REQUEST_BYTES = 1024 * 1024
 
 vi.mock('@/lib/db', () => ({
   getRequestSqlServerDataSource: routeState.getRequestSqlServerDataSource,
@@ -85,6 +89,60 @@ function makeRequest(
   return request
 }
 
+function makePaddedStreamRequest(totalBytes: number): Request {
+  const body = new TextEncoder().encode(
+    JSON.stringify({
+      areaId: 1,
+      errors: ['schemaVersion is missing'],
+      locale: 'en',
+      mode: 'library',
+      rawJson: '{"requirements":[]}',
+    }),
+  )
+  if (totalBytes < body.byteLength) {
+    throw new Error('Stream size must fit the valid JSON body')
+  }
+  let bodySent = false
+  let paddingBytes = totalBytes - body.byteLength
+  const request = new Request(
+    'https://example.test/api/ai/repair-requirement-import-json',
+    {
+      body: new ReadableStream({
+        pull(controller) {
+          if (!bodySent) {
+            bodySent = true
+            controller.enqueue(body)
+            return
+          }
+          if (paddingBytes === 0) {
+            controller.close()
+            return
+          }
+          const chunkBytes = Math.min(paddingBytes, 64 * 1024)
+          controller.enqueue(new Uint8Array(chunkBytes).fill(0x20))
+          paddingBytes -= chunkBytes
+        },
+      }),
+      duplex: 'half',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-correlation-id': 'workflow-ai-repair',
+        'x-request-id': 'request-ai-repair',
+      },
+      method: 'POST',
+    } as RequestInit,
+  )
+  attachVerifiedActor(request, {
+    displayName: 'AI User',
+    hsaId: 'SE5560000001-ai1',
+    id: 'ai-user',
+    isAuthenticated: true,
+    roles: ['Admin'],
+    source: 'oidc',
+  })
+  return request
+}
+
 function enableAiForensicCapture(): void {
   routeState.query.mockImplementation((sql: string) => {
     if (sql.includes('FROM ai_forensic_capture_windows')) {
@@ -134,6 +192,79 @@ describe('POST /api/ai/repair-requirement-import-json', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs()
+  })
+
+  it('rejects an oversized streamed request before starting work', async () => {
+    const request = makePaddedStreamRequest(
+      EXPECTED_AI_REPAIR_MAX_REQUEST_BYTES + 1,
+    )
+
+    const response = await POST(request)
+
+    expect(AI_REPAIR_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES).toBe(
+      EXPECTED_AI_REPAIR_MAX_REQUEST_BYTES,
+    )
+    expect(response.status).toBe(413)
+    await expect(response.json()).resolves.toEqual({
+      code: 'ai_request_bytes_exceeded',
+      details: {
+        maxBytes: EXPECTED_AI_REPAIR_MAX_REQUEST_BYTES,
+      },
+      error: 'AI repair request exceeds the allowed size.',
+    })
+    expect(request.bodyUsed).toBe(true)
+    expect(routeState.getRequestSqlServerDataSource).not.toHaveBeenCalled()
+    expect(routeState.generateChat).not.toHaveBeenCalled()
+  })
+
+  it('accepts an actual request at the transport byte boundary', async () => {
+    routeState.generateChat.mockResolvedValue({
+      content: {
+        requirements: [{ description: 'A bounded repaired requirement.' }],
+        schemaVersion: REQUIREMENTS_IMPORT_SCHEMA_VERSION,
+      },
+      stats: { totalTokens: 1 },
+      thinking: '',
+    })
+    const request = makePaddedStreamRequest(
+      EXPECTED_AI_REPAIR_MAX_REQUEST_BYTES,
+    )
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      payload: {
+        requirements: [{ description: 'A bounded repaired requirement.' }],
+      },
+    })
+    expect(routeState.generateChat).toHaveBeenCalledOnce()
+  })
+
+  it('does not amplify provider work for duplicate repair errors', async () => {
+    routeState.generateChat.mockResolvedValue({
+      content: {
+        requirements: [{ description: 'A repaired requirement.' }],
+        schemaVersion: REQUIREMENTS_IMPORT_SCHEMA_VERSION,
+      },
+      stats: { totalTokens: 1 },
+      thinking: '',
+    })
+
+    const response = await POST(
+      makeRequest({
+        areaId: 1,
+        errors: ['schemaVersion is missing', ' schemaVersion is missing '],
+        locale: 'en',
+        mode: 'library',
+        rawJson: '{"requirements":[]}',
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const providerRequest = routeState.generateChat.mock.calls[0]?.[0]
+    const repairPrompt = String(providerRequest.messages[1].content)
+    expect(repairPrompt.match(/schemaVersion is missing/g)).toHaveLength(1)
   })
 
   it('returns repaired requirement import JSON after schema validation', async () => {

--- a/tests/unit/ai-repair-requirement-import-json-route.test.ts
+++ b/tests/unit/ai-repair-requirement-import-json-route.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  AI_REPAIR_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES,
-  POST,
-} from '@/app/api/ai/repair-requirement-import-json/route'
+import { POST } from '@/app/api/ai/repair-requirement-import-json/route'
 import {
   AiProviderCallerCancelledError,
   createAiProviderError,
@@ -201,9 +198,6 @@ describe('POST /api/ai/repair-requirement-import-json', () => {
 
     const response = await POST(request)
 
-    expect(AI_REPAIR_REQUIREMENT_IMPORT_MAX_REQUEST_BYTES).toBe(
-      EXPECTED_AI_REPAIR_MAX_REQUEST_BYTES,
-    )
     expect(response.status).toBe(413)
     await expect(response.json()).resolves.toEqual({
       code: 'ai_request_bytes_exceeded',


### PR DESCRIPTION
## Description

Bound the AI requirement-import JSON repair request to 1 MiB before parsing so oversized payloads cannot be fully materialized in the application process. Return a stable `413` response above the limit and deduplicate normalized validation errors before AI safety screening and provider use.

Document the focused AI route contract and the schema-validating bounded-reader pattern for secure mutation routes.

## Related Issues

Fixes #837

## Reviewer Notes

- `npm run check`
- Focused boundary coverage verifies that the exact request limit succeeds, one byte above it fails before database or provider work, and duplicate validation errors reach the provider only once.
- No visible UI workflow changed, so no screenshots or manual Playwright case updates are needed.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1065)
<!-- Reviewable:end -->
