### PR TITLE
fix: authorize RFI question collection reads

### DIFF
--- a/app/api/rfi-questions/route.ts
+++ b/app/api/rfi-questions/route.ts
@@ -1,17 +1,25 @@
 import { NextResponse } from 'next/server'
 import type { z } from 'zod'
 import { recordAllowedActionAuditEvent } from '@/lib/audit/action-audit'
-import { createRfiQuestion, listRfiQuestions } from '@/lib/dal/rfi-questions'
+import { createRfiQuestion } from '@/lib/dal/rfi-questions'
 import { getRequestSqlServerDataSource } from '@/lib/db'
 import {
   type MutationPolicy,
   secureMutationRoute,
 } from '@/lib/http/secure-mutation-route'
 import { parseSearchParams } from '@/lib/http/validation'
+import { applyResponseCorrelationHeaders } from '@/lib/observability/request-ids'
 import { requireHumanActorSnapshot } from '@/lib/requirements/auth'
+import { toHttpErrorPayload } from '@/lib/requirements/http-errors'
+import { createRequirementsRestRuntime } from '@/lib/requirements/server'
 import { rfiQuestionCreateSchema, rfiQuestionQuerySchema } from './_schemas'
 
 type RfiQuestionCreateBody = z.infer<typeof rfiQuestionCreateSchema>
+
+function errorResponse(error: unknown) {
+  const { body, status } = toHttpErrorPayload(error)
+  return NextResponse.json(body, { status })
+}
 
 export async function GET(request: Request) {
   const parsedQuery = parseSearchParams(
@@ -19,9 +27,22 @@ export async function GET(request: Request) {
     rfiQuestionQuerySchema,
   )
   if (!parsedQuery.ok) return parsedQuery.response
-  const db = await getRequestSqlServerDataSource()
-  const questions = await listRfiQuestions(db, parsedQuery.data)
-  return NextResponse.json({ questions })
+  const runtime = await createRequirementsRestRuntime(request)
+  try {
+    const questions = await runtime.service.listRfiQuestions(
+      runtime.context,
+      parsedQuery.data,
+    )
+    return applyResponseCorrelationHeaders(
+      NextResponse.json({ questions }),
+      runtime.context,
+    )
+  } catch (error) {
+    return applyResponseCorrelationHeaders(
+      errorResponse(error),
+      runtime.context,
+    )
+  }
 }
 
 const createPolicy = {

--- a/docs/governance/behörigheter.md
+++ b/docs/governance/behörigheter.md
@@ -198,7 +198,8 @@ förvaltningsdetaljer kräver författarbehörighet i frågans kravområde, som
 kravområdesägare, kravområdesmedförfattare eller `Admin`.
 Den ofiltrerade förvaltningslistan visar bara RFI-frågor från kravområden där
 användaren har författarbehörighet; `Admin` kan läsa listan över alla
-kravområden.
+kravområden. En inloggad användare som inte är `Admin` och anger `areaId` för
+ett kravområde där användaren saknar författarbehörighet får 403.
 
 Ett kravunderlags RFI-frågelista hör däremot till kravunderlaget.
 Kravunderlagsansvarig, kravunderlagsmedförfattare och `Admin` kan ändra

--- a/docs/governance/behörigheter.md
+++ b/docs/governance/behörigheter.md
@@ -196,6 +196,9 @@ RFI-frågor hör till kravområdet i kravbiblioteksförvaltningen. Att skapa,
 redigera, arkivera, återaktivera eller läsa en enskild RFI-frågas
 förvaltningsdetaljer kräver författarbehörighet i frågans kravområde, som
 kravområdesägare, kravområdesmedförfattare eller `Admin`.
+Den ofiltrerade förvaltningslistan visar bara RFI-frågor från kravområden där
+användaren har författarbehörighet; `Admin` kan läsa listan över alla
+kravområden.
 
 Ett kravunderlags RFI-frågelista hör däremot till kravunderlaget.
 Kravunderlagsansvarig, kravunderlagsmedförfattare och `Admin` kan ändra

--- a/docs/governance/manuella-testfall.md
+++ b/docs/governance/manuella-testfall.md
@@ -435,11 +435,17 @@ tilldelningar.
 1. Öppna kravområdet `AUTHZ-AREA-2026`.
 1. Skapa ett krav i det tilldelade kravområdet via API eller UI och verifiera
    att kravet sparas.
+1. Skapa en RFI-fråga i det tilldelade kravområdet och en annan RFI-fråga i
+   ett främmande kravområde med en behörig testanvändare. Läs RFI-frågor utan
+   områdesfilter och försök sedan läsa det främmande kravområdet direkt via
+   API.
 1. Försök ändra kravområdets ägare eller listan över medförfattare.
 1. Kör API-kontroll mot samma otillåtna tilldelningsändring.
 
-**Förväntat resultat:** Cora kan skapa krav inom området men får 403 för
-tilldelningsstyrning och global Admin.
+**Förväntat resultat:** Cora kan skapa krav och RFI-frågor inom området. Den
+ofiltrerade RFI-frågelistan innehåller bara frågor från tilldelade kravområden,
+och direkt läsning av det främmande kravområdets RFI-frågor ger 403. Cora får
+också 403 för tilldelningsstyrning och global Admin.
 
 ### AUTHZ-04: kravunderlagsansvarig
 

--- a/lib/dal/rfi-questions.ts
+++ b/lib/dal/rfi-questions.ts
@@ -187,9 +187,13 @@ interface SqlSelection {
   sql: string
 }
 
-interface RfiQuestionSelectionOptions {
+export interface RfiQuestionListOptions {
   areaId?: number
+  areaIds?: number[]
   includeArchived?: boolean
+}
+
+interface RfiQuestionSelectionOptions extends RfiQuestionListOptions {
   questionId?: number
 }
 
@@ -209,6 +213,16 @@ function buildRfiQuestionSelection(
   if (options.areaId != null) {
     parameters.push(options.areaId)
     conditions.push(`question.area_id = @${parameters.length - 1}`)
+  } else if (options.areaIds != null) {
+    if (options.areaIds.length === 0) {
+      conditions.push('1 = 0')
+    } else {
+      const offset = parameters.length
+      parameters.push(...options.areaIds)
+      conditions.push(
+        `question.area_id IN (${placeholders(options.areaIds, offset)})`,
+      )
+    }
   }
   if (!options.includeArchived) {
     conditions.push('question.is_archived = 0')
@@ -545,7 +559,7 @@ async function getRfiQuestionRows(
 
 export async function listRfiQuestions(
   db: SqlServerDatabase,
-  options: { areaId?: number; includeArchived?: boolean } = {},
+  options: RfiQuestionListOptions = {},
 ): Promise<RfiQuestionRow[]> {
   return getRfiQuestionRows(db, options)
 }

--- a/lib/requirements/service-rfi-questions.ts
+++ b/lib/requirements/service-rfi-questions.ts
@@ -1,0 +1,56 @@
+import { listAreaIdsActorCanAuthor } from '@/lib/dal/requirement-areas'
+import {
+  listRfiQuestions,
+  type RfiQuestionListOptions,
+  type RfiQuestionRow,
+} from '@/lib/dal/rfi-questions'
+import type { SqlServerDatabase } from '@/lib/db'
+import type {
+  AuthorizationService,
+  RequestContext,
+} from '@/lib/requirements/auth'
+import { authorize } from '@/lib/requirements/service-shared'
+
+export interface RfiQuestionQueryService {
+  listRfiQuestions(
+    context: RequestContext,
+    input: Omit<RfiQuestionListOptions, 'areaIds'>,
+  ): Promise<RfiQuestionRow[]>
+}
+
+export function createRfiQuestionQueryService({
+  authorization,
+  db,
+}: {
+  authorization: AuthorizationService
+  db: SqlServerDatabase
+}): RfiQuestionQueryService {
+  return {
+    async listRfiQuestions(context, input) {
+      if (input.areaId != null) {
+        await authorize(
+          authorization,
+          {
+            areaId: input.areaId,
+            kind: 'manage_rfi_question',
+            operation: 'read',
+          },
+          context,
+        )
+        return listRfiQuestions(db, input)
+      }
+
+      if (context.actor.roles.includes('Admin')) {
+        return listRfiQuestions(db, input)
+      }
+
+      const areaIds = await listAreaIdsActorCanAuthor(db, context.actor.hsaId)
+      if (areaIds.length === 0) return []
+
+      return listRfiQuestions(db, {
+        areaIds,
+        includeArchived: input.includeArchived,
+      })
+    },
+  }
+}

--- a/lib/requirements/service.ts
+++ b/lib/requirements/service.ts
@@ -58,6 +58,10 @@ import {
 } from '@/lib/requirements/service-norm-references'
 import { createRequirementWorkflow } from '@/lib/requirements/service-requirements'
 import {
+  createRfiQuestionQueryService,
+  type RfiQuestionQueryService,
+} from '@/lib/requirements/service-rfi-questions'
+import {
   authorize,
   createServiceMessage,
   resolveSpecificationIdOrThrow,
@@ -369,7 +373,7 @@ export interface ManageSuggestionOutput {
   result: unknown
 }
 
-export interface RequirementsService {
+export interface RequirementsService extends RfiQuestionQueryService {
   addToSpecification(
     context: RequestContext,
     input: AddToSpecificationInput,
@@ -565,6 +569,7 @@ export function createRequirementsService(
     ...createNeedsReferenceWorkflow({ authorization, db, logger }),
     ...createNormReferenceWorkflow({ authorization, db, logger }),
     ...createRequirementWorkflow({ authorization, db, logger }),
+    ...createRfiQuestionQueryService({ authorization, db }),
 
     ...createSpecificationWorkflow({ authorization, db, logger }),
     ...createSuggestionWorkflow({ authorization, db, logger }),

--- a/tests/integration/authorization/03-requirement-area-coauthor.spec.ts
+++ b/tests/integration/authorization/03-requirement-area-coauthor.spec.ts
@@ -104,80 +104,97 @@ test('AUTHZ-03/AUTH-10/AUTH-11: requirement area co-authors only list RFI questi
   const createdQuestionIds: number[] = []
 
   try {
-    const areasResponse = await expectApiResponseOkWithRetry(
-      'find a foreign requirement area for RFI authorization',
-      () => admin.get('/api/requirement-areas', { timeout: 30_000 }),
-    )
-    const areasPayload = (await areasResponse.json()) as {
-      areas?: Array<{ id: number }>
-    }
-    const foreignArea = areasPayload.areas?.find(
-      area => area.id !== fixture.areaId,
-    )
-    if (!foreignArea) {
-      throw new Error('No foreign requirement area available for RFI check')
-    }
+    const testData =
+      await test.step('create assigned and foreign RFI questions', async () => {
+        const areasResponse = await expectApiResponseOkWithRetry(
+          'find a foreign requirement area for RFI authorization',
+          () => admin.get('/api/requirement-areas', { timeout: 30_000 }),
+        )
+        const areasPayload = (await areasResponse.json()) as {
+          areas?: Array<{ id: number }>
+        }
+        const foreignArea = areasPayload.areas?.find(
+          area => area.id !== fixture.areaId,
+        )
+        if (!foreignArea) {
+          throw new Error('No foreign requirement area available for RFI check')
+        }
 
-    const timestamp = Date.now()
-    const assignedResponse = await areaCoauthor.post('/api/rfi-questions', {
-      data: {
-        areaId: fixture.areaId,
-        questionText: `Assigned RFI authorization question ${timestamp}`,
-      },
+        const timestamp = Date.now()
+        const assignedResponse = await areaCoauthor.post('/api/rfi-questions', {
+          data: {
+            areaId: fixture.areaId,
+            questionText: `Assigned RFI authorization question ${timestamp}`,
+          },
+        })
+        await expectStatus(
+          assignedResponse,
+          201,
+          'area co-author assigned RFI question create',
+        )
+        const assignedQuestion = (await assignedResponse.json()) as {
+          id: number
+        }
+        createdQuestionIds.push(assignedQuestion.id)
+
+        const foreignResponse = await admin.post('/api/rfi-questions', {
+          data: {
+            areaId: foreignArea.id,
+            questionText: `Foreign RFI authorization question ${timestamp}`,
+          },
+        })
+        await expectStatus(
+          foreignResponse,
+          201,
+          'admin foreign RFI question create',
+        )
+        const foreignQuestion = (await foreignResponse.json()) as {
+          id: number
+        }
+        createdQuestionIds.push(foreignQuestion.id)
+
+        return {
+          assignedQuestionId: assignedQuestion.id,
+          foreignAreaId: foreignArea.id,
+          foreignQuestionId: foreignQuestion.id,
+        }
+      })
+
+    await test.step('verify the unfiltered RFI question collection', async () => {
+      const listResponse = await expectApiResponseOkWithRetry(
+        'area co-author authorized RFI question list',
+        () =>
+          areaCoauthor.get('/api/rfi-questions?includeArchived=true', {
+            timeout: 30_000,
+          }),
+      )
+      const listPayload = (await listResponse.json()) as {
+        questions?: Array<{ id: number }>
+      }
+      const listedQuestionIds = (listPayload.questions ?? []).map(
+        question => question.id,
+      )
+      expect(listedQuestionIds).toContain(testData.assignedQuestionId)
+      expect(listedQuestionIds).not.toContain(testData.foreignQuestionId)
     })
-    await expectStatus(
-      assignedResponse,
-      201,
-      'area co-author assigned RFI question create',
-    )
-    const assignedQuestion = (await assignedResponse.json()) as {
-      id: number
-    }
-    createdQuestionIds.push(assignedQuestion.id)
 
-    const foreignResponse = await admin.post('/api/rfi-questions', {
-      data: {
-        areaId: foreignArea.id,
-        questionText: `Foreign RFI authorization question ${timestamp}`,
-      },
+    await test.step('verify explicit-area RFI question collections', async () => {
+      const assignedAreaResponse = await areaCoauthor.get(
+        `/api/rfi-questions?areaId=${fixture.areaId}`,
+      )
+      await expectStatus(
+        assignedAreaResponse,
+        200,
+        'area co-author assigned-area RFI question list',
+      )
+      await expectStatus(
+        await areaCoauthor.get(
+          `/api/rfi-questions?areaId=${testData.foreignAreaId}`,
+        ),
+        403,
+        'area co-author foreign-area RFI question list',
+      )
     })
-    await expectStatus(
-      foreignResponse,
-      201,
-      'admin foreign RFI question create',
-    )
-    const foreignQuestion = (await foreignResponse.json()) as { id: number }
-    createdQuestionIds.push(foreignQuestion.id)
-
-    const listResponse = await expectApiResponseOkWithRetry(
-      'area co-author authorized RFI question list',
-      () =>
-        areaCoauthor.get('/api/rfi-questions?includeArchived=true', {
-          timeout: 30_000,
-        }),
-    )
-    const listPayload = (await listResponse.json()) as {
-      questions?: Array<{ id: number }>
-    }
-    const listedQuestionIds = (listPayload.questions ?? []).map(
-      question => question.id,
-    )
-    expect(listedQuestionIds).toContain(assignedQuestion.id)
-    expect(listedQuestionIds).not.toContain(foreignQuestion.id)
-
-    const assignedAreaResponse = await areaCoauthor.get(
-      `/api/rfi-questions?areaId=${fixture.areaId}`,
-    )
-    await expectStatus(
-      assignedAreaResponse,
-      200,
-      'area co-author assigned-area RFI question list',
-    )
-    await expectStatus(
-      await areaCoauthor.get(`/api/rfi-questions?areaId=${foreignArea.id}`),
-      403,
-      'area co-author foreign-area RFI question list',
-    )
   } finally {
     for (const questionId of createdQuestionIds) {
       await admin.delete(`/api/rfi-questions/${questionId}`)

--- a/tests/integration/authorization/03-requirement-area-coauthor.spec.ts
+++ b/tests/integration/authorization/03-requirement-area-coauthor.spec.ts
@@ -95,6 +95,98 @@ test('AUTHZ-03/AUTH-10/AUTH-11: requirement area co-authors can create requireme
   }
 })
 
+test('AUTHZ-03/AUTH-10/AUTH-11: requirement area co-authors only list RFI questions from assigned areas', async ({
+  browserName: _browserName,
+}, testInfo) => {
+  referenceManualCases(testInfo, 'AUTHZ-03', 'AUTH-10', 'AUTH-11')
+  const admin = await newRoleContext(testInfo, 'admin')
+  const areaCoauthor = await newRoleContext(testInfo, 'areaCoauthor')
+  const createdQuestionIds: number[] = []
+
+  try {
+    const areasResponse = await expectApiResponseOkWithRetry(
+      'find a foreign requirement area for RFI authorization',
+      () => admin.get('/api/requirement-areas', { timeout: 30_000 }),
+    )
+    const areasPayload = (await areasResponse.json()) as {
+      areas?: Array<{ id: number }>
+    }
+    const foreignArea = areasPayload.areas?.find(
+      area => area.id !== fixture.areaId,
+    )
+    if (!foreignArea) {
+      throw new Error('No foreign requirement area available for RFI check')
+    }
+
+    const timestamp = Date.now()
+    const assignedResponse = await areaCoauthor.post('/api/rfi-questions', {
+      data: {
+        areaId: fixture.areaId,
+        questionText: `Assigned RFI authorization question ${timestamp}`,
+      },
+    })
+    await expectStatus(
+      assignedResponse,
+      201,
+      'area co-author assigned RFI question create',
+    )
+    const assignedQuestion = (await assignedResponse.json()) as {
+      id: number
+    }
+    createdQuestionIds.push(assignedQuestion.id)
+
+    const foreignResponse = await admin.post('/api/rfi-questions', {
+      data: {
+        areaId: foreignArea.id,
+        questionText: `Foreign RFI authorization question ${timestamp}`,
+      },
+    })
+    await expectStatus(
+      foreignResponse,
+      201,
+      'admin foreign RFI question create',
+    )
+    const foreignQuestion = (await foreignResponse.json()) as { id: number }
+    createdQuestionIds.push(foreignQuestion.id)
+
+    const listResponse = await expectApiResponseOkWithRetry(
+      'area co-author authorized RFI question list',
+      () =>
+        areaCoauthor.get('/api/rfi-questions?includeArchived=true', {
+          timeout: 30_000,
+        }),
+    )
+    const listPayload = (await listResponse.json()) as {
+      questions?: Array<{ id: number }>
+    }
+    const listedQuestionIds = (listPayload.questions ?? []).map(
+      question => question.id,
+    )
+    expect(listedQuestionIds).toContain(assignedQuestion.id)
+    expect(listedQuestionIds).not.toContain(foreignQuestion.id)
+
+    const assignedAreaResponse = await areaCoauthor.get(
+      `/api/rfi-questions?areaId=${fixture.areaId}`,
+    )
+    await expectStatus(
+      assignedAreaResponse,
+      200,
+      'area co-author assigned-area RFI question list',
+    )
+    await expectStatus(
+      await areaCoauthor.get(`/api/rfi-questions?areaId=${foreignArea.id}`),
+      403,
+      'area co-author foreign-area RFI question list',
+    )
+  } finally {
+    for (const questionId of createdQuestionIds) {
+      await admin.delete(`/api/rfi-questions/${questionId}`)
+    }
+    await areaCoauthor.dispose()
+    await admin.dispose()
+  }
+})
+
 test('AUTHZ-03/AUTH-10/AUTH-11: requirement area co-authors cannot delegate area access', async ({
   page,
 }, testInfo) => {

--- a/tests/unit/mcp-authz.test.ts
+++ b/tests/unit/mcp-authz.test.ts
@@ -178,6 +178,7 @@ function createService() {
     graduateSpecificationLocalRequirement,
     listDeviations: vi.fn(),
     listGraduationTargetAreas,
+    listRfiQuestions: vi.fn(async () => []),
     listSpecifications,
     listSuggestions,
     manageDeviation: vi.fn(),

--- a/tests/unit/mcp-property.test.ts
+++ b/tests/unit/mcp-property.test.ts
@@ -227,6 +227,7 @@ function createService() {
       areas: [{ id: 2, name: 'Security', prefix: 'SEC' }],
       message: 'Graduation target requirement areas',
     })),
+    listRfiQuestions: vi.fn(async () => []),
     listSpecifications: vi.fn(async () => ({
       message: 'Specifications',
       specifications: [],

--- a/tests/unit/mcp-security.test.ts
+++ b/tests/unit/mcp-security.test.ts
@@ -141,6 +141,7 @@ function createService() {
       areas: [{ id: 2, name: 'Security', prefix: 'SEC' }],
       message: 'Graduation target requirement areas',
     })),
+    listRfiQuestions: vi.fn(async () => []),
     listSpecifications: vi.fn(async () => ({
       message: 'Specifications',
       specifications: [],

--- a/tests/unit/rfi-question-route.test.ts
+++ b/tests/unit/rfi-question-route.test.ts
@@ -12,6 +12,7 @@ const routeState = vi.hoisted(() => ({
   db: { query: vi.fn() },
   getRfiQuestion: vi.fn(),
   getRequestSqlServerDataSource: vi.fn(),
+  listRfiQuestionsForActor: vi.fn(),
   listRfiQuestions: vi.fn(),
   recordAllowedActionAuditEvent: vi.fn(),
   recordDeniedActionAuditEvent: vi.fn(),
@@ -92,6 +93,7 @@ function jsonRequest(url: string, method: string, body?: unknown) {
 describe('RFI question routes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    context.actor.roles = ['RequirementsEditor']
     routeState.assertAuthorized.mockResolvedValue(undefined)
     routeState.createDefaultAuthorizationService.mockReturnValue({
       assertAuthorized: routeState.assertAuthorized,
@@ -104,6 +106,9 @@ describe('RFI question routes', () => {
       authorization: { assertAuthorized: vi.fn() },
       context,
       db: { db: true },
+      service: {
+        listRfiQuestions: routeState.listRfiQuestionsForActor,
+      },
     })
     routeState.authorize.mockResolvedValue(undefined)
     routeState.getRfiQuestion.mockResolvedValue({
@@ -118,6 +123,7 @@ describe('RFI question routes', () => {
       questionText: 'How do you handle logs?',
     })
     routeState.listRfiQuestions.mockResolvedValue([])
+    routeState.listRfiQuestionsForActor.mockResolvedValue([])
     routeState.setRfiQuestionArchived.mockResolvedValue({
       areaId: 7,
       id: 12,
@@ -262,7 +268,7 @@ describe('RFI question routes', () => {
 
   it('lists RFI questions using the validated filters', async () => {
     const questions = [{ areaId: 7, id: 12, questionCode: 'INF-RFI001' }]
-    routeState.listRfiQuestions.mockResolvedValueOnce(questions)
+    routeState.listRfiQuestionsForActor.mockResolvedValueOnce(questions)
 
     const response = await listRfiQuestionsGet(
       new Request(
@@ -272,10 +278,58 @@ describe('RFI question routes', () => {
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ questions })
-    expect(routeState.listRfiQuestions).toHaveBeenCalledWith(routeState.db, {
+    expect(routeState.listRfiQuestionsForActor).toHaveBeenCalledWith(context, {
       areaId: 7,
       includeArchived: true,
     })
+  })
+
+  it('returns the service authorization failure for a foreign-area collection read', async () => {
+    routeState.listRfiQuestionsForActor.mockRejectedValueOnce(
+      forbiddenError('denied'),
+    )
+
+    const response = await listRfiQuestionsGet(
+      new Request('http://localhost/api/rfi-questions?areaId=8'),
+    )
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toMatchObject({
+      code: 'forbidden',
+      error: 'Forbidden',
+    })
+    expect(routeState.listRfiQuestionsForActor).toHaveBeenCalledWith(context, {
+      areaId: 8,
+      includeArchived: false,
+    })
+    expect(routeState.listRfiQuestions).not.toHaveBeenCalled()
+  })
+
+  it('returns only the authorized questions supplied by the requirements service', async () => {
+    const authorizedQuestions = [
+      { areaId: 7, id: 12, questionCode: 'INF-RFI001' },
+    ]
+    routeState.listRfiQuestionsForActor.mockResolvedValueOnce(
+      authorizedQuestions,
+    )
+
+    const response = await listRfiQuestionsGet(
+      new Request('http://localhost/api/rfi-questions?includeArchived=true'),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      questions: authorizedQuestions,
+    })
+  })
+
+  it('returns an empty authorized collection', async () => {
+    const response = await listRfiQuestionsGet(
+      new Request('http://localhost/api/rfi-questions'),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ questions: [] })
   })
 
   it('rejects invalid RFI question filters before querying persistence', async () => {
@@ -284,7 +338,7 @@ describe('RFI question routes', () => {
     )
 
     expect(response.status).toBe(400)
-    expect(routeState.listRfiQuestions).not.toHaveBeenCalled()
+    expect(routeState.listRfiQuestionsForActor).not.toHaveBeenCalled()
   })
 
   it('returns 404 when the requested RFI question does not exist', async () => {

--- a/tests/unit/rfi-questions-dal.test.ts
+++ b/tests/unit/rfi-questions-dal.test.ts
@@ -147,6 +147,34 @@ describe('RFI questions DAL', () => {
     expect(query.mock.calls[1]?.[1]).toEqual([2])
   })
 
+  it('scopes catalog queries to the authorized requirement areas', async () => {
+    const query = createQuery([[activeQuestionRow], []])
+
+    await listRfiQuestions(
+      { query } as unknown as Parameters<typeof listRfiQuestions>[0],
+      { areaIds: [2, 4], includeArchived: true },
+    )
+
+    expect(String(query.mock.calls[0]?.[0])).toContain(
+      'question.area_id IN (@0, @1)',
+    )
+    expect(query.mock.calls[0]?.[1]).toEqual([2, 4])
+    expect(query.mock.calls[1]?.[1]).toEqual([2, 4])
+  })
+
+  it('fails closed when the authorized requirement area set is empty', async () => {
+    const query = createQuery([[]])
+
+    await expect(
+      listRfiQuestions(
+        { query } as unknown as Parameters<typeof listRfiQuestions>[0],
+        { areaIds: [], includeArchived: true },
+      ),
+    ).resolves.toEqual([])
+
+    expect(String(query.mock.calls[0]?.[0])).toContain('WHERE 1 = 0')
+  })
+
   it('returns an empty catalog without running the version-link query', async () => {
     const query = createQuery([[]])
 

--- a/tests/unit/service-rfi-questions.test.ts
+++ b/tests/unit/service-rfi-questions.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RequestContext } from '@/lib/requirements/auth'
+import { forbiddenError } from '@/lib/requirements/errors'
+
+const mocks = vi.hoisted(() => ({
+  listAreaIdsActorCanAuthor: vi.fn(),
+  listRfiQuestions: vi.fn(),
+  recordAuthorizationDenied: vi.fn(),
+}))
+
+vi.mock('@/lib/dal/requirement-areas', () => ({
+  listAreaIdsActorCanAuthor: mocks.listAreaIdsActorCanAuthor,
+}))
+
+vi.mock('@/lib/dal/rfi-questions', () => ({
+  listRfiQuestions: mocks.listRfiQuestions,
+}))
+
+vi.mock('@/lib/requirements/security-audit', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('@/lib/requirements/security-audit')>()
+  return {
+    ...actual,
+    recordAuthorizationDenied: mocks.recordAuthorizationDenied,
+  }
+})
+
+import { createRfiQuestionQueryService } from '@/lib/requirements/service-rfi-questions'
+
+const db = { query: vi.fn() }
+const question = { areaId: 7, id: 12, questionCode: 'INF-RFI001' }
+const context: RequestContext = {
+  actor: {
+    displayName: 'RFI Author',
+    hsaId: 'SE5560000001-rfi-author',
+    id: 'rfi-author',
+    isAuthenticated: true,
+    roles: ['RequirementsEditor'],
+    source: 'oidc',
+  },
+  correlationId: 'correlation-1',
+  requestId: 'request-1',
+  source: 'rest',
+}
+
+describe('RFI question query service', () => {
+  const assertAuthorized = vi.fn()
+  const service = createRfiQuestionQueryService({
+    authorization: { assertAuthorized },
+    db: db as never,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    context.actor.roles = ['RequirementsEditor']
+    assertAuthorized.mockResolvedValue(undefined)
+    mocks.listAreaIdsActorCanAuthor.mockResolvedValue([7])
+    mocks.listRfiQuestions.mockResolvedValue([question])
+    mocks.recordAuthorizationDenied.mockResolvedValue(undefined)
+  })
+
+  it('authorizes an explicit requirement area before returning its questions', async () => {
+    await expect(
+      service.listRfiQuestions(context, {
+        areaId: 7,
+        includeArchived: true,
+      }),
+    ).resolves.toEqual([question])
+
+    expect(assertAuthorized).toHaveBeenCalledWith(
+      {
+        areaId: 7,
+        kind: 'manage_rfi_question',
+        operation: 'read',
+      },
+      context,
+    )
+    expect(mocks.listRfiQuestions).toHaveBeenCalledWith(db, {
+      areaId: 7,
+      includeArchived: true,
+    })
+  })
+
+  it('rejects a foreign requirement area before reading protected questions', async () => {
+    assertAuthorized.mockRejectedValueOnce(forbiddenError('denied'))
+
+    await expect(
+      service.listRfiQuestions(context, { areaId: 8 }),
+    ).rejects.toMatchObject({ code: 'forbidden' })
+
+    expect(mocks.listRfiQuestions).not.toHaveBeenCalled()
+  })
+
+  it('returns only questions from the actor authored requirement areas', async () => {
+    mocks.listAreaIdsActorCanAuthor.mockResolvedValueOnce([7, 9])
+
+    await expect(
+      service.listRfiQuestions(context, { includeArchived: true }),
+    ).resolves.toEqual([question])
+
+    expect(mocks.listAreaIdsActorCanAuthor).toHaveBeenCalledWith(
+      db,
+      context.actor.hsaId,
+    )
+    expect(mocks.listRfiQuestions).toHaveBeenCalledWith(db, {
+      areaIds: [7, 9],
+      includeArchived: true,
+    })
+  })
+
+  it('returns no questions without an authored requirement area', async () => {
+    mocks.listAreaIdsActorCanAuthor.mockResolvedValueOnce([])
+
+    await expect(service.listRfiQuestions(context, {})).resolves.toEqual([])
+
+    expect(mocks.listRfiQuestions).not.toHaveBeenCalled()
+  })
+
+  it('allows Admin to list questions across all requirement areas', async () => {
+    context.actor.roles = ['Admin']
+
+    await expect(
+      service.listRfiQuestions(context, { includeArchived: true }),
+    ).resolves.toEqual([question])
+
+    expect(mocks.listAreaIdsActorCanAuthor).not.toHaveBeenCalled()
+    expect(mocks.listRfiQuestions).toHaveBeenCalledWith(db, {
+      includeArchived: true,
+    })
+  })
+})


### PR DESCRIPTION
## Description

- Authorize area-filtered RFI question collection reads before accessing protected question data.
- Restrict unfiltered RFI question management lists to requirement areas where the user is an owner or co-author, while preserving all-area access for `Admin` users.
- Centralize the collection-read policy in `RequirementsService` and add route, service, DAL, and authorization regression coverage.

## Related Issues

Fixes #842

## Reviewer Notes

- `npm run check` passed: 503 test files and 7,264 tests, plus both HSA support suites.
- The Playwright authorization scenario was added but was not run locally because Keycloak and SQL Server were not running.
- Standards and specification review passes reported no findings.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
After the upgrade, RFI question management lists show only questions from requirement areas where the signed-in user is an owner or co-author. Direct collection reads for an unassigned requirement area now return 403. `Admin` users retain access to all requirement areas.

Before rollout, confirm that users who manage RFI questions have the required requirement area assignments. Validate this access boundary during rollout.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1066)
<!-- Reviewable:end -->
