### PR TITLE
docs: persist operator upgrade notes from #1066

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -298,6 +298,11 @@ requests are rejected before database work starts.
 <!-- operator-upgrade:source pr-1062 start -->
 Standard Kravhantering Keycloak provisioning and demo-user setup are not affected. This change affects only deployments that use custom delegated Keycloak administrators: make sure these administrators can manage client scopes, and assign Admin API roles directly or through groups instead of through protocol mappers.
 <!-- operator-upgrade:source pr-1062 end -->
+
+<!-- operator-upgrade:source pr-1066 start -->
+After the upgrade, RFI question management lists show only questions from requirement areas where the signed-in user is an owner or co-author. Direct collection reads for an unassigned requirement area now return 403. `Admin` users retain access to all requirement areas.
+Before rollout, confirm that users who manage RFI questions have the required requirement area assignments. Validate this access boundary during rollout.
+<!-- operator-upgrade:source pr-1066 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #1066
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/32126462099

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1067)
<!-- Reviewable:end -->
