### PR TITLE
docs: persist operator upgrade notes from #1068

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -303,6 +303,11 @@ Standard Kravhantering Keycloak provisioning and demo-user setup are not affecte
 After the upgrade, RFI question management lists show only questions from requirement areas where the signed-in user is an owner or co-author. Direct collection reads for an unassigned requirement area now return 403. `Admin` users retain access to all requirement areas.
 Before rollout, confirm that users who manage RFI questions have the required requirement area assignments. Validate this access boundary during rollout.
 <!-- operator-upgrade:source pr-1066 end -->
+
+<!-- operator-upgrade:source pr-1068 start -->
+Before upgrade, review generated-output limits and temporary-storage capacity. JSON person data exports now use the existing CSV item, file-size, timeout, and shared per-node concurrency limits. PDF person data exports use the PDF item, file-size, timeout, per-node concurrency, and worker-memory limits.
+Exports that exceed these limits are rejected without a partial file. Validate the limits against retained subject histories and monitor privacy export capacity events after rollout.
+<!-- operator-upgrade:source pr-1068 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #1068
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/32143633955

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1070)
<!-- Reviewable:end -->
