### PR TITLE
Authenticate Azure development SSH host keys

### DIFF
--- a/docs/development/azure-vm-remote-ssh-development.md
+++ b/docs/development/azure-vm-remote-ssh-development.md
@@ -296,7 +296,10 @@ Install these tools on the workstation:
 
 - PowerShell 7+ terminal
 - Azure CLI
-- OpenSSH client, `ssh-keygen`, and `scp`
+- OpenSSH 8.6 or later on Windows, or OpenSSH 8.5 or later on macOS and Linux,
+  plus `ssh-keygen` and `scp`. The workflow reads Windows application-version
+  metadata through PowerShell and reads the OpenSSH version output on macOS and
+  Linux.
 - VS Code with Remote SSH
 - GitHub CLI when GitHub access is required from the remote environment
 - MesloLGS Nerd Font Mono installed on the workstation

--- a/docs/development/azure-vm-remote-ssh-development.md
+++ b/docs/development/azure-vm-remote-ssh-development.md
@@ -265,9 +265,11 @@ group. If the group exists without them, setup fails closed and prints the
 ### Register providers
 
 The least-practical custom role needs resource-group deployment, compute,
-network, disk, public IP, SSH public-key, and optional DevTestLab schedule
-actions. The setup command does not create role assignments and does not use VM
-extensions, VM runCommand, Azure SSH key-pair generation, or `DataActions`.
+network, disk, public IP, SSH public-key, Azure Run Command, and optional
+DevTestLab schedule actions. Host-key authentication specifically requires
+`Microsoft.Compute/virtualMachines/runCommand/action`. The setup command does
+not create role assignments and does not use Azure SSH key-pair generation or
+`DataActions`.
 
 If your tenant requires explicit provider registration, an owner can check or
 register these providers:
@@ -799,12 +801,36 @@ every charge. It does not run the Azure deployment preview; use
 
 Use `-Yes` for non-interactive confirmation. The command creates a dedicated
 SSH key if missing, provisions Azure resources, installs the managed SSH config
-block with SSH agent forwarding enabled when approved, waits for SSH, uploads
-the local bootstrap and Quadlet templates, the selected Zsh profile, and the
-Azure development-tooling files, configures the remote Git identity and SSH
-commit signing, reruns the VM bootstrap, and runs smoke validation.
+block with SSH agent forwarding enabled when approved, authenticates the VM
+host keys through Azure Run Command, waits for strict SSH, uploads the local
+bootstrap and Quadlet templates, the selected Zsh profile, and the Azure
+development-tooling files, configures the remote Git identity and SSH commit
+signing, reruns the VM bootstrap, and runs smoke validation.
 If the VM already exists but was deallocated by `stop` or auto-shutdown, `setup`
 starts it before waiting for SSH.
+
+### SSH host trust
+
+Setup and start establish host trust before their first network SSH
+connection. Through the authenticated Azure control plane, Azure Run Command
+reads the VM's `/etc/ssh/ssh_host_*_key.pub` files. The local workflow validates
+the returned public-key wire blobs, then atomically replaces only the managed
+alias and resolved-host entries in `~/.ssh/known_hosts`. Other entries,
+including hashed entries for unrelated hosts, remain intact.
+
+The first SSH probe and all later setup, bootstrap, validation, start, and
+maintenance SSH or SCP operations use `StrictHostKeyChecking=yes`, the pinned
+user `known_hosts` file, no global known-host file, and
+`KnownHostsCommand=none`, `VerifyHostKeyDNS=no`, and `UpdateHostKeys=no`.
+Missing, malformed, or unavailable Azure evidence stops the workflow before
+SSH. A network-presented mismatch stops immediately before remote preparation,
+local bootstrap credential-file generation, or upload.
+
+When Azure legitimately recreates the VM or rotates its host keys, rerun
+`setup -Yes` or `start -Yes`. The command obtains fresh keys independently
+through Azure Run Command and replaces only the entries authenticated by that
+evidence. If Azure Run Command cannot return valid keys, do not remove
+`known_hosts` entries manually; restore VM Agent/control-plane access and retry.
 
 The first setup can take a while. It installs host packages, mounts the data
 disk at `/mnt/krav-azure-dev-data`, bind-mounts
@@ -924,6 +950,9 @@ For administration tasks, use the generated regular SSH command:
 
 ```sh
 ssh -i "<private-key-path>" -o IdentitiesOnly=yes \
+  -o StrictHostKeyChecking=yes -o GlobalKnownHostsFile=none \
+  -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+  -o KnownHostsCommand=none -o VerifyHostKeyDNS=no -o UpdateHostKeys=no \
   -o SendEnv=GH_TOKEN -o SendEnv=COPILOT_GITHUB_TOKEN \
   vscode@<public-ip-or-tailscale-name>
 ```
@@ -1542,12 +1571,19 @@ for name in GH_TOKEN COPILOT_GITHUB_TOKEN; do
 done
 ```
 
-If Azure recreates the VM and SSH reports a host-key mismatch, run the exact
-command printed by the tool:
+If Azure recreates the VM or rotates its SSH host keys, refresh trust through
+the authenticated Azure control plane:
 
-```sh
-ssh-keygen -R kravhantering-azure-dev
+```powershell
+./scripts/azure-dev.ps1 setup -Yes
+# Or, when no setup convergence is needed:
+./scripts/azure-dev.ps1 start -Yes
 ```
+
+Do not run `ssh-keygen -R` and accept the next network-presented key. If the
+refresh reports missing, malformed, or unavailable Azure host-key evidence,
+restore Azure VM Agent and Run Command access first. Setup remains stopped
+before bootstrap credential generation or upload.
 
 If setup reports that the existing VM was created with a different SSH public
 key, the VM must be recreated. Azure does not allow changing

--- a/docs/development/azure-vm-remote-ssh-internals.md
+++ b/docs/development/azure-vm-remote-ssh-internals.md
@@ -54,7 +54,7 @@ Module responsibilities:
 | `AzureDev.Config.psm1` | Strict dotenv parsing, defaults, precedence, config validation, and context creation. |
 | `AzureDev.Logging.psm1` | Local state, locks, JSONL logs, redaction, and native command execution helpers. |
 | `AzureDev.Azure.psm1` | Azure CLI calls, authentication checks, SKU and image lookup, resource-group ownership, deployment, power operations, CIDR updates, and tag-based deletion. |
-| `AzureDev.Ssh.psm1` | Public IPv4 detection, CIDR validation, SSH key generation, managed OpenSSH config blocks, host-key mismatch handling, SSH wait loop, and VS Code command formatting. |
+| `AzureDev.Ssh.psm1` | Public IPv4 detection, CIDR validation, SSH key generation, managed OpenSSH config blocks, Azure control-plane host-key authentication, SSH wait loop, and VS Code command formatting. |
 | `AzureDev.Bootstrap.psm1` | Uploads `bootstrap-host.sh`, Quadlet templates, and the selected Zsh profile with `scp`, then invokes bootstrap over SSH with port forwarding disabled. |
 | `AzureDev.Validation.psm1` | Checks the workstation terminal font, runs post-setup smoke validation over SSH, and reports remote diagnostics on failure. |
 | `AzureDev.Podman.psm1` | Shared support-service unit and port metadata used by validation. |
@@ -338,16 +338,44 @@ installation choices. It points to `.vscode/extensions.json` as the source for
 SSH host, and gives the workspace-only Command Palette alternative. Do not
 silently change the developer's application-wide VS Code settings.
 
-Remote command probes use:
+Before the first network SSH connection, setup and start invoke
+`RunShellScript` through the authenticated Azure control plane. The guest
+script reads `/etc/ssh/ssh_host_*_key.pub`; it does not create or transmit any
+bootstrap credential. The workstation validates every returned SSH public-key
+wire blob and rejects missing output, malformed JSON, malformed keys, or guest
+errors.
+
+Only authenticated key material may update `~/.ssh/known_hosts`. The update is
+built in a temporary file: `ssh-keygen -R` removes the managed alias and
+resolved host from that copy, including hashed entries, then the authenticated
+keys are appended for both names and the file is moved into place. Unrelated
+entries remain unchanged. This gives a recreated VM a replacement path without
+trusting the network-presented key.
+
+The first SSH probe and every setup, bootstrap, validation, start, and
+maintenance SSH or SCP operation use:
 
 ```text
 BatchMode=yes
 ClearAllForwardings=yes
-StrictHostKeyChecking=accept-new
+StrictHostKeyChecking=yes
+UserKnownHostsFile=~/.ssh/known_hosts
+GlobalKnownHostsFile=none
+KnownHostsCommand=none
+VerifyHostKeyDNS=no
+UpdateHostKeys=no
 ```
 
 `ClearAllForwardings=yes` is important for maintenance commands because an
 existing VS Code Remote SSH session may already own the forwarded local ports.
+The explicit known-host options disable global, command-provided, and DNS trust
+sources and prevent learning replacement keys from the network.
+
+A network-presented mismatch fails immediately. The workflow does not delete
+the installed entry and retry. Missing or unverifiable Azure evidence also
+fails before SSH, remote preparation, bootstrap credential generation, or SCP.
+After a successful strict probe, the in-memory setup context records that host
+trust is established; bootstrap and smoke validation require that state.
 
 Tailscale mode is explicit. It uses ordinary OpenSSH over the VM's Tailscale
 address and does not enable Tailscale SSH.

--- a/docs/reference/openssh-client-minimum-version-research.md
+++ b/docs/reference/openssh-client-minimum-version-research.md
@@ -1,0 +1,108 @@
+# OpenSSH client minimum-version research note
+
+Research date: 2026-08-18
+
+## Decision summary
+
+The Azure development workflow supports Windows, macOS, and Linux
+workstations. The supported platform names are an explicit contract in
+[`AzureDev.Workstation.psm1`](../../scripts/azure-dev/AzureDev.Workstation.psm1).
+
+The complete host-key argument set requires OpenSSH 8.5 or later on every
+platform. This is an upstream OpenSSH client feature boundary, not an operating
+system boundary. The repository should enforce these platform floors:
+
+<!-- markdownlint-disable MD013 -->
+| Platform | Minimum to enforce | Basis |
+| --- | --- | --- |
+| Windows | Win32-OpenSSH 8.6 | OpenSSH 8.5 contains the required behavior, but Microsoft's official Windows release history jumps from 8.1.0.0 to 8.6.0.0. Version 8.6 is therefore the first supported Microsoft build that contains it. |
+| macOS | OpenSSH 8.5 | The option parser and host-file behavior come from upstream OpenSSH. Apple's in-box release history also jumps from OpenSSH 8.1 to 8.6, but a non-Apple OpenSSH 8.5 client is technically sufficient. |
+| Linux | OpenSSH 8.5 | The upstream portable OpenSSH 8.5 release is the feature boundary. Distribution package revisions do not change that upstream major/minor floor. |
+<!-- markdownlint-enable MD013 -->
+
+A hypothetical Windows build based on upstream OpenSSH 8.5 can support the
+features, but Microsoft does not publish a Win32-OpenSSH 8.5 release. The 8.6
+Windows floor is therefore a supported-package floor rather than a different
+implementation boundary. Microsoft's
+[Win32-OpenSSH release history](https://github.com/PowerShell/Win32-OpenSSH#release-history)
+lists 8.1.0.0 followed by 8.6.0.0.
+
+Apple's source history shows the same practical vendor jump. Apple package
+`OpenSSH-240.40.1` identifies its upstream client as
+[OpenSSH 8.1](https://github.com/apple-oss-distributions/OpenSSH/blob/OpenSSH-240.40.1/openssh/version.h),
+while `OpenSSH-268.100.4` identifies it as
+[OpenSSH 8.6](https://github.com/apple-oss-distributions/OpenSSH/blob/OpenSSH-268.100.4/openssh/version.h).
+This does not make 8.6 an OpenSSH feature requirement on macOS because users
+can install a portable client independently of the operating system.
+
+## Option-by-option boundary
+
+The repository supplies these host-key options to `ssh` and `scp`:
+
+- `StrictHostKeyChecking=yes`
+- `UserKnownHostsFile=<managed path>`
+- `GlobalKnownHostsFile=none`
+- `KnownHostsCommand=none`
+- `VerifyHostKeyDNS=no`
+- `UpdateHostKeys=no`
+
+`StrictHostKeyChecking`, `UserKnownHostsFile`, and `GlobalKnownHostsFile`
+predate the other relevant boundaries. `VerifyHostKeyDNS` is present in
+OpenSSH 3.7p1. `UpdateHostKeys` is introduced in OpenSSH 6.8; the upstream
+[6.8 release notes](https://www.openssh.org/txt/release-6.8) describe both the
+host-key rotation protocol and its client configuration option.
+
+`KnownHostsCommand` is the newest named option. The upstream
+[8.5 release notes](https://www.openssh.org/txt/release-8.5) identify it as a
+new client option since OpenSSH 8.4. The
+[8.5p1 client manual](https://raw.githubusercontent.com/openssh/openssh-portable/V_8_5_P1/ssh_config.5)
+contains the directive, while the
+[8.4p1 client manual](https://raw.githubusercontent.com/openssh/openssh-portable/V_8_4_P1/ssh_config.5)
+does not.
+
+The value `none` for `GlobalKnownHostsFile` adds a second 8.5 dependency.
+OpenSSH 8.5 client startup explicitly recognizes `none` and clears the global
+host-file list in
+[`ssh.c`](https://github.com/openssh/openssh-portable/blob/V_8_5_P1/ssh.c#L1430-L1447).
+OpenSSH 8.4 parses the value only as an ordinary filename in
+[the OpenSSH 8.4 parser source](https://github.com/openssh/openssh-portable/blob/V_8_4_P1/readconf.c#L1184-L1210).
+Consequently, an older client can accept
+`GlobalKnownHostsFile=none` without providing the intended isolation from
+global trust data.
+
+Removing only `KnownHostsCommand=none` therefore does **not** safely lower the
+minimum version. The current `GlobalKnownHostsFile=none` behavior still
+requires OpenSSH 8.5. If both that command option is removed and the global
+host-file value is replaced with a safe platform-specific null path, the next
+feature boundary is OpenSSH 6.8 because of `UpdateHostKeys`.
+
+## Version reporting and enforcement
+
+PowerShell exposes Windows executable version resources through
+`(Get-Command ssh -CommandType Application).Version`. The
+[ApplicationInfo API](https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.applicationinfo?view=powershellsdk-7.4.0)
+describes this property as the application's source version. Compare its major
+and minor components for official Win32-OpenSSH binaries; the remaining
+components are Windows servicing/build values.
+
+That metadata is not portable. Microsoft's own
+[`Get-Command` documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/get-command?view=powershell-7.6)
+shows Unix native applications with version `0.0.0.0`. On macOS and Linux,
+resolve the executable with `Get-Command`, invoke that resolved path with
+`-V`, and parse the `OpenSSH_<major>.<minor>` product version. The upstream
+[`ssh(1)` manual](https://man.openbsd.org/ssh.1) defines `-V` as displaying the
+version number and exiting.
+
+Microsoft likewise directs Windows administrators to use `ssh -V` to check
+the OpenSSH product version and `Get-Command ssh.exe` to identify the selected
+binary in its
+[in-box OpenSSH upgrade guidance](https://learn.microsoft.com/en-us/troubleshoot/windows-server/system-management-components/upgrade-in-box-openssh-to-latest-openssh-release).
+Using the PowerShell application version on Windows is convenient, but
+`ssh -V` remains a suitable fallback when that metadata is absent or zero.
+
+Linux distribution package versions can include an epoch and distribution
+revision in addition to the upstream version. For example, Ubuntu publishes
+OpenSSH 8.9p1 as package
+[`1:8.9p1-3ubuntu0.15`](https://packages.ubuntu.com/jammy/openssh-client).
+Enforcement should compare the OpenSSH product major/minor, not the package
+manager's full version string.

--- a/scripts/azure-dev.ps1
+++ b/scripts/azure-dev.ps1
@@ -234,6 +234,9 @@ function Write-AzureDevSshInstructions {
   Write-Host 'For administration tasks, connect using standard SSH:'
   Write-Host (
     "ssh -i `"$identityFile`" -o IdentitiesOnly=yes " +
+    '-o StrictHostKeyChecking=yes -o GlobalKnownHostsFile=none ' +
+    "-o UserKnownHostsFile=`"$($Context.Config.SshKnownHostsPath)`" " +
+    '-o KnownHostsCommand=none -o VerifyHostKeyDNS=no -o UpdateHostKeys=no ' +
     "-o SendEnv=GH_TOKEN -o SendEnv=COPILOT_GITHUB_TOKEN vscode@$hostName"
   )
 
@@ -384,20 +387,22 @@ function Wait-AzureDevTrustedLaunchGuestReadiness {
   $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
   $lastReason = ''
   do {
+    $arguments = [System.Object[]]@(
+      '-o',
+      'BatchMode=yes',
+      '-o',
+      'ClearAllForwardings=yes',
+      '-o',
+      'ConnectTimeout=15'
+    )
+    $arguments += $Context.Config.SshHostKeyArguments
+    $arguments += [System.Object[]]@(
+      $Context.Config.SshHostAlias,
+      ($commands -join '; ')
+    )
     $result = Invoke-AzureDevNativeCommand `
       -FilePath 'ssh' `
-      -Arguments @(
-        '-o',
-        'BatchMode=yes',
-        '-o',
-        'ClearAllForwardings=yes',
-        '-o',
-        'ConnectTimeout=15',
-        '-o',
-        'StrictHostKeyChecking=accept-new',
-        $Context.Config.SshHostAlias,
-        ($commands -join '; ')
-      )
+      -Arguments $arguments
     if (
       $result.ExitCode -eq 0 -and
       $result.Text -match 'AZURE_DEV_TRUSTED_LAUNCH_READY'
@@ -641,6 +646,9 @@ function Invoke-AzureDevSetup {
               'config is applied. Rerun setup with -Apply or -Yes.'
             )
           }
+          Wait-AzureDevSsh `
+            -Context $Context `
+            -HostName $trustedLaunchHostName | Out-Null
           Wait-AzureDevTrustedLaunchGuestReadiness `
             -Context $Context `
             -Plan $trustedLaunchPlan `
@@ -669,6 +677,9 @@ function Invoke-AzureDevSetup {
           $trustedLaunchPlan.TemplateEnabled = $trustedLaunchResult.Succeeded
           if ($trustedLaunchResult.Succeeded) {
             Start-AzureDevAzureVm -Context $Context
+            Wait-AzureDevSsh `
+              -Context $Context `
+              -HostName $trustedLaunchHostName | Out-Null
             Wait-AzureDevTrustedLaunchGuestReadiness `
               -Context $Context `
               -Plan $trustedLaunchPlan | Out-Null

--- a/scripts/azure-dev/AzureDev.Azure.psm1
+++ b/scripts/azure-dev/AzureDev.Azure.psm1
@@ -72,6 +72,53 @@ function Test-AzureDevLocalTool {
   return $null -ne $command
 }
 
+function Get-AzureDevOpenSshVersion {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('windows', 'macos', 'linux')]
+    [string]$Platform
+  )
+
+  $sshCommand = Get-Command ssh -CommandType Application -ErrorAction Stop
+  if ($Platform -eq 'windows') {
+    if ($sshCommand.Version -eq [System.Version]::new(0, 0, 0, 0)) {
+      throw 'Could not determine the Windows OpenSSH client version.'
+    }
+    return $sshCommand.Version
+  }
+
+  $sshVersionResult = Invoke-AzureDevNativeCommand `
+    -FilePath $sshCommand.Source `
+    -Arguments @('-V')
+  $sshVersionMatch = [regex]::Match(
+    $sshVersionResult.Text,
+    'OpenSSH_(?<major>[0-9]+)\.(?<minor>[0-9]+)'
+  )
+  if ($sshVersionResult.ExitCode -ne 0 -or -not $sshVersionMatch.Success) {
+    throw "Could not determine the $Platform OpenSSH client version."
+  }
+  return [System.Version]::new(
+    [int]$sshVersionMatch.Groups['major'].Value,
+    [int]$sshVersionMatch.Groups['minor'].Value
+  )
+}
+
+function Get-AzureDevMinimumOpenSshVersion {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('windows', 'macos', 'linux')]
+    [string]$Platform
+  )
+
+  if ($Platform -eq 'windows') {
+    # Microsoft did not publish an OpenSSH for Windows 8.5 release.
+    return [System.Version]::new(8, 6)
+  }
+  return [System.Version]::new(8, 5)
+}
+
 function Test-AzureDevRuntime {
   [CmdletBinding()]
   param()
@@ -203,6 +250,30 @@ function Test-AzureDevPrerequisites {
   Test-AzureDevLocalTool -Name 'scp' | Out-Null
   Test-AzureDevLocalTool -Name 'git' | Out-Null
   Test-AzureDevLocalTool -Name 'code' -Optional | Out-Null
+
+  $sshPlatform = if ($IsWindows) {
+    'windows'
+  } elseif ($IsMacOS) {
+    'macos'
+  } elseif ($IsLinux) {
+    'linux'
+  } else {
+    throw 'Azure development scripts do not support this workstation platform.'
+  }
+  $sshPlatformLabels = @{
+    windows = 'Windows'
+    macos = 'macOS'
+    linux = 'Linux'
+  }
+  $sshVersion = Get-AzureDevOpenSshVersion -Platform $sshPlatform
+  $minimumSshVersion = Get-AzureDevMinimumOpenSshVersion -Platform $sshPlatform
+  if ($sshVersion -lt $minimumSshVersion) {
+    throw (
+      "OpenSSH $minimumSshVersion or later is required on " +
+      "$($sshPlatformLabels[$sshPlatform]). Detected OpenSSH $sshVersion. " +
+      'Upgrade the OpenSSH client and rerun.'
+    )
+  }
 
   $connected = Connect-AzureDevServicePrincipal `
     -Config $Context.Config `

--- a/scripts/azure-dev/AzureDev.Bootstrap.psm1
+++ b/scripts/azure-dev/AzureDev.Bootstrap.psm1
@@ -21,19 +21,22 @@ function Invoke-AzureDevRemoteCommand {
     [string]$Description = 'Run remote command'
   )
 
+  Assert-AzureDevSshHostTrust -Context $Context
   if ($PSCmdlet.ShouldProcess($Context.Config.SshHostAlias, $Description)) {
+    $arguments = [System.Object[]]@(
+      '-o',
+      'BatchMode=yes',
+      '-o',
+      'ClearAllForwardings=yes'
+    )
+    $arguments += $Context.Config.SshHostKeyArguments
+    $arguments += [System.Object[]]@(
+      $Context.Config.SshHostAlias,
+      $Command
+    )
     $result = Invoke-AzureDevNativeCommand `
       -FilePath 'ssh' `
-      -Arguments @(
-        '-o',
-        'BatchMode=yes',
-        '-o',
-        'ClearAllForwardings=yes',
-        '-o',
-        'StrictHostKeyChecking=accept-new',
-        $Context.Config.SshHostAlias,
-        $Command
-      )
+      -Arguments $arguments
     if ($result.ExitCode -ne 0) {
       throw "Remote command failed with exit code $($result.ExitCode): $Description`n$($result.Text.Trim())"
     }
@@ -50,23 +53,26 @@ function Copy-AzureDevBootstrapFile {
     [string]$RemotePath
   )
 
+  Assert-AzureDevSshHostTrust -Context $Context
   if (-not (Test-Path -LiteralPath $Context.BootstrapPath -PathType Leaf)) {
     throw "Bootstrap script is missing: $($Context.BootstrapPath)"
   }
 
   if ($PSCmdlet.ShouldProcess($Context.Config.SshHostAlias, 'Upload host bootstrap')) {
+    $arguments = [System.Object[]]@(
+      '-o',
+      'BatchMode=yes',
+      '-o',
+      'ClearAllForwardings=yes'
+    )
+    $arguments += $Context.Config.SshHostKeyArguments
+    $arguments += [System.Object[]]@(
+      $Context.BootstrapPath,
+      "$($Context.Config.SshHostAlias):$RemotePath"
+    )
     $result = Invoke-AzureDevNativeCommand `
       -FilePath 'scp' `
-      -Arguments @(
-        '-o',
-        'BatchMode=yes',
-        '-o',
-        'ClearAllForwardings=yes',
-        '-o',
-        'StrictHostKeyChecking=accept-new',
-        $Context.BootstrapPath,
-        "$($Context.Config.SshHostAlias):$RemotePath"
-      )
+      -Arguments $arguments
     if ($result.ExitCode -ne 0) {
       throw "Bootstrap upload failed.`n$($result.Text.Trim())"
     }
@@ -83,6 +89,7 @@ function Copy-AzureDevQuadletFiles {
     [string]$RemotePath
   )
 
+  Assert-AzureDevSshHostTrust -Context $Context
   $templatesPath = Split-Path -Parent $Context.BootstrapPath
   $quadletPath = Join-Path $templatesPath 'quadlet'
   if (-not (Test-Path -LiteralPath $quadletPath -PathType Container)) {
@@ -105,10 +112,9 @@ function Copy-AzureDevQuadletFiles {
       '-o',
       'BatchMode=yes',
       '-o',
-      'ClearAllForwardings=yes',
-      '-o',
-      'StrictHostKeyChecking=accept-new'
+      'ClearAllForwardings=yes'
     )
+    $arguments += $Context.Config.SshHostKeyArguments
     $arguments += @($quadletFiles | ForEach-Object { $_.FullName })
     $arguments += "$($Context.Config.SshHostAlias):$RemotePath/"
 
@@ -131,6 +137,7 @@ function Copy-AzureDevZshTemplate {
     [string]$RemotePath
   )
 
+  Assert-AzureDevSshHostTrust -Context $Context
   $templatesPath = Split-Path -Parent $Context.BootstrapPath
   $customPath = Join-Path $templatesPath 'zshrc.template'
   $examplePath = Join-Path $templatesPath 'zshrc.template.example'
@@ -156,18 +163,20 @@ function Copy-AzureDevZshTemplate {
       -Command "mkdir -p -- $remoteDirectoryLiteral" `
       -Description 'Prepare Zsh template upload directory'
 
+    $arguments = [System.Object[]]@(
+      '-o',
+      'BatchMode=yes',
+      '-o',
+      'ClearAllForwardings=yes'
+    )
+    $arguments += $Context.Config.SshHostKeyArguments
+    $arguments += [System.Object[]]@(
+      $sourcePath,
+      "$($Context.Config.SshHostAlias):$RemotePath"
+    )
     $result = Invoke-AzureDevNativeCommand `
       -FilePath 'scp' `
-      -Arguments @(
-        '-o',
-        'BatchMode=yes',
-        '-o',
-        'ClearAllForwardings=yes',
-        '-o',
-        'StrictHostKeyChecking=accept-new',
-        $sourcePath,
-        "$($Context.Config.SshHostAlias):$RemotePath"
-      )
+      -Arguments $arguments
     if ($result.ExitCode -ne 0) {
       throw "Zsh template upload failed.`n$($result.Text.Trim())"
     }
@@ -184,6 +193,7 @@ function Copy-AzureDevDevelopmentToolFiles {
     [string]$RemotePath
   )
 
+  Assert-AzureDevSshHostTrust -Context $Context
   if ($RemotePath.Length -le 1 -or -not $RemotePath.StartsWith('/')) {
     throw "Development-tooling remote path must be absolute: $RemotePath"
   }
@@ -215,10 +225,9 @@ function Copy-AzureDevDevelopmentToolFiles {
       '-o',
       'BatchMode=yes',
       '-o',
-      'ClearAllForwardings=yes',
-      '-o',
-      'StrictHostKeyChecking=accept-new'
+      'ClearAllForwardings=yes'
     )
+    $arguments += $Context.Config.SshHostKeyArguments
     $arguments += $sourcePaths
     $arguments += "$($Context.Config.SshHostAlias):$RemotePath/"
     $result = Invoke-AzureDevNativeCommand `
@@ -310,6 +319,7 @@ function Copy-AzureDevServiceEnvironmentFiles {
     [string]$RemotePath
   )
 
+  Assert-AzureDevSshHostTrust -Context $Context
   Test-AzureDevBootstrapSecrets -Config $Context.Config
 
   $localPath = Join-Path `
@@ -387,10 +397,9 @@ function Copy-AzureDevServiceEnvironmentFiles {
         '-o',
         'BatchMode=yes',
         '-o',
-        'ClearAllForwardings=yes',
-        '-o',
-        'StrictHostKeyChecking=accept-new'
+        'ClearAllForwardings=yes'
       )
+      $arguments += $Context.Config.SshHostKeyArguments
       $arguments += $uploadPaths
       $arguments += "$($Context.Config.SshHostAlias):$RemotePath/"
       $result = Invoke-AzureDevNativeCommand `
@@ -429,6 +438,7 @@ function Invoke-AzureDevBootstrap {
     [pscustomobject]$Context
   )
 
+  Assert-AzureDevSshHostTrust -Context $Context
   $remoteBootstrapPath = '/tmp/krav-bootstrap-host.sh'
   $remoteQuadletPath = '/tmp/krav-azure-dev/quadlet'
   $remoteZshrcPath = '/tmp/krav-azure-dev/zshrc'

--- a/scripts/azure-dev/AzureDev.Config.psm1
+++ b/scripts/azure-dev/AzureDev.Config.psm1
@@ -530,6 +530,21 @@ function Get-AzureDevConfig {
   $privateKeyPath = Resolve-AzureDevPath `
     -Path $values.AZURE_DEV_VM_SSH_PRIVATE_KEY_PATH
   $publicKeyPath = "$privateKeyPath.pub"
+  $sshKnownHostsPath = Join-Path (Join-Path $HOME '.ssh') 'known_hosts'
+  $sshHostKeyArguments = [System.Object[]]@(
+    '-o',
+    'StrictHostKeyChecking=yes',
+    '-o',
+    "UserKnownHostsFile=$sshKnownHostsPath",
+    '-o',
+    'GlobalKnownHostsFile=none',
+    '-o',
+    'KnownHostsCommand=none',
+    '-o',
+    'VerifyHostKeyDNS=no',
+    '-o',
+    'UpdateHostKeys=no'
+  )
   $workstationApproverPublicKeyPath = if (
     [string]::IsNullOrWhiteSpace(
       $values.AZURE_DEV_WORKSTATION_APPROVER_PUBLIC_KEY_PATH
@@ -563,6 +578,8 @@ function Get-AzureDevConfig {
     SshHostName = $values.AZURE_DEV_VM_SSH_HOST_NAME
     SshPrivateKeyPath = $privateKeyPath
     SshPublicKeyPath = $publicKeyPath
+    SshKnownHostsPath = $sshKnownHostsPath
+    SshHostKeyArguments = $sshHostKeyArguments
     WorkstationApproverPublicKeyPath = $workstationApproverPublicKeyPath
     AutoStopEnabled = ConvertTo-AzureDevBoolean `
       -Value $values.AZURE_DEV_VM_AUTO_STOP_ENABLED `
@@ -730,6 +747,7 @@ function New-AzureDevContext {
     CleanupKeys = [bool]$CleanupKeys
     SkipSshConfig = [bool]$SkipSshConfig
     SkipSmokeValidation = [bool]$SkipSmokeValidation
+    SshHostTrustEstablished = $false
     StateDirectory = Join-Path $Config.RepoRoot '.azure'
     LogsDirectory = Join-Path $Config.RepoRoot '.azure/logs'
     StatePath = Join-Path $Config.RepoRoot '.azure/development.state.json'

--- a/scripts/azure-dev/AzureDev.Ssh.psm1
+++ b/scripts/azure-dev/AzureDev.Ssh.psm1
@@ -363,10 +363,23 @@ function Get-AzureDevVmSshHostKeyEvidence {
     )
   }
   $runCommandResults = @($responseValue)
+  foreach ($runCommandResult in $runCommandResults) {
+    if (
+      $null -eq $runCommandResult -or
+      $null -eq $runCommandResult.PSObject.Properties['code']
+    ) {
+      throw (
+        'Azure control-plane SSH host-key evidence was malformed. No SSH ' +
+        'connection was attempted.'
+      )
+    }
+  }
 
   $stderr = @(
     $runCommandResults |
-      Where-Object { $_.code -match '/StdErr/' } |
+      Where-Object {
+        $_.PSObject.Properties['code'].Value -match '/StdErr/'
+      } |
       ForEach-Object { [string]$_.message } |
       Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
   )
@@ -379,7 +392,9 @@ function Get-AzureDevVmSshHostKeyEvidence {
 
   $lines = @(
     $runCommandResults |
-      Where-Object { $_.code -match '/StdOut/' } |
+      Where-Object {
+        $_.PSObject.Properties['code'].Value -match '/StdOut/'
+      } |
       ForEach-Object { [string]$_.message -split '\r?\n' } |
       ForEach-Object { $_.Trim() } |
       Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
@@ -409,7 +424,7 @@ function Get-AzureDevVmSshHostKeyEvidence {
 }
 
 function Set-AzureDevKnownHostTrust {
-  [CmdletBinding()]
+  [CmdletBinding(SupportsShouldProcess = $true)]
   param(
     [Parameter(Mandatory = $true)]
     [pscustomobject]$Context,
@@ -422,6 +437,14 @@ function Set-AzureDevKnownHostTrust {
   )
 
   $knownHostsPath = $Context.Config.SshKnownHostsPath
+  if (
+    -not $PSCmdlet.ShouldProcess(
+      $knownHostsPath,
+      'Update managed SSH host trust'
+    )
+  ) {
+    return
+  }
   $directory = Split-Path -Parent $knownHostsPath
   [System.IO.Directory]::CreateDirectory($directory) | Out-Null
 
@@ -507,7 +530,30 @@ function Wait-AzureDevSsh {
       'established through Azure.'
     )
   }
-  $hostKeys = Get-AzureDevVmSshHostKeyEvidence -Context $Context
+  $hostKeys = $null
+  $lastEvidenceError = $null
+  $firstEvidenceAttempt = $true
+  while ($firstEvidenceAttempt -or (Get-Date) -lt $deadline) {
+    $firstEvidenceAttempt = $false
+    try {
+      $hostKeys = @(Get-AzureDevVmSshHostKeyEvidence -Context $Context)
+      $lastEvidenceError = $null
+      break
+    } catch {
+      $lastEvidenceError = $_
+    }
+    $remainingMilliseconds = [int][System.Math]::Ceiling(
+      ($deadline - (Get-Date)).TotalMilliseconds
+    )
+    if ($remainingMilliseconds -gt 0) {
+      Start-Sleep -Milliseconds (
+        [System.Math]::Min(10000, $remainingMilliseconds)
+      )
+    }
+  }
+  if ($null -ne $lastEvidenceError) {
+    throw $lastEvidenceError
+  }
   Set-AzureDevKnownHostTrust `
     -Context $Context `
     -HostName $HostName `
@@ -535,19 +581,13 @@ function Wait-AzureDevSsh {
     $lastOutput = $result.Text
     if (Test-AzureDevHostKeyMismatch -Output $lastOutput) {
       throw (
-        'SSH host-key mismatch against Azure control-plane evidence. Setup ' +
-        'stopped before remote commands or credential upload.'
+        'SSH host-key mismatch against Azure control-plane evidence. Rerun ' +
+        'setup or start to retrieve authenticated replacement evidence. No ' +
+        'remote commands or credential uploads were attempted.'
       )
     }
     Start-Sleep -Seconds 10
   } while ((Get-Date) -lt $deadline)
-
-  if (Test-AzureDevHostKeyMismatch -Output $lastOutput) {
-    throw (
-      'SSH host-key mismatch against Azure control-plane evidence. Rerun ' +
-      'setup or start to retrieve authenticated replacement evidence.'
-    )
-  }
 
   $diagnostics = @(
     "SSH did not become reachable for $($Context.Config.SshHostAlias)."

--- a/scripts/azure-dev/AzureDev.Ssh.psm1
+++ b/scripts/azure-dev/AzureDev.Ssh.psm1
@@ -150,13 +150,8 @@ function Get-AzureDevSshConfigBlock {
   )
 
   $identityFile = ConvertTo-AzureDevSshPath -Path $Context.Config.SshPrivateKeyPath
-  $strictHostKeyChecking = if (
-    -not [string]::IsNullOrWhiteSpace($Context.Config.SshHostName)
-  ) {
-    'yes'
-  } else {
-    'accept-new'
-  }
+  $knownHostsFile = ConvertTo-AzureDevSshPath `
+    -Path $Context.Config.SshKnownHostsPath
   $lines = @(
     "# >>> $script:AzureDevSshMarkerName managed",
     "Host $($Context.Config.SshHostAlias)",
@@ -165,7 +160,12 @@ function Get-AzureDevSshConfigBlock {
     "    IdentityFile $identityFile",
     '    IdentitiesOnly yes',
     '    ForwardAgent yes',
-    "    StrictHostKeyChecking $strictHostKeyChecking",
+    '    StrictHostKeyChecking yes',
+    "    UserKnownHostsFile $knownHostsFile",
+    '    GlobalKnownHostsFile none',
+    '    KnownHostsCommand none',
+    '    VerifyHostKeyDNS no',
+    '    UpdateHostKeys no',
     '    SendEnv GH_TOKEN',
     '    SendEnv COPILOT_GITHUB_TOKEN'
   )
@@ -267,24 +267,221 @@ function Test-AzureDevHostKeyMismatch {
     $Output -match 'Host key verification failed'
 }
 
-function Reset-AzureDevKnownHost {
-  [CmdletBinding(SupportsShouldProcess = $true)]
+function Assert-AzureDevSshHostTrust {
+  [CmdletBinding()]
   param(
     [Parameter(Mandatory = $true)]
-    [string]$HostName
+    [pscustomobject]$Context
   )
 
-  if ([string]::IsNullOrWhiteSpace($HostName)) {
-    return
+  $trustEstablished = if (
+    $null -ne $Context.PSObject.Properties['SshHostTrustEstablished']
+  ) {
+    $Context.PSObject.Properties['SshHostTrustEstablished'].Value
+  } elseif (
+    $Context -is [System.Collections.IDictionary] -and
+    $Context.Contains('SshHostTrustEstablished')
+  ) {
+    $Context['SshHostTrustEstablished']
+  } else {
+    $false
+  }
+  if ($trustEstablished -ne $true) {
+    throw (
+      'Authenticated SSH host trust has not been established. Run the Azure ' +
+      'host-key validation flow before remote commands or credential upload.'
+    )
+  }
+}
+
+function Invoke-AzureDevHostKeyRunCommand {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [pscustomobject]$Context
+  )
+
+  return Invoke-AzCli `
+    -Arguments @(
+      'vm',
+      'run-command',
+      'invoke',
+      '--subscription',
+      $Context.Config.SubscriptionId,
+      '--resource-group',
+      $Context.Config.ResourceGroup,
+      '--name',
+      $Context.Config.VmName,
+      '--command-id',
+      'RunShellScript',
+      '--scripts',
+      (
+        'set -eu; found=0; for key in /etc/ssh/ssh_host_*_key.pub; do ' +
+        '[ -r "$key" ] || continue; cat "$key"; found=1; done; ' +
+        '[ "$found" -eq 1 ]'
+      ),
+      '--output',
+      'json'
+    ) `
+    -Json
+}
+
+function Get-AzureDevVmSshHostKeyEvidence {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [pscustomobject]$Context
+  )
+
+  try {
+    $response = Invoke-AzureDevHostKeyRunCommand -Context $Context
+  } catch {
+    throw (
+      'Azure control-plane SSH host-key retrieval failed. No SSH connection ' +
+      "was attempted. $($_.Exception.Message)"
+    )
   }
 
-  if ($PSCmdlet.ShouldProcess($HostName, 'Remove stale OpenSSH known_hosts entry')) {
-    $result = Invoke-AzureDevNativeCommand `
-      -FilePath 'ssh-keygen' `
-      -Arguments @('-R', $HostName)
-    if ($result.ExitCode -ne 0) {
-      Write-Warning "Could not remove known_hosts entry for $HostName`: $($result.Text.Trim())"
+  $responseValue = if (
+    $null -ne $response -and
+    $null -ne $response.PSObject.Properties['value']
+  ) {
+    $response.PSObject.Properties['value'].Value
+  } elseif (
+    $null -ne $response -and
+    $response -is [System.Collections.IDictionary] -and
+    $response.Contains('value')
+  ) {
+    $response['value']
+  } else {
+    $null
+  }
+  if ($null -eq $responseValue) {
+    throw (
+      'Azure control-plane SSH host-key evidence was malformed. No SSH ' +
+      'connection was attempted.'
+    )
+  }
+  $runCommandResults = @($responseValue)
+
+  $stderr = @(
+    $runCommandResults |
+      Where-Object { $_.code -match '/StdErr/' } |
+      ForEach-Object { [string]$_.message } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+  if ($stderr.Count -gt 0) {
+    throw (
+      'Azure control-plane SSH host-key retrieval returned guest errors. No ' +
+      'SSH connection was attempted.'
+    )
+  }
+
+  $lines = @(
+    $runCommandResults |
+      Where-Object { $_.code -match '/StdOut/' } |
+      ForEach-Object { [string]$_.message -split '\r?\n' } |
+      ForEach-Object { $_.Trim() } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+  if ($lines.Count -eq 0) {
+    throw (
+      'Azure control-plane SSH host-key evidence was empty. No SSH connection ' +
+      'was attempted.'
+    )
+  }
+
+  $hostKeys = [System.Collections.Generic.List[string]]::new()
+  foreach ($line in $lines) {
+    if (-not (Test-AzureDevSshPublicKey -Value $line)) {
+      throw (
+        'Azure control-plane SSH host-key evidence was malformed. No SSH ' +
+        'connection was attempted.'
+      )
     }
+    $parts = $line -split '[ \t]+', 3
+    $hostKey = "$($parts[0]) $($parts[1])"
+    if (-not $hostKeys.Contains($hostKey)) {
+      $hostKeys.Add($hostKey)
+    }
+  }
+  return @($hostKeys)
+}
+
+function Set-AzureDevKnownHostTrust {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [pscustomobject]$Context,
+
+    [Parameter(Mandatory = $true)]
+    [string]$HostName,
+
+    [Parameter(Mandatory = $true)]
+    [string[]]$HostKeys
+  )
+
+  $knownHostsPath = $Context.Config.SshKnownHostsPath
+  $directory = Split-Path -Parent $knownHostsPath
+  [System.IO.Directory]::CreateDirectory($directory) | Out-Null
+
+  $temporaryPath = Join-Path `
+    $directory `
+    ".$([System.IO.Path]::GetFileName($knownHostsPath)).$([guid]::NewGuid().ToString('N')).tmp"
+  $backupPath = "$temporaryPath.old"
+  try {
+    if ([System.IO.File]::Exists($knownHostsPath)) {
+      [System.IO.File]::Copy($knownHostsPath, $temporaryPath)
+    } else {
+      [System.IO.File]::WriteAllText($temporaryPath, '')
+    }
+    if ([System.IO.FileInfo]::new($temporaryPath).Length -gt 0) {
+      $existingText = [System.IO.File]::ReadAllText($temporaryPath)
+      if (-not $existingText.EndsWith("`n") -and -not $existingText.EndsWith("`r")) {
+        [System.IO.File]::AppendAllText(
+          $temporaryPath,
+          [System.Environment]::NewLine
+        )
+      }
+    }
+
+    $hostEntries = @($Context.Config.SshHostAlias, $HostName) |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+      Select-Object -Unique
+    foreach ($hostEntry in $hostEntries) {
+      $removeResult = Invoke-AzureDevNativeCommand `
+        -FilePath 'ssh-keygen' `
+        -Arguments @('-R', $hostEntry, '-f', $temporaryPath)
+      if ($removeResult.ExitCode -ne 0) {
+        throw "Could not update managed SSH host trust for $hostEntry."
+      }
+      Remove-Item -LiteralPath $backupPath -Force -ErrorAction SilentlyContinue
+    }
+
+    $trustedLines = foreach ($hostEntry in $hostEntries) {
+      foreach ($hostKey in $HostKeys) {
+        "$hostEntry $hostKey"
+      }
+    }
+    Add-Content -LiteralPath $temporaryPath -Value $trustedLines -Encoding ascii
+    if (-not $IsWindows) {
+      $directoryPermission = Invoke-AzureDevNativeCommand `
+        -FilePath 'chmod' `
+        -Arguments @('700', $directory)
+      $filePermission = Invoke-AzureDevNativeCommand `
+        -FilePath 'chmod' `
+        -Arguments @('600', $temporaryPath)
+      if (
+        $directoryPermission.ExitCode -ne 0 -or
+        $filePermission.ExitCode -ne 0
+      ) {
+        throw 'Could not secure the managed SSH host-trust files.'
+      }
+    }
+    Move-Item -LiteralPath $temporaryPath -Destination $knownHostsPath -Force
+  } finally {
+    Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $backupPath -Force -ErrorAction SilentlyContinue
   }
 }
 
@@ -303,45 +500,53 @@ function Wait-AzureDevSsh {
 
   $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
   $lastOutput = ''
-  $knownHostReset = $false
+  $Context.SshHostTrustEstablished = $false
+  if ([string]::IsNullOrWhiteSpace($HostName)) {
+    throw (
+      'The resolved VM host is required before SSH host trust can be ' +
+      'established through Azure.'
+    )
+  }
+  $hostKeys = Get-AzureDevVmSshHostKeyEvidence -Context $Context
+  Set-AzureDevKnownHostTrust `
+    -Context $Context `
+    -HostName $HostName `
+    -HostKeys $hostKeys
   do {
+    $arguments = [System.Collections.Generic.List[System.String]]::new()
+    $arguments.AddRange([System.String[]]@(
+      '-o',
+      'BatchMode=yes',
+      '-o',
+      'ClearAllForwardings=yes',
+      '-o',
+      'ConnectTimeout=10'
+    ))
+    $arguments.AddRange([System.String[]]$Context.Config.SshHostKeyArguments)
+    $arguments.Add($Context.Config.SshHostAlias)
+    $arguments.Add('true')
     $result = Invoke-AzureDevNativeCommand `
       -FilePath 'ssh' `
-      -Arguments @(
-        '-o',
-        'BatchMode=yes',
-        '-o',
-        'ClearAllForwardings=yes',
-        '-o',
-        'ConnectTimeout=10',
-        '-o',
-        'StrictHostKeyChecking=accept-new',
-        $Context.Config.SshHostAlias,
-        'true'
-      )
+      -Arguments $arguments.ToArray()
     if ($result.ExitCode -eq 0) {
+      $Context.SshHostTrustEstablished = $true
       return $true
     }
     $lastOutput = $result.Text
-    if (-not $knownHostReset -and (Test-AzureDevHostKeyMismatch -Output $lastOutput)) {
-      $hostEntries = @($Context.Config.SshHostAlias, $HostName) |
-        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
-        Select-Object -Unique
-      foreach ($hostEntry in $hostEntries) {
-        Reset-AzureDevKnownHost -HostName $hostEntry
-      }
-      $knownHostReset = $true
-      continue
+    if (Test-AzureDevHostKeyMismatch -Output $lastOutput) {
+      throw (
+        'SSH host-key mismatch against Azure control-plane evidence. Setup ' +
+        'stopped before remote commands or credential upload.'
+      )
     }
     Start-Sleep -Seconds 10
   } while ((Get-Date) -lt $deadline)
 
   if (Test-AzureDevHostKeyMismatch -Output $lastOutput) {
-    $commands = @("ssh-keygen -R $($Context.Config.SshHostAlias)")
-    if (-not [string]::IsNullOrWhiteSpace($HostName)) {
-      $commands += "ssh-keygen -R $HostName"
-    }
-    throw "SSH host-key mismatch. Run: $($commands -join '; ')"
+    throw (
+      'SSH host-key mismatch against Azure control-plane evidence. Rerun ' +
+      'setup or start to retrieve authenticated replacement evidence.'
+    )
   }
 
   $diagnostics = @(
@@ -411,6 +616,7 @@ function Get-AzureDevCodeCommand {
 }
 
 Export-ModuleMember -Function `
+  Assert-AzureDevSshHostTrust, `
   ConvertTo-AzureDevSshPath, `
   Get-AzureDevCodeCommand, `
   Get-AzureDevCurrentIpv4, `
@@ -420,7 +626,6 @@ Export-ModuleMember -Function `
   Get-AzureDevSshPublicKey, `
   New-AzureDevSshKey, `
   Remove-AzureDevManagedSshConfig, `
-  Reset-AzureDevKnownHost, `
   Set-AzureDevManagedSshConfig, `
   Test-AzureDevHostKeyMismatch, `
   Test-AzureDevCidr, `

--- a/scripts/azure-dev/AzureDev.Validation.psm1
+++ b/scripts/azure-dev/AzureDev.Validation.psm1
@@ -105,6 +105,8 @@ function Invoke-AzureDevSmokeValidation {
     [pscustomobject]$Context
   )
 
+  Assert-AzureDevSshHostTrust -Context $Context
+
   $remoteScript = @'
 set -euo pipefail
 expected_git_user_name="$1"
@@ -516,18 +518,20 @@ run_workspace_command_or_diagnose 'Playwright dry-run install check' ./node_modu
   )
 
   if ($PSCmdlet.ShouldProcess($Context.Config.SshHostAlias, 'Run smoke validation')) {
+    $arguments = [System.Object[]]@(
+      '-o',
+      'BatchMode=yes',
+      '-o',
+      'ClearAllForwardings=yes'
+    )
+    $arguments += $Context.Config.SshHostKeyArguments
+    $arguments += [System.Object[]]@(
+      $Context.Config.SshHostAlias,
+      $command
+    )
     $result = Invoke-AzureDevNativeCommand `
       -FilePath 'ssh' `
-      -Arguments @(
-        '-o',
-        'BatchMode=yes',
-        '-o',
-        'ClearAllForwardings=yes',
-        '-o',
-        'StrictHostKeyChecking=accept-new',
-        $Context.Config.SshHostAlias,
-        $command
-      )
+      -Arguments $arguments
     if ($result.ExitCode -ne 0) {
       throw "Azure VM smoke validation failed.`n$($result.Text.Trim())"
     }

--- a/scripts/azure-dev/AzureDev.Workstation.psm1
+++ b/scripts/azure-dev/AzureDev.Workstation.psm1
@@ -1090,14 +1090,18 @@ function Register-AzureDevRemoteWorkstationKey {
     'chmod 600 "$tmp"'
     'mv "$tmp" "$HOME/.ssh/authorized_keys"'
   ) -join '; '
+  $arguments = [System.Object[]]@(
+    '-o',
+    'ClearAllForwardings=yes'
+  )
+  $arguments += $Context.Config.SshHostKeyArguments
+  $arguments += [System.Object[]]@(
+    $Context.Config.SshHostAlias,
+    $remoteCommand
+  )
   $result = Invoke-AzureDevNativeCommand `
     -FilePath 'ssh' `
-    -Arguments @(
-      '-o',
-      'ClearAllForwardings=yes',
-      $Context.Config.SshHostAlias,
-      $remoteCommand
-    )
+    -Arguments $arguments
   if ($result.ExitCode -ne 0) {
     throw "Could not register workstation key: $($result.Text.Trim())"
   }
@@ -1223,16 +1227,20 @@ function Get-AzureDevRemoteGitSigningPublicKey {
     [pscustomobject]$Context
   )
 
+  $arguments = [System.Object[]]@(
+    '-o',
+    'BatchMode=yes',
+    '-o',
+    'ClearAllForwardings=yes'
+  )
+  $arguments += $Context.Config.SshHostKeyArguments
+  $arguments += [System.Object[]]@(
+    $Context.Config.SshHostAlias,
+    'git config --global --get user.signingkey'
+  )
   $result = Invoke-AzureDevNativeCommand `
     -FilePath 'ssh' `
-    -Arguments @(
-      '-o',
-      'BatchMode=yes',
-      '-o',
-      'ClearAllForwardings=yes',
-      $Context.Config.SshHostAlias,
-      'git config --global --get user.signingkey'
-    )
+    -Arguments $arguments
   if ($result.ExitCode -ne 0) {
     throw (
       'Git commit signing was selected, but the VM has no usable global SSH ' +
@@ -2889,14 +2897,18 @@ function Remove-AzureDevRemoteWorkstationKey {
     'chmod 600 "$tmp"'
     'mv "$tmp" "$file"'
   ) -join '; '
+  $arguments = [System.Object[]]@(
+    '-o',
+    'ClearAllForwardings=yes'
+  )
+  $arguments += $Context.Config.SshHostKeyArguments
+  $arguments += [System.Object[]]@(
+    $Context.Config.SshHostAlias,
+    $remoteCommand
+  )
   $result = Invoke-AzureDevNativeCommand `
     -FilePath 'ssh' `
-    -Arguments @(
-      '-o',
-      'ClearAllForwardings=yes',
-      $Context.Config.SshHostAlias,
-      $remoteCommand
-    )
+    -Arguments $arguments
   if ($result.ExitCode -eq 42) {
     throw 'Refusing to remove the final usable SSH key without -ForceRecovery.'
   }

--- a/scripts/azure-dev/AzureDev.Workstation.psm1
+++ b/scripts/azure-dev/AzureDev.Workstation.psm1
@@ -1073,6 +1073,7 @@ function Register-AzureDevRemoteWorkstationKey {
   ) {
     return
   }
+  Assert-AzureDevSshHostTrust -Context $Context
   $remoteCommand = @(
     'set -eu'
     'umask 077'
@@ -1227,6 +1228,7 @@ function Get-AzureDevRemoteGitSigningPublicKey {
     [pscustomobject]$Context
   )
 
+  Assert-AzureDevSshHostTrust -Context $Context
   $arguments = [System.Object[]]@(
     '-o',
     'BatchMode=yes',
@@ -2886,6 +2888,7 @@ function Remove-AzureDevRemoteWorkstationKey {
   ) {
     return
   }
+  Assert-AzureDevSshHostTrust -Context $Context
   $remoteCommand = @(
     'set -eu'
     'file="$HOME/.ssh/authorized_keys"'
@@ -2960,6 +2963,10 @@ function Remove-AzureDevWorkstation {
   ) {
     return
   }
+  Wait-AzureDevSsh `
+    -Context $Context `
+    -HostName $Context.Config.SshHostName |
+    Out-Null
   Remove-AzureDevRemoteWorkstationKey `
     -Context $Context `
     -WorkstationName $name `

--- a/scripts/azure-dev/AzureDev.Workstation.psm1
+++ b/scripts/azure-dev/AzureDev.Workstation.psm1
@@ -2963,9 +2963,10 @@ function Remove-AzureDevWorkstation {
   ) {
     return
   }
+  $hostName = Get-AzureDevPublicIpAddress -Config $Context.Config
   Wait-AzureDevSsh `
     -Context $Context `
-    -HostName $Context.Config.SshHostName |
+    -HostName $hostName |
     Out-Null
   Remove-AzureDevRemoteWorkstationKey `
     -Context $Context `

--- a/tests/powershell/Integration/Public/Assert-AzureDevSshHostTrust.Tests.ps1
+++ b/tests/powershell/Integration/Public/Assert-AzureDevSshHostTrust.Tests.ps1
@@ -37,4 +37,18 @@ Describe `
       $null = Assert-AzureDevSshHostTrust -Context $context
     }
   }
+
+  Context 'When the setup context has no authenticated host trust' {
+    It 'Should reject the context across the module boundary' {
+      $context = [System.Management.Automation.PSObject]@{
+        SshHostTrustEstablished = $false
+      }
+
+      {
+        Assert-AzureDevSshHostTrust -Context $context
+      } | Should-Throw -ExceptionMessage (
+        '*Authenticated SSH host trust has not been established*'
+      )
+    }
+  }
 }

--- a/tests/powershell/Integration/Public/Assert-AzureDevSshHostTrust.Tests.ps1
+++ b/tests/powershell/Integration/Public/Assert-AzureDevSshHostTrust.Tests.ps1
@@ -1,0 +1,40 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+BeforeDiscovery {
+  $script:integrationEnabled =
+    [System.Environment]::GetEnvironmentVariable(
+      'KRAVHANTERING_PESTER_INTEGRATION',
+      'Process'
+    ) -ceq '1'
+}
+
+Describe `
+  'Assert-AzureDevSshHostTrust' `
+  -Tag 'Integration' `
+  -Skip:(-not $script:integrationEnabled) {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Ssh'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Ssh.psm1'
+    ) -Force -ErrorAction Stop
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+  }
+
+  Context 'When the setup context records authenticated host trust' {
+    It 'Should accept the context across the module boundary' {
+      $context = [System.Management.Automation.PSObject]@{
+        SshHostTrustEstablished = $true
+      }
+
+      $null = Assert-AzureDevSshHostTrust -Context $context
+    }
+  }
+}

--- a/tests/powershell/Integration/Public/Remove-AzureDevWorkstation.Tests.ps1
+++ b/tests/powershell/Integration/Public/Remove-AzureDevWorkstation.Tests.ps1
@@ -1,0 +1,86 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+BeforeDiscovery {
+  $script:integrationEnabled =
+    [System.Environment]::GetEnvironmentVariable(
+      'KRAVHANTERING_PESTER_INTEGRATION',
+      'Process'
+    ) -ceq '1'
+}
+
+Describe `
+  'Remove-AzureDevWorkstation' `
+  -Tag 'Integration' `
+  -Skip:(-not $script:integrationEnabled) {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Workstation'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    foreach ($modulePath in @(
+      'scripts/azure-dev/AzureDev.Config.psm1',
+      'scripts/azure-dev/AzureDev.Logging.psm1',
+      'scripts/azure-dev/AzureDev.Azure.psm1',
+      'scripts/azure-dev/AzureDev.Ssh.psm1',
+      'scripts/azure-dev/AzureDev.Workstation.psm1'
+    )) {
+      Import-Module (
+        Join-Path $script:repositoryRoot $modulePath
+      ) -Force -ErrorAction Stop
+    }
+    $PSDefaultParameterValues = @{
+      'Mock:ModuleName' = $script:moduleName
+      'Should-Invoke:ModuleName' = $script:moduleName
+    }
+
+    Mock -CommandName Test-AzureDevPrerequisites
+    Mock -CommandName ConvertTo-AzureDevAccessName -MockWith { return $Value }
+    Mock -CommandName Get-AzureDevSshAccessRules
+    Mock -CommandName Confirm-AzureDevWorkstationAction -MockWith { return $true }
+    Mock -CommandName Get-AzureDevPublicIpAddress -MockWith {
+      return '203.0.113.10'
+    }
+    Mock -CommandName Wait-AzureDevSsh
+    Mock -CommandName Remove-AzureDevRemoteWorkstationKey
+    Mock -CommandName Remove-AzureDevSshAccessRule
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    foreach ($moduleName in @(
+      'AzureDev.Ssh',
+      'AzureDev.Azure',
+      'AzureDev.Logging',
+      'AzureDev.Config'
+    )) {
+      Get-Module $moduleName -All | Remove-Module -Force
+    }
+  }
+
+  Context 'When removal resolves a live host through the public boundary' {
+    It 'Should validate SSH trust for the resolved Azure public IP' {
+      $context = [System.Management.Automation.PSObject]@{
+        Config = [System.Management.Automation.PSObject]@{
+          SshHostName = ''
+        }
+      }
+
+      $null = Remove-AzureDevWorkstation `
+        -Context $context `
+        -WorkstationName 'developer-laptop' `
+        -Confirm:$false
+
+      Should-Invoke `
+        -CommandName Wait-AzureDevSsh `
+        -Exactly `
+        -Times 1 `
+        -Scope It `
+        -ParameterFilter {
+          $Context -eq $context -and
+          $HostName -eq '203.0.113.10'
+        }
+    }
+  }
+}

--- a/tests/powershell/Integration/Public/Test-AzureDevPrerequisites.Tests.ps1
+++ b/tests/powershell/Integration/Public/Test-AzureDevPrerequisites.Tests.ps1
@@ -1,0 +1,75 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+BeforeDiscovery {
+  $script:integrationEnabled =
+    [System.Environment]::GetEnvironmentVariable(
+      'KRAVHANTERING_PESTER_INTEGRATION',
+      'Process'
+    ) -ceq '1'
+}
+
+Describe `
+  'Test-AzureDevPrerequisites' `
+  -Tag 'Integration' `
+  -Skip:(-not $script:integrationEnabled) {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Azure'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Logging.psm1'
+    ) -Force -ErrorAction Stop
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Azure.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'Mock:ModuleName' = $script:moduleName
+      'Should-NotInvoke:ModuleName' = $script:moduleName
+    }
+
+    Mock -CommandName Test-AzureDevRuntime
+    Mock -CommandName Test-AzureDevLocalTool -MockWith { return $true }
+    Mock -CommandName Get-AzureDevOpenSshVersion -MockWith {
+      return [System.Version]::new(7, 7)
+    }
+    Mock -CommandName Connect-AzureDevServicePrincipal -MockWith { return $true }
+    Mock -CommandName Test-AzureDevSubscriptionVisible -MockWith { return $true }
+    Mock -CommandName Test-AzureDevSkuAvailability -MockWith { return $true }
+
+    if ($IsWindows) {
+      $script:expectedPlatformLabel = 'Windows'
+      $script:expectedMinimumVersion = [System.Version]::new(8, 6)
+    } elseif ($IsMacOS) {
+      $script:expectedPlatformLabel = 'macOS'
+      $script:expectedMinimumVersion = [System.Version]::new(8, 5)
+    } else {
+      $script:expectedPlatformLabel = 'Linux'
+      $script:expectedMinimumVersion = [System.Version]::new(8, 5)
+    }
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Logging' -All | Remove-Module -Force
+  }
+
+  Context 'When an unsupported OpenSSH version crosses the public boundary' {
+    It 'Should reject the client before Azure access' {
+      $context = [System.Management.Automation.PSObject]@{
+        Config = [System.Management.Automation.PSObject]@{}
+      }
+
+      {
+        Test-AzureDevPrerequisites -Context $context
+      } | Should-Throw -ExceptionMessage (
+        "*OpenSSH $($script:expectedMinimumVersion) or later is required on " +
+        "$($script:expectedPlatformLabel)*Detected OpenSSH 7.7*"
+      )
+
+      Should-NotInvoke -CommandName Connect-AzureDevServicePrincipal -Scope It
+    }
+  }
+}

--- a/tests/powershell/Integration/Public/Wait-AzureDevSsh.Tests.ps1
+++ b/tests/powershell/Integration/Public/Wait-AzureDevSsh.Tests.ps1
@@ -1,0 +1,143 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+BeforeDiscovery {
+  $script:integrationEnabled =
+    [System.Environment]::GetEnvironmentVariable(
+      'KRAVHANTERING_PESTER_INTEGRATION',
+      'Process'
+    ) -ceq '1'
+}
+
+Describe `
+  'Wait-AzureDevSsh' `
+  -Tag 'Integration' `
+  -Skip:(-not $script:integrationEnabled) {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Ssh'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    $script:trustedHostKey = (
+      'ssh-ed25519 ' +
+      'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Config.psm1'
+    ) -Force -ErrorAction Stop
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Logging.psm1'
+    ) -Force -ErrorAction Stop
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Azure.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'Mock:ModuleName' = $script:moduleName
+    }
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Ssh.psm1'
+    ) -Force -ErrorAction Stop
+
+    Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
+      return [System.Management.Automation.PSObject]@{
+        value = @(
+          [System.Management.Automation.PSObject]@{
+            code = 'ComponentStatus/StdOut/succeeded'
+            message = (
+              'ssh-ed25519 ' +
+              'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+            )
+          }
+        )
+      }
+    }
+    Mock -CommandName Invoke-AzureDevNativeCommand -MockWith {
+      if ($FilePath -eq 'ssh') {
+        return [System.Management.Automation.PSObject]@{
+          ExitCode = 0
+          Text = ''
+        }
+      }
+      $mockOutput = & $FilePath @Arguments 2>&1
+      return [System.Management.Automation.PSObject]@{
+        ExitCode = $LASTEXITCODE
+        Text = ($mockOutput | Out-String)
+      }
+    }
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Azure' -All | Remove-Module -Force
+    Get-Module 'AzureDev.Logging' -All | Remove-Module -Force
+    Get-Module 'AzureDev.Config' -All | Remove-Module -Force
+  }
+
+  Context 'When replacing hashed managed host entries' {
+    BeforeEach {
+      $script:knownHostsPath = Join-Path $TestDrive 'known_hosts'
+      $oldHostKey = (
+        'ssh-ed25519 ' +
+        'AAAAC3NzaC1lZDI1NTE5AAAAINHTPpE1LHuzHN/oirKpSYd7H/LfaLu0H1gp8VOcBt1y'
+      )
+      Set-Content -LiteralPath $script:knownHostsPath -Value @(
+        "krav-test $oldHostKey"
+        "203.0.113.10 $oldHostKey"
+        "unrelated.example $script:trustedHostKey"
+      )
+      & ssh-keygen -H -f $script:knownHostsPath | Out-Null
+      Remove-Item -LiteralPath "$script:knownHostsPath.old" -Force
+
+      $script:context = [System.Management.Automation.PSObject]@{
+        SshHostTrustEstablished = $false
+        Config = [System.Management.Automation.PSObject]@{
+          ResourceGroup = 'rg-test'
+          SubscriptionId = '00000000-0000-0000-0000-000000000000'
+          VmName = 'vm-test'
+          SshHostAlias = 'krav-test'
+          SshKnownHostsPath = $script:knownHostsPath
+          SshHostKeyArguments = [System.Object[]]@(
+            '-o',
+            'StrictHostKeyChecking=yes',
+            '-o',
+            "UserKnownHostsFile=$script:knownHostsPath",
+            '-o',
+            'GlobalKnownHostsFile=none',
+            '-o',
+            'KnownHostsCommand=none',
+            '-o',
+            'VerifyHostKeyDNS=no',
+            '-o',
+            'UpdateHostKeys=no'
+          )
+        }
+      }
+
+    }
+
+    It 'Should preserve unrelated hashed trust while installing Azure evidence' {
+      $result = Wait-AzureDevSsh `
+        -Context $script:context `
+        -HostName '203.0.113.10' `
+        -TimeoutSeconds 1
+
+      $result | Should-BeTrue
+      $aliasLookup = & ssh-keygen `
+        -F 'krav-test' `
+        -f $script:knownHostsPath
+      $hostLookup = & ssh-keygen `
+        -F '203.0.113.10' `
+        -f $script:knownHostsPath
+      $unrelatedLookup = & ssh-keygen `
+        -F 'unrelated.example' `
+        -f $script:knownHostsPath
+      (($aliasLookup -join "`n") -like "*$script:trustedHostKey*") |
+        Should-BeTrue
+      (($hostLookup -join "`n") -like "*$script:trustedHostKey*") |
+        Should-BeTrue
+      (($unrelatedLookup -join "`n") -like "*$script:trustedHostKey*") |
+        Should-BeTrue
+    }
+  }
+}

--- a/tests/powershell/Integration/Public/Wait-AzureDevSsh.Tests.ps1
+++ b/tests/powershell/Integration/Public/Wait-AzureDevSsh.Tests.ps1
@@ -42,7 +42,7 @@ Describe `
     Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
       return [System.Management.Automation.PSObject]@{
         value = @(
-          [System.Management.Automation.PSObject]@{
+          New-Object -TypeName System.Management.Automation.PSObject -Property @{
             code = 'ComponentStatus/StdOut/succeeded'
             message = (
               'ssh-ed25519 ' +
@@ -77,13 +77,13 @@ Describe `
   Context 'When replacing hashed managed host entries' {
     BeforeEach {
       $script:knownHostsPath = Join-Path $TestDrive 'known_hosts'
-      $oldHostKey = (
+      $script:oldHostKey = (
         'ssh-ed25519 ' +
         'AAAAC3NzaC1lZDI1NTE5AAAAINHTPpE1LHuzHN/oirKpSYd7H/LfaLu0H1gp8VOcBt1y'
       )
       Set-Content -LiteralPath $script:knownHostsPath -Value @(
-        "krav-test $oldHostKey"
-        "203.0.113.10 $oldHostKey"
+        "krav-test $script:oldHostKey"
+        "203.0.113.10 $script:oldHostKey"
         "unrelated.example $script:trustedHostKey"
       )
       & ssh-keygen -H -f $script:knownHostsPath | Out-Null
@@ -136,6 +136,10 @@ Describe `
         Should-BeTrue
       (($hostLookup -join "`n") -like "*$script:trustedHostKey*") |
         Should-BeTrue
+      (($aliasLookup -join "`n") -like "*$script:oldHostKey*") |
+        Should-BeFalse
+      (($hostLookup -join "`n") -like "*$script:oldHostKey*") |
+        Should-BeFalse
       (($unrelatedLookup -join "`n") -like "*$script:trustedHostKey*") |
         Should-BeTrue
     }

--- a/tests/powershell/Unit/Private/Get-AzureDevMinimumOpenSshVersion.Tests.ps1
+++ b/tests/powershell/Unit/Private/Get-AzureDevMinimumOpenSshVersion.Tests.ps1
@@ -1,0 +1,53 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Get-AzureDevMinimumOpenSshVersion' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Azure'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Logging.psm1'
+    ) -Force -ErrorAction Stop
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Azure.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'InModuleScope:ModuleName' = $script:moduleName
+    }
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Logging' -All | Remove-Module -Force
+  }
+
+  It 'Should require the first compatible Microsoft Windows release' {
+    $version = InModuleScope -ScriptBlock {
+      Set-StrictMode -Version 1.0
+      Get-AzureDevMinimumOpenSshVersion -Platform 'windows'
+    }
+
+    $version | Should-Be ([System.Version]::new(8, 6))
+  }
+
+  It 'Should require the upstream feature boundary on macOS' {
+    $version = InModuleScope -ScriptBlock {
+      Set-StrictMode -Version 1.0
+      Get-AzureDevMinimumOpenSshVersion -Platform 'macos'
+    }
+
+    $version | Should-Be ([System.Version]::new(8, 5))
+  }
+
+  It 'Should require the upstream feature boundary on Linux' {
+    $version = InModuleScope -ScriptBlock {
+      Set-StrictMode -Version 1.0
+      Get-AzureDevMinimumOpenSshVersion -Platform 'linux'
+    }
+
+    $version | Should-Be ([System.Version]::new(8, 5))
+  }
+}

--- a/tests/powershell/Unit/Private/Get-AzureDevOpenSshVersion.Tests.ps1
+++ b/tests/powershell/Unit/Private/Get-AzureDevOpenSshVersion.Tests.ps1
@@ -1,0 +1,125 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Get-AzureDevOpenSshVersion' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Azure'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Logging.psm1'
+    ) -Force -ErrorAction Stop
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Azure.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'InModuleScope:ModuleName' = $script:moduleName
+      'Mock:ModuleName' = $script:moduleName
+      'Should-Invoke:ModuleName' = $script:moduleName
+      'Should-NotInvoke:ModuleName' = $script:moduleName
+    }
+
+    Mock -CommandName Get-Command -MockWith {
+      return $script:mockSshCommand
+    }
+    Mock -CommandName Invoke-AzureDevNativeCommand -MockWith {
+      return $script:mockSshVersionResult
+    }
+  }
+
+  BeforeEach {
+    $script:mockSshCommand = [System.Management.Automation.PSObject]@{
+      Source = '/usr/bin/ssh'
+      Version = [System.Version]::new(9, 5, 6, 1)
+    }
+    $script:mockSshVersionResult = [System.Management.Automation.PSObject]@{
+      ExitCode = 0
+      Text = 'OpenSSH_9.6p1, OpenSSL 3.0.13'
+    }
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Logging' -All | Remove-Module -Force
+  }
+
+  Context 'When Windows exposes application-version metadata' {
+    It 'Should return the PowerShell command version' {
+      $version = InModuleScope -ScriptBlock {
+        Set-StrictMode -Version 1.0
+        Get-AzureDevOpenSshVersion -Platform 'windows'
+      }
+
+      $version | Should-Be ([System.Version]::new(9, 5, 6, 1))
+      Should-NotInvoke -CommandName Invoke-AzureDevNativeCommand -Scope It
+    }
+  }
+
+  Context 'When Windows does not expose application-version metadata' {
+    It 'Should fail closed' {
+      $script:mockSshCommand.Version = [System.Version]::new(0, 0, 0, 0)
+
+      {
+        InModuleScope -ScriptBlock {
+          Set-StrictMode -Version 1.0
+          Get-AzureDevOpenSshVersion -Platform 'windows'
+        }
+      } | Should-Throw -ExceptionMessage (
+        '*Could not determine the Windows OpenSSH client version*'
+      )
+    }
+  }
+
+  Context 'When macOS reports its OpenSSH version' {
+    It 'Should parse the upstream major and minor version' {
+      $version = InModuleScope -ScriptBlock {
+        Set-StrictMode -Version 1.0
+        Get-AzureDevOpenSshVersion -Platform 'macos'
+      }
+
+      $version | Should-Be ([System.Version]::new(9, 6))
+      Should-Invoke `
+        -CommandName Invoke-AzureDevNativeCommand `
+        -Exactly `
+        -Times 1 `
+        -Scope It `
+        -ParameterFilter {
+          $FilePath -eq '/usr/bin/ssh' -and
+          $Arguments.Count -eq 1 -and
+          $Arguments[0] -eq '-V'
+        }
+    }
+  }
+
+  Context 'When Linux reports its OpenSSH version' {
+    It 'Should parse the upstream major and minor version' {
+      $script:mockSshVersionResult.Text = (
+        'OpenSSH_8.5p1 Ubuntu-1, OpenSSL 1.1.1f'
+      )
+
+      $version = InModuleScope -ScriptBlock {
+        Set-StrictMode -Version 1.0
+        Get-AzureDevOpenSshVersion -Platform 'linux'
+      }
+
+      $version | Should-Be ([System.Version]::new(8, 5))
+    }
+  }
+
+  Context 'When a non-Windows version cannot be determined' {
+    It 'Should fail closed' {
+      $script:mockSshVersionResult.Text = 'unexpected version output'
+
+      {
+        InModuleScope -ScriptBlock {
+          Set-StrictMode -Version 1.0
+          Get-AzureDevOpenSshVersion -Platform 'linux'
+        }
+      } | Should-Throw -ExceptionMessage (
+        '*Could not determine the linux OpenSSH client version*'
+      )
+    }
+  }
+}

--- a/tests/powershell/Unit/Private/Get-AzureDevVmSshHostKeyEvidence.Tests.ps1
+++ b/tests/powershell/Unit/Private/Get-AzureDevVmSshHostKeyEvidence.Tests.ps1
@@ -38,7 +38,7 @@ Describe 'Get-AzureDevVmSshHostKeyEvidence' -Tag 'Unit' {
       Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
         return [System.Management.Automation.PSObject]@{
           value = @(
-            [System.Management.Automation.PSObject]@{
+            New-Object -TypeName System.Management.Automation.PSObject -Property @{
               code = 'ComponentStatus/StdOut/succeeded'
               message = (
                 'ssh-ed25519 ' +
@@ -92,7 +92,7 @@ Describe 'Get-AzureDevVmSshHostKeyEvidence' -Tag 'Unit' {
       Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
         return [System.Management.Automation.PSObject]@{
           value = @(
-            [System.Management.Automation.PSObject]@{
+            New-Object -TypeName System.Management.Automation.PSObject -Property @{
               code = 'ComponentStatus/StdOut/succeeded'
               message = 'ssh-ed25519 QQ=='
             }
@@ -112,6 +112,144 @@ Describe 'Get-AzureDevVmSshHostKeyEvidence' -Tag 'Unit' {
       } | Should-Throw -ExceptionMessage (
         '*control-plane SSH host-key evidence was malformed*'
       )
+    }
+  }
+
+  Context 'When Run Command omits its value collection' {
+    BeforeAll {
+      Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
+        return New-Object `
+          -TypeName System.Management.Automation.PSObject `
+          -Property @{
+          status = 'succeeded'
+        }
+      }
+    }
+
+    It 'Should reject the malformed response' {
+      {
+        InModuleScope `
+          -Parameters @{ Context = $script:context } `
+          -ScriptBlock {
+            Set-StrictMode -Version 1.0
+            Get-AzureDevVmSshHostKeyEvidence -Context $Context
+          }
+      } | Should-Throw -ExceptionMessage (
+        '*control-plane SSH host-key evidence was malformed*'
+      )
+    }
+  }
+
+  Context 'When a Run Command result omits its code' {
+    BeforeAll {
+      Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
+        return New-Object `
+          -TypeName System.Management.Automation.PSObject `
+          -Property @{
+          value = @(
+            New-Object -TypeName System.Management.Automation.PSObject -Property @{
+              message = 'unexpected output'
+            }
+          )
+        }
+      }
+    }
+
+    It 'Should report malformed evidence explicitly' {
+      {
+        InModuleScope `
+          -Parameters @{ Context = $script:context } `
+          -ScriptBlock {
+            Set-StrictMode -Version 1.0
+            Get-AzureDevVmSshHostKeyEvidence -Context $Context
+          }
+      } | Should-Throw -ExceptionMessage (
+        '*control-plane SSH host-key evidence was malformed*'
+      )
+    }
+  }
+
+  Context 'When Run Command returns guest errors' {
+    BeforeAll {
+      Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
+        return New-Object `
+          -TypeName System.Management.Automation.PSObject `
+          -Property @{
+          value = @(
+            New-Object -TypeName System.Management.Automation.PSObject -Property @{
+              code = 'ComponentStatus/StdErr/succeeded'
+              message = 'host keys unavailable'
+            }
+          )
+        }
+      }
+    }
+
+    It 'Should fail closed before accepting output' {
+      {
+        InModuleScope `
+          -Parameters @{ Context = $script:context } `
+          -ScriptBlock {
+            Set-StrictMode -Version 1.0
+            Get-AzureDevVmSshHostKeyEvidence -Context $Context
+          }
+      } | Should-Throw -ExceptionMessage (
+        '*control-plane SSH host-key retrieval returned guest errors*'
+      )
+    }
+  }
+
+  Context 'When Run Command repeats valid keys across algorithms' {
+    BeforeAll {
+      Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
+        $ed25519 = (
+          'ssh-ed25519 ' +
+          'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+        )
+        $rsa = (
+          'ssh-rsa ' +
+          'AAAAB3NzaC1yc2EAAAADAQABAAAAgQC5rITfpGc4oPleBfphM/dw00CuU8+E0xzLsRxLfTzCwsn5r4+mYeYNvdpxLaIVqPxiX6EXI8mdU6KwWExxo/QDLy8XXw27VFwgeFQJTQB/SVLRkDMjpP6q0a17E9Xm3BoSwDCyQNBFtO4CBF82p5otDgLCt6+AChsr36+GeJ8QCw=='
+        )
+        return New-Object `
+          -TypeName System.Management.Automation.PSObject `
+          -Property @{
+          value = @(
+            New-Object -TypeName System.Management.Automation.PSObject -Property @{
+              code = 'ComponentStatus/StdOut/succeeded'
+              message = "$ed25519`n$rsa"
+            }
+            New-Object -TypeName System.Management.Automation.PSObject -Property @{
+              code = 'ComponentStatus/StdOut/succeeded'
+              message = "$rsa duplicate`n$ed25519 duplicate"
+            }
+          )
+        }
+      }
+    }
+
+    It 'Should preserve only unique normalized key material' {
+      $result = @(
+        InModuleScope `
+          -Parameters @{ Context = $script:context } `
+          -ScriptBlock {
+            Set-StrictMode -Version 1.0
+            Get-AzureDevVmSshHostKeyEvidence -Context $Context
+          }
+      )
+
+      $result.Count | Should-Be 2
+      $result[0] | Should-BeString `
+        -Expected (
+          'ssh-ed25519 ' +
+          'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+        ) `
+        -CaseSensitive
+      $result[1] | Should-BeString `
+        -Expected (
+          'ssh-rsa ' +
+          'AAAAB3NzaC1yc2EAAAADAQABAAAAgQC5rITfpGc4oPleBfphM/dw00CuU8+E0xzLsRxLfTzCwsn5r4+mYeYNvdpxLaIVqPxiX6EXI8mdU6KwWExxo/QDLy8XXw27VFwgeFQJTQB/SVLRkDMjpP6q0a17E9Xm3BoSwDCyQNBFtO4CBF82p5otDgLCt6+AChsr36+GeJ8QCw=='
+        ) `
+        -CaseSensitive
     }
   }
 }

--- a/tests/powershell/Unit/Private/Get-AzureDevVmSshHostKeyEvidence.Tests.ps1
+++ b/tests/powershell/Unit/Private/Get-AzureDevVmSshHostKeyEvidence.Tests.ps1
@@ -1,0 +1,117 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Get-AzureDevVmSshHostKeyEvidence' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Ssh'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Config.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'InModuleScope:ModuleName' = $script:moduleName
+      'Mock:ModuleName' = $script:moduleName
+      'Should-NotInvoke:ModuleName' = $script:moduleName
+    }
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Ssh.psm1'
+    ) -Force -ErrorAction Stop
+    $script:context = [System.Management.Automation.PSObject]@{
+      Config = [System.Management.Automation.PSObject]@{
+        SubscriptionId = '00000000-0000-0000-0000-000000000000'
+        ResourceGroup = 'rg-test'
+        VmName = 'vm-test'
+      }
+    }
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Config' -All | Remove-Module -Force
+  }
+
+  Context 'When Run Command returns valid public keys' {
+    BeforeAll {
+      Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
+        return [System.Management.Automation.PSObject]@{
+          value = @(
+            [System.Management.Automation.PSObject]@{
+              code = 'ComponentStatus/StdOut/succeeded'
+              message = (
+                'ssh-ed25519 ' +
+                'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda' +
+                ' guest-comment'
+              )
+            }
+          )
+        }
+      }
+    }
+
+    It 'Should return normalized authenticated key material' {
+      $result = InModuleScope `
+        -Parameters @{ Context = $script:context } `
+        -ScriptBlock {
+          Set-StrictMode -Version 1.0
+          Get-AzureDevVmSshHostKeyEvidence -Context $Context
+        }
+
+      $result | Should-BeString -Expected (
+        'ssh-ed25519 ' +
+        'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+      ) -CaseSensitive
+    }
+  }
+
+  Context 'When Run Command is unavailable' {
+    BeforeAll {
+      Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
+        throw 'VM agent unavailable'
+      }
+    }
+
+    It 'Should fail closed with no network fallback' {
+      {
+        InModuleScope `
+          -Parameters @{ Context = $script:context } `
+          -ScriptBlock {
+            Set-StrictMode -Version 1.0
+            Get-AzureDevVmSshHostKeyEvidence -Context $Context
+          }
+      } | Should-Throw -ExceptionMessage (
+        '*control-plane SSH host-key retrieval failed*'
+      )
+    }
+  }
+
+  Context 'When Run Command returns malformed key material' {
+    BeforeAll {
+      Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
+        return [System.Management.Automation.PSObject]@{
+          value = @(
+            [System.Management.Automation.PSObject]@{
+              code = 'ComponentStatus/StdOut/succeeded'
+              message = 'ssh-ed25519 QQ=='
+            }
+          )
+        }
+      }
+    }
+
+    It 'Should reject the unverified evidence' {
+      {
+        InModuleScope `
+          -Parameters @{ Context = $script:context } `
+          -ScriptBlock {
+            Set-StrictMode -Version 1.0
+            Get-AzureDevVmSshHostKeyEvidence -Context $Context
+          }
+      } | Should-Throw -ExceptionMessage (
+        '*control-plane SSH host-key evidence was malformed*'
+      )
+    }
+  }
+}

--- a/tests/powershell/Unit/Private/Invoke-AzureDevHostKeyRunCommand.Tests.ps1
+++ b/tests/powershell/Unit/Private/Invoke-AzureDevHostKeyRunCommand.Tests.ps1
@@ -1,0 +1,68 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Invoke-AzureDevHostKeyRunCommand' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Ssh'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Logging.psm1'
+    ) -Force -ErrorAction Stop
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Azure.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'InModuleScope:ModuleName' = $script:moduleName
+      'Mock:ModuleName' = $script:moduleName
+      'Should-Invoke:ModuleName' = $script:moduleName
+    }
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Ssh.psm1'
+    ) -Force -ErrorAction Stop
+
+    Mock -CommandName Invoke-AzCli -MockWith {
+      return [System.Management.Automation.PSObject]@{ value = @() }
+    }
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Azure' -All | Remove-Module -Force
+    Get-Module 'AzureDev.Logging' -All | Remove-Module -Force
+  }
+
+  Context 'When host-key evidence is requested' {
+    It 'Should read only public host keys through authenticated Run Command' {
+      $context = [System.Management.Automation.PSObject]@{
+        Config = [System.Management.Automation.PSObject]@{
+          SubscriptionId = '00000000-0000-0000-0000-000000000000'
+          ResourceGroup = 'rg-test'
+          VmName = 'vm-test'
+        }
+      }
+
+      $null = InModuleScope -Parameters @{ Context = $context } -ScriptBlock {
+        Set-StrictMode -Version 1.0
+        Invoke-AzureDevHostKeyRunCommand -Context $Context
+      }
+
+      Should-Invoke `
+        -CommandName Invoke-AzCli `
+        -ParameterFilter {
+          $Json -and
+          ($Arguments -join ' ') -like '*vm run-command invoke*' -and
+          ($Arguments -contains '00000000-0000-0000-0000-000000000000') -and
+          ($Arguments -contains 'rg-test') -and
+          ($Arguments -contains 'vm-test') -and
+          ($Arguments -contains 'RunShellScript') -and
+          ($Arguments -join ' ') -like '*/etc/ssh/ssh_host_*_key.pub*'
+        } `
+        -Exactly `
+        -Times 1 `
+        -Scope It
+    }
+  }
+}

--- a/tests/powershell/Unit/Private/Set-AzureDevKnownHostTrust.Tests.ps1
+++ b/tests/powershell/Unit/Private/Set-AzureDevKnownHostTrust.Tests.ps1
@@ -1,0 +1,106 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Set-AzureDevKnownHostTrust' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Ssh'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Logging.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'InModuleScope:ModuleName' = $script:moduleName
+      'Mock:ModuleName' = $script:moduleName
+      'Should-Invoke:ModuleName' = $script:moduleName
+    }
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Ssh.psm1'
+    ) -Force -ErrorAction Stop
+    $script:trustedHostKey = (
+      'ssh-ed25519 ' +
+      'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+    )
+
+    Mock -CommandName Invoke-AzureDevNativeCommand -MockWith {
+      if ($FilePath -eq 'ssh-keygen') {
+        return [System.Management.Automation.PSObject]@{
+          ExitCode = 0
+          Text = ''
+        }
+      }
+      if ($FilePath -eq 'chmod') {
+        return [System.Management.Automation.PSObject]@{
+          ExitCode = 0
+          Text = ''
+        }
+      }
+      throw "Unexpected native command: $FilePath"
+    }
+  }
+
+  BeforeEach {
+    $script:knownHostsPath = Join-Path $TestDrive 'known_hosts'
+    Set-Content `
+      -LiteralPath $script:knownHostsPath `
+      -Value (
+        'unrelated.example ssh-ed25519 ' +
+        'AAAAC3NzaC1lZDI1NTE5AAAAIEZzZWVkZWQtdW5yZWxhdGVkLWtleS0xMjM0NTY3ODkw'
+      ) `
+      -NoNewline
+    $script:context = [System.Management.Automation.PSObject]@{
+      Config = [System.Management.Automation.PSObject]@{
+        SshHostAlias = 'krav-test'
+        SshKnownHostsPath = $script:knownHostsPath
+      }
+    }
+
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Logging' -All | Remove-Module -Force
+  }
+
+  Context 'When unrelated trust lacks a trailing newline' {
+    It 'Should preserve it as a separate entry while installing both names' {
+      $null = InModuleScope `
+        -Parameters @{
+          Context = $script:context
+          TrustedHostKey = $script:trustedHostKey
+        } `
+        -ScriptBlock {
+          Set-StrictMode -Version 1.0
+          Set-AzureDevKnownHostTrust `
+            -Context $Context `
+            -HostName '203.0.113.10' `
+            -HostKeys @($TrustedHostKey)
+        }
+
+      $knownHosts = Get-Content -LiteralPath $script:knownHostsPath
+      $knownHosts.Count | Should-Be 3
+      $knownHosts[0] | Should-BeString `
+        -Expected (
+          'unrelated.example ssh-ed25519 ' +
+          'AAAAC3NzaC1lZDI1NTE5AAAAIEZzZWVkZWQtdW5yZWxhdGVkLWtleS0xMjM0NTY3ODkw'
+        ) `
+        -CaseSensitive
+      $knownHosts[1] |
+        Should-BeString `
+          -Expected "krav-test $script:trustedHostKey" `
+          -CaseSensitive
+      $knownHosts[2] |
+        Should-BeString `
+          -Expected "203.0.113.10 $script:trustedHostKey" `
+          -CaseSensitive
+      Should-Invoke `
+        -CommandName Invoke-AzureDevNativeCommand `
+        -ParameterFilter { $FilePath -eq 'ssh-keygen' } `
+        -Exactly `
+        -Times 2 `
+        -Scope It
+    }
+  }
+}

--- a/tests/powershell/Unit/Private/Set-AzureDevKnownHostTrust.Tests.ps1
+++ b/tests/powershell/Unit/Private/Set-AzureDevKnownHostTrust.Tests.ps1
@@ -15,6 +15,7 @@ Describe 'Set-AzureDevKnownHostTrust' -Tag 'Unit' {
       'InModuleScope:ModuleName' = $script:moduleName
       'Mock:ModuleName' = $script:moduleName
       'Should-Invoke:ModuleName' = $script:moduleName
+      'Should-NotInvoke:ModuleName' = $script:moduleName
     }
     Import-Module (
       Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Ssh.psm1'
@@ -100,6 +101,113 @@ Describe 'Set-AzureDevKnownHostTrust' -Tag 'Unit' {
         -ParameterFilter { $FilePath -eq 'ssh-keygen' } `
         -Exactly `
         -Times 2 `
+        -Scope It
+    }
+  }
+
+  Context 'When ssh-keygen cannot remove a managed entry' {
+    BeforeAll {
+      Mock -CommandName Invoke-AzureDevNativeCommand -MockWith {
+        if ($FilePath -eq 'ssh-keygen') {
+          return [System.Management.Automation.PSObject]@{
+            ExitCode = 1
+            Text = 'failed'
+          }
+        }
+        throw "Unexpected native command: $FilePath"
+      }
+    }
+
+    It 'Should fail without replacing the known-hosts file' {
+      $original = Get-Content -LiteralPath $script:knownHostsPath -Raw
+
+      {
+        InModuleScope `
+          -Parameters @{
+            Context = $script:context
+            TrustedHostKey = $script:trustedHostKey
+          } `
+          -ScriptBlock {
+            Set-StrictMode -Version 1.0
+            Set-AzureDevKnownHostTrust `
+              -Context $Context `
+              -HostName '203.0.113.10' `
+              -HostKeys @($TrustedHostKey)
+          }
+      } | Should-Throw -ExceptionMessage (
+        '*Could not update managed SSH host trust*'
+      )
+
+      (Get-Content -LiteralPath $script:knownHostsPath -Raw) |
+        Should-BeString -Expected $original -CaseSensitive
+    }
+  }
+
+  Context 'When ssh-keygen creates its backup file' {
+    BeforeAll {
+      Mock -CommandName Invoke-AzureDevNativeCommand -MockWith {
+        if ($FilePath -eq 'ssh-keygen') {
+          $fileOption = [System.Array]::IndexOf($Arguments, '-f')
+          $path = [System.String]$Arguments[$fileOption + 1]
+          [System.IO.File]::WriteAllText("$path.old", 'backup')
+          return [System.Management.Automation.PSObject]@{
+            ExitCode = 0
+            Text = ''
+          }
+        }
+        if ($FilePath -eq 'chmod') {
+          return [System.Management.Automation.PSObject]@{
+            ExitCode = 0
+            Text = ''
+          }
+        }
+        throw "Unexpected native command: $FilePath"
+      }
+    }
+
+    It 'Should remove the backup after installing authenticated trust' {
+      $null = InModuleScope `
+        -Parameters @{
+          Context = $script:context
+          TrustedHostKey = $script:trustedHostKey
+        } `
+        -ScriptBlock {
+          Set-StrictMode -Version 1.0
+          Set-AzureDevKnownHostTrust `
+            -Context $Context `
+            -HostName '203.0.113.10' `
+            -HostKeys @($TrustedHostKey)
+        }
+
+      @(Get-ChildItem -LiteralPath $TestDrive -Filter '*.old').Count |
+        Should-Be 0
+    }
+  }
+
+  Context 'When WhatIf is requested' {
+    It 'Should not create or replace managed trust files' {
+      $directory = Join-Path $TestDrive 'whatif'
+      $script:context.Config.SshKnownHostsPath = Join-Path `
+        $directory `
+        'known_hosts'
+
+      $null = InModuleScope `
+        -Parameters @{
+          Context = $script:context
+          TrustedHostKey = $script:trustedHostKey
+        } `
+        -ScriptBlock {
+          Set-StrictMode -Version 1.0
+          Set-AzureDevKnownHostTrust `
+            -Context $Context `
+            -HostName '203.0.113.10' `
+            -HostKeys @($TrustedHostKey) `
+            -WhatIf
+        }
+
+      (Test-Path -LiteralPath $directory) | Should-BeFalse
+      Should-NotInvoke `
+        -CommandName Invoke-AzureDevNativeCommand `
         -Scope It
     }
   }

--- a/tests/powershell/Unit/Public/Assert-AzureDevSshHostTrust.Tests.ps1
+++ b/tests/powershell/Unit/Public/Assert-AzureDevSshHostTrust.Tests.ps1
@@ -1,0 +1,43 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Assert-AzureDevSshHostTrust' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Ssh'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Ssh.psm1'
+    ) -Force -ErrorAction Stop
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+  }
+
+  Context 'When authenticated host trust is established' {
+    It 'Should allow remote work to continue' {
+      $context = [System.Management.Automation.PSObject]@{
+        SshHostTrustEstablished = $true
+      }
+
+      $null = Assert-AzureDevSshHostTrust -Context $context
+    }
+  }
+
+  Context 'When authenticated host trust is absent' {
+    It 'Should stop before remote work' {
+      $context = [System.Management.Automation.PSObject]@{
+        SshHostTrustEstablished = $false
+      }
+
+      {
+        Assert-AzureDevSshHostTrust -Context $context
+      } | Should-Throw -ExceptionMessage (
+        '*authenticated SSH host trust has not been established*'
+      )
+    }
+  }
+}

--- a/tests/powershell/Unit/Public/Invoke-AzureDevBootstrap.Tests.ps1
+++ b/tests/powershell/Unit/Public/Invoke-AzureDevBootstrap.Tests.ps1
@@ -1,0 +1,59 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Invoke-AzureDevBootstrap' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Bootstrap'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    $PSDefaultParameterValues = @{
+      'Mock:ModuleName' = $script:moduleName
+      'Should-NotInvoke:ModuleName' = $script:moduleName
+    }
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Ssh.psm1'
+    ) -Force -ErrorAction Stop
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Bootstrap.psm1'
+    ) -Force -ErrorAction Stop
+
+    Mock -CommandName Test-AzureDevGitIdentity
+    Mock -CommandName Copy-AzureDevBootstrapFile
+    Mock -CommandName Copy-AzureDevQuadletFiles
+    Mock -CommandName Copy-AzureDevZshTemplate
+    Mock -CommandName Copy-AzureDevDevelopmentToolFiles
+    Mock -CommandName Copy-AzureDevServiceEnvironmentFiles
+    Mock -CommandName Invoke-AzureDevRemoteCommand
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Ssh' -All | Remove-Module -Force
+  }
+
+  Context 'When authenticated SSH host trust has not been established' {
+    It 'Should stop before bootstrap validation, preparation, or secret creation' {
+      $context = [System.Management.Automation.PSObject]@{
+        SshHostTrustEstablished = $false
+        Config = [System.Management.Automation.PSObject]@{
+          SshHostAlias = 'krav-test'
+        }
+      }
+
+      {
+        Invoke-AzureDevBootstrap -Context $context
+      } | Should-Throw -ExceptionMessage (
+        '*authenticated SSH host trust has not been established*'
+      )
+
+      Should-NotInvoke -CommandName Test-AzureDevGitIdentity -Scope It
+      Should-NotInvoke -CommandName Copy-AzureDevBootstrapFile -Scope It
+      Should-NotInvoke `
+        -CommandName Copy-AzureDevServiceEnvironmentFiles `
+        -Scope It
+      Should-NotInvoke -CommandName Invoke-AzureDevRemoteCommand -Scope It
+    }
+  }
+}

--- a/tests/powershell/Unit/Public/Remove-AzureDevWorkstation.Tests.ps1
+++ b/tests/powershell/Unit/Public/Remove-AzureDevWorkstation.Tests.ps1
@@ -1,0 +1,86 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Remove-AzureDevWorkstation' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Workstation'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    foreach ($modulePath in @(
+      'scripts/azure-dev/AzureDev.Config.psm1',
+      'scripts/azure-dev/AzureDev.Logging.psm1',
+      'scripts/azure-dev/AzureDev.Azure.psm1',
+      'scripts/azure-dev/AzureDev.Ssh.psm1',
+      'scripts/azure-dev/AzureDev.Workstation.psm1'
+    )) {
+      Import-Module (
+        Join-Path $script:repositoryRoot $modulePath
+      ) -Force -ErrorAction Stop
+    }
+    $PSDefaultParameterValues = @{
+      'Mock:ModuleName' = $script:moduleName
+      'Should-Invoke:ModuleName' = $script:moduleName
+    }
+
+    Mock -CommandName Test-AzureDevPrerequisites
+    Mock -CommandName ConvertTo-AzureDevAccessName -MockWith { return $Value }
+    Mock -CommandName Get-AzureDevSshAccessRules
+    Mock -CommandName Confirm-AzureDevWorkstationAction -MockWith { return $true }
+    Mock -CommandName Get-AzureDevPublicIpAddress -MockWith {
+      return '203.0.113.10'
+    }
+    Mock -CommandName Wait-AzureDevSsh
+    Mock -CommandName Remove-AzureDevRemoteWorkstationKey
+    Mock -CommandName Remove-AzureDevSshAccessRule
+
+    $script:context = [System.Management.Automation.PSObject]@{
+      Config = [System.Management.Automation.PSObject]@{
+        SshHostName = ''
+      }
+    }
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    foreach ($moduleName in @(
+      'AzureDev.Ssh',
+      'AzureDev.Azure',
+      'AzureDev.Logging',
+      'AzureDev.Config'
+    )) {
+      Get-Module $moduleName -All | Remove-Module -Force
+    }
+  }
+
+  Context 'When the manager configuration has no persisted SSH host name' {
+    It 'Should resolve the live public IP before establishing host trust' {
+      $null = Remove-AzureDevWorkstation `
+        -Context $script:context `
+        -WorkstationName 'developer-laptop' `
+        -Confirm:$false
+
+      Should-Invoke `
+        -CommandName Get-AzureDevPublicIpAddress `
+        -Exactly `
+        -Times 1 `
+        -Scope It `
+        -ParameterFilter { $Config -eq $script:context.Config }
+      Should-Invoke `
+        -CommandName Wait-AzureDevSsh `
+        -Exactly `
+        -Times 1 `
+        -Scope It `
+        -ParameterFilter {
+          $Context -eq $script:context -and
+          $HostName -eq '203.0.113.10'
+        }
+      Should-Invoke `
+        -CommandName Remove-AzureDevRemoteWorkstationKey `
+        -Exactly `
+        -Times 1 `
+        -Scope It
+    }
+  }
+}

--- a/tests/powershell/Unit/Public/Test-AzureDevPrerequisites.Tests.ps1
+++ b/tests/powershell/Unit/Public/Test-AzureDevPrerequisites.Tests.ps1
@@ -1,0 +1,96 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Test-AzureDevPrerequisites' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Azure'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Logging.psm1'
+    ) -Force -ErrorAction Stop
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Azure.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'Mock:ModuleName' = $script:moduleName
+      'Should-Invoke:ModuleName' = $script:moduleName
+      'Should-NotInvoke:ModuleName' = $script:moduleName
+    }
+
+    Mock -CommandName Test-AzureDevRuntime
+    Mock -CommandName Test-AzureDevLocalTool -MockWith { return $true }
+    Mock -CommandName Get-AzureDevOpenSshVersion -MockWith {
+      return $script:mockOpenSshVersion
+    }
+    Mock -CommandName Connect-AzureDevServicePrincipal -MockWith { return $true }
+    Mock -CommandName Test-AzureDevSubscriptionVisible -MockWith { return $true }
+    Mock -CommandName Test-AzureDevSkuAvailability -MockWith { return $true }
+
+    $script:context = [System.Management.Automation.PSObject]@{
+      Config = [System.Management.Automation.PSObject]@{}
+    }
+    if ($IsWindows) {
+      $script:expectedPlatform = 'windows'
+      $script:expectedPlatformLabel = 'Windows'
+      $script:expectedMinimumVersion = [System.Version]::new(8, 6)
+    } elseif ($IsMacOS) {
+      $script:expectedPlatform = 'macos'
+      $script:expectedPlatformLabel = 'macOS'
+      $script:expectedMinimumVersion = [System.Version]::new(8, 5)
+    } else {
+      $script:expectedPlatform = 'linux'
+      $script:expectedPlatformLabel = 'Linux'
+      $script:expectedMinimumVersion = [System.Version]::new(8, 5)
+    }
+  }
+
+  BeforeEach {
+    $script:mockOpenSshVersion = $script:expectedMinimumVersion
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Logging' -All | Remove-Module -Force
+  }
+
+  Context 'When OpenSSH meets the platform minimum' {
+    It 'Should continue prerequisite validation' {
+      $null = Test-AzureDevPrerequisites -Context $script:context
+
+      Should-Invoke `
+        -CommandName Get-AzureDevOpenSshVersion `
+        -Exactly `
+        -Times 1 `
+        -Scope It `
+        -ParameterFilter { $Platform -eq $script:expectedPlatform }
+      Should-Invoke `
+        -CommandName Test-AzureDevSubscriptionVisible `
+        -Exactly `
+        -Times 1 `
+        -Scope It
+    }
+  }
+
+  Context 'When OpenSSH is older than the platform minimum' {
+    It 'Should reject the unsupported client before Azure validation' {
+      $script:mockOpenSshVersion = [System.Version]::new(
+        $script:expectedMinimumVersion.Major,
+        $script:expectedMinimumVersion.Minor - 1
+      )
+
+      {
+        Test-AzureDevPrerequisites -Context $script:context
+      } | Should-Throw -ExceptionMessage (
+        "*OpenSSH $($script:expectedMinimumVersion) or later is required on " +
+        "$($script:expectedPlatformLabel)*Detected OpenSSH " +
+        "$($script:mockOpenSshVersion)*"
+      )
+
+      Should-NotInvoke -CommandName Connect-AzureDevServicePrincipal -Scope It
+      Should-NotInvoke -CommandName Test-AzureDevSubscriptionVisible -Scope It
+    }
+  }
+}

--- a/tests/powershell/Unit/Public/Wait-AzureDevSsh.Tests.ps1
+++ b/tests/powershell/Unit/Public/Wait-AzureDevSsh.Tests.ps1
@@ -1,0 +1,338 @@
+#requires -Version 7.4
+
+Set-StrictMode -Version Latest
+
+Describe 'Wait-AzureDevSsh' -Tag 'Unit' {
+  BeforeAll {
+    $script:moduleName = 'AzureDev.Ssh'
+    $script:repositoryRoot = [System.IO.Path]::GetFullPath(
+      (Join-Path $PSScriptRoot '../../../..')
+    )
+    $script:trustedHostKey = (
+      'ssh-ed25519 ' +
+      'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+    )
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Config.psm1'
+    ) -Force -ErrorAction Stop
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Logging.psm1'
+    ) -Force -ErrorAction Stop
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Azure.psm1'
+    ) -Force -ErrorAction Stop
+    $PSDefaultParameterValues = @{
+      'Mock:ModuleName' = $script:moduleName
+      'Should-Invoke:ModuleName' = $script:moduleName
+      'Should-NotInvoke:ModuleName' = $script:moduleName
+    }
+    Import-Module (
+      Join-Path $script:repositoryRoot 'scripts/azure-dev/AzureDev.Ssh.psm1'
+    ) -Force -ErrorAction Stop
+
+    Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
+      return [System.Management.Automation.PSObject]@{
+        value = @(
+          [System.Management.Automation.PSObject]@{
+            code = 'ComponentStatus/StdOut/succeeded'
+            message = (
+              'ssh-ed25519 ' +
+              'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+            )
+          }
+        )
+      }
+    }
+  }
+
+  BeforeEach {
+    $script:knownHostsPath = Join-Path $TestDrive 'known_hosts'
+    Set-Content -LiteralPath $script:knownHostsPath -Value (
+      'unrelated.example ssh-ed25519 ' +
+      'AAAAC3NzaC1lZDI1NTE5AAAAIEZzZWVkZWQtdW5yZWxhdGVkLWtleS0xMjM0NTY3ODkw'
+    )
+    $script:context = [System.Management.Automation.PSObject]@{
+      SshHostTrustEstablished = $false
+      Config = [System.Management.Automation.PSObject]@{
+        ResourceGroup = 'rg-test'
+        SubscriptionId = '00000000-0000-0000-0000-000000000000'
+        VmName = 'vm-test'
+        SshHostAlias = 'krav-test'
+        SshKnownHostsPath = $script:knownHostsPath
+        SshHostKeyArguments = [System.Object[]]@(
+          '-o',
+          'StrictHostKeyChecking=yes',
+          '-o',
+          "UserKnownHostsFile=$script:knownHostsPath",
+          '-o',
+          'GlobalKnownHostsFile=none',
+          '-o',
+          'KnownHostsCommand=none',
+          '-o',
+          'VerifyHostKeyDNS=no',
+          '-o',
+          'UpdateHostKeys=no'
+        )
+      }
+    }
+    $script:mockSshArguments = $null
+    $script:mockSshResults =
+      [System.Collections.Generic.Queue[System.Object]]::new()
+    $script:mockSshResults.Enqueue(
+      [System.Management.Automation.PSObject]@{
+        ExitCode = 0
+        Text = ''
+      }
+    )
+    Mock -CommandName Invoke-AzureDevNativeCommand -MockWith {
+      if ($FilePath -eq 'ssh-keygen') {
+        $target = [System.String]$Arguments[1]
+        $fileOption = [System.Array]::IndexOf($Arguments, '-f')
+        $path = [System.String]$Arguments[$fileOption + 1]
+        $remaining = @(
+          Get-Content -LiteralPath $path |
+            Where-Object {
+              $hostField = @($_ -split '[ \t]+', 2)[0]
+              $target -notin @($hostField -split ',')
+            }
+        )
+        Set-Content -LiteralPath $path -Value $remaining
+        return [System.Management.Automation.PSObject]@{
+          ExitCode = 0
+          Text = ''
+        }
+      }
+      if ($FilePath -eq 'chmod') {
+        return [System.Management.Automation.PSObject]@{
+          ExitCode = 0
+          Text = ''
+        }
+      }
+      if ($FilePath -eq 'ssh') {
+        $script:mockSshArguments = @($Arguments)
+        return $script:mockSshResults.Dequeue()
+      }
+      throw "Unexpected native command: $FilePath"
+    }
+  }
+
+  AfterAll {
+    Get-Module $script:moduleName -All | Remove-Module -Force
+    Get-Module 'AzureDev.Azure' -All | Remove-Module -Force
+    Get-Module 'AzureDev.Logging' -All | Remove-Module -Force
+    Get-Module 'AzureDev.Config' -All | Remove-Module -Force
+  }
+
+  Context 'When the VM has no managed host trust yet' {
+    It 'Should pin Azure control-plane evidence before the first SSH connection' {
+      $result = Wait-AzureDevSsh `
+        -Context $script:context `
+        -HostName '203.0.113.10' `
+        -TimeoutSeconds 1
+
+      $result | Should-BeTrue
+      $knownHosts = Get-Content -LiteralPath $script:knownHostsPath
+      ($knownHosts -contains "krav-test $script:trustedHostKey") |
+        Should-BeTrue
+      ($knownHosts -contains "203.0.113.10 $script:trustedHostKey") |
+        Should-BeTrue
+      (
+        $knownHosts -contains (
+          'unrelated.example ssh-ed25519 ' +
+          'AAAAC3NzaC1lZDI1NTE5AAAAIEZzZWVkZWQtdW5yZWxhdGVkLWtleS0xMjM0NTY3ODkw'
+        )
+      ) | Should-BeTrue
+      ($script:mockSshArguments -contains 'StrictHostKeyChecking=yes') |
+        Should-BeTrue
+      ($script:mockSshArguments -notcontains 'StrictHostKeyChecking=accept-new') |
+        Should-BeTrue
+      ($script:mockSshArguments -contains 'KnownHostsCommand=none') |
+        Should-BeTrue
+      ($script:mockSshArguments -contains 'VerifyHostKeyDNS=no') |
+        Should-BeTrue
+      Should-Invoke `
+        -CommandName Invoke-AzureDevHostKeyRunCommand `
+        -Exactly `
+        -Times 1 `
+        -Scope It
+      Should-Invoke `
+        -CommandName Invoke-AzureDevNativeCommand `
+        -ParameterFilter { $FilePath -eq 'ssh' } `
+        -Exactly `
+        -Times 1 `
+        -Scope It
+    }
+  }
+
+  Context 'When unrelated trust has no trailing newline' {
+    BeforeEach {
+      Set-Content `
+        -LiteralPath $script:knownHostsPath `
+        -Value (
+          'unrelated.example ssh-ed25519 ' +
+          'AAAAC3NzaC1lZDI1NTE5AAAAIEZzZWVkZWQtdW5yZWxhdGVkLWtleS0xMjM0NTY3ODkw'
+        ) `
+        -NoNewline
+    }
+
+    It 'Should separate authenticated entries without changing unrelated trust' {
+      $null = Wait-AzureDevSsh `
+        -Context $script:context `
+        -HostName '203.0.113.10' `
+        -TimeoutSeconds 1
+
+      $knownHosts = Get-Content -LiteralPath $script:knownHostsPath
+      $knownHosts.Count | Should-Be 3
+      $knownHosts[0] | Should-BeString `
+        -Expected (
+          'unrelated.example ssh-ed25519 ' +
+          'AAAAC3NzaC1lZDI1NTE5AAAAIEZzZWVkZWQtdW5yZWxhdGVkLWtleS0xMjM0NTY3ODkw'
+        ) `
+        -CaseSensitive
+      $knownHosts[1] |
+        Should-BeString `
+          -Expected "krav-test $script:trustedHostKey" `
+          -CaseSensitive
+    }
+  }
+
+  Context 'When the installed host key already matches Azure evidence' {
+    It 'Should retain one matching entry for each managed host name' {
+      Add-Content -LiteralPath $script:knownHostsPath -Value @(
+        "krav-test $script:trustedHostKey"
+        "203.0.113.10 $script:trustedHostKey"
+      )
+
+      $result = Wait-AzureDevSsh `
+        -Context $script:context `
+        -HostName '203.0.113.10' `
+        -TimeoutSeconds 1
+
+      $result | Should-BeTrue
+      $knownHosts = @(Get-Content -LiteralPath $script:knownHostsPath)
+      @($knownHosts | Where-Object {
+          $_ -ceq "krav-test $script:trustedHostKey"
+        }).Count | Should-Be 1
+      @($knownHosts | Where-Object {
+          $_ -ceq "203.0.113.10 $script:trustedHostKey"
+        }).Count | Should-Be 1
+    }
+  }
+
+  Context 'When the network presents a different host key' {
+    BeforeEach {
+      $script:mockSshResults.Clear()
+      $script:mockSshResults.Enqueue(
+        [System.Management.Automation.PSObject]@{
+          ExitCode = 255
+          Text = 'REMOTE HOST IDENTIFICATION HAS CHANGED'
+        }
+      )
+    }
+
+    It 'Should fail without accepting or retrying the mismatched key' {
+      {
+        Wait-AzureDevSsh `
+          -Context $script:context `
+          -HostName '203.0.113.10' `
+          -TimeoutSeconds 1
+      } | Should-Throw -ExceptionMessage (
+        '*mismatch against Azure control-plane evidence*'
+      )
+
+      ($script:mockSshArguments -contains 'StrictHostKeyChecking=yes') |
+        Should-BeTrue
+      ($script:mockSshArguments -notcontains 'StrictHostKeyChecking=accept-new') |
+        Should-BeTrue
+      Should-Invoke `
+        -CommandName Invoke-AzureDevNativeCommand `
+        -ParameterFilter { $FilePath -eq 'ssh' } `
+        -Exactly `
+        -Times 1 `
+        -Scope It
+    }
+  }
+
+  Context 'When Azure host-key evidence is unavailable' {
+    BeforeAll {
+      Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
+        throw 'VM agent unavailable'
+      }
+    }
+
+    It 'Should fail before opening an SSH connection' {
+      {
+        Wait-AzureDevSsh `
+          -Context $script:context `
+          -HostName '203.0.113.10' `
+          -TimeoutSeconds 1
+      } | Should-Throw -ExceptionMessage (
+        '*control-plane SSH host-key retrieval failed*'
+      )
+
+      Should-NotInvoke `
+        -CommandName Invoke-AzureDevNativeCommand `
+        -ParameterFilter { $FilePath -eq 'ssh' } `
+        -Scope It
+    }
+  }
+
+  Context 'When Azure host-key evidence is malformed' {
+    BeforeAll {
+      Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
+        return [System.Management.Automation.PSObject]@{
+          value = @(
+            [System.Management.Automation.PSObject]@{
+              code = 'ComponentStatus/StdOut/succeeded'
+              message = 'ssh-ed25519 QQ=='
+            }
+          )
+        }
+      }
+    }
+
+    It 'Should reject the evidence before opening an SSH connection' {
+      {
+        Wait-AzureDevSsh `
+          -Context $script:context `
+          -HostName '203.0.113.10' `
+          -TimeoutSeconds 1
+      } | Should-Throw -ExceptionMessage (
+        '*control-plane SSH host-key evidence was malformed*'
+      )
+
+      Should-NotInvoke `
+        -CommandName Invoke-AzureDevNativeCommand `
+        -ParameterFilter { $FilePath -eq 'ssh' } `
+        -Scope It
+    }
+  }
+
+  Context 'When Azure authenticates a legitimate replacement host key' {
+    It 'Should replace only the managed host entries' {
+      $oldHostKey = (
+        'ssh-ed25519 ' +
+        'AAAAC3NzaC1lZDI1NTE5AAAAINHTPpE1LHuzHN/oirKpSYd7H/LfaLu0H1gp8VOcBt1y'
+      )
+      Add-Content -LiteralPath $script:knownHostsPath -Value @(
+        "krav-test $oldHostKey"
+        "203.0.113.10 $oldHostKey"
+      )
+
+      $result = Wait-AzureDevSsh `
+        -Context $script:context `
+        -HostName '203.0.113.10' `
+        -TimeoutSeconds 1
+
+      $result | Should-BeTrue
+      $knownHosts = @(Get-Content -LiteralPath $script:knownHostsPath)
+      ($knownHosts -contains "krav-test $script:trustedHostKey") |
+        Should-BeTrue
+      ($knownHosts -contains "203.0.113.10 $script:trustedHostKey") |
+        Should-BeTrue
+      ($knownHosts -contains "krav-test $oldHostKey") | Should-BeFalse
+      ($knownHosts -contains "203.0.113.10 $oldHostKey") | Should-BeFalse
+      ($knownHosts[0] -like 'unrelated.example *') | Should-BeTrue
+    }
+  }
+}

--- a/tests/powershell/Unit/Public/Wait-AzureDevSsh.Tests.ps1
+++ b/tests/powershell/Unit/Public/Wait-AzureDevSsh.Tests.ps1
@@ -33,7 +33,7 @@ Describe 'Wait-AzureDevSsh' -Tag 'Unit' {
     Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
       return [System.Management.Automation.PSObject]@{
         value = @(
-          [System.Management.Automation.PSObject]@{
+          New-Object -TypeName System.Management.Automation.PSObject -Property @{
             code = 'ComponentStatus/StdOut/succeeded'
             message = (
               'ssh-ed25519 ' +
@@ -131,6 +131,7 @@ Describe 'Wait-AzureDevSsh' -Tag 'Unit' {
         -TimeoutSeconds 1
 
       $result | Should-BeTrue
+      $script:context.SshHostTrustEstablished | Should-BeTrue
       $knownHosts = Get-Content -LiteralPath $script:knownHostsPath
       ($knownHosts -contains "krav-test $script:trustedHostKey") |
         Should-BeTrue
@@ -235,7 +236,7 @@ Describe 'Wait-AzureDevSsh' -Tag 'Unit' {
         Wait-AzureDevSsh `
           -Context $script:context `
           -HostName '203.0.113.10' `
-          -TimeoutSeconds 1
+          -TimeoutSeconds 0
       } | Should-Throw -ExceptionMessage (
         '*mismatch against Azure control-plane evidence*'
       )
@@ -250,6 +251,7 @@ Describe 'Wait-AzureDevSsh' -Tag 'Unit' {
         -Exactly `
         -Times 1 `
         -Scope It
+      $script:context.SshHostTrustEstablished | Should-BeFalse
     }
   }
 
@@ -265,7 +267,7 @@ Describe 'Wait-AzureDevSsh' -Tag 'Unit' {
         Wait-AzureDevSsh `
           -Context $script:context `
           -HostName '203.0.113.10' `
-          -TimeoutSeconds 1
+          -TimeoutSeconds 0
       } | Should-Throw -ExceptionMessage (
         '*control-plane SSH host-key retrieval failed*'
       )
@@ -273,6 +275,53 @@ Describe 'Wait-AzureDevSsh' -Tag 'Unit' {
       Should-NotInvoke `
         -CommandName Invoke-AzureDevNativeCommand `
         -ParameterFilter { $FilePath -eq 'ssh' } `
+        -Scope It
+      $script:context.SshHostTrustEstablished | Should-BeFalse
+    }
+  }
+
+  Context 'When Azure host-key evidence becomes available before the deadline' {
+    BeforeAll {
+      $script:mockEvidenceAttempts = 0
+      Mock -CommandName Start-Sleep
+      Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
+        $script:mockEvidenceAttempts++
+        if ($script:mockEvidenceAttempts -eq 1) {
+          throw 'VM agent starting'
+        }
+        return [System.Management.Automation.PSObject]@{
+          value = @(
+            New-Object -TypeName System.Management.Automation.PSObject -Property @{
+              code = 'ComponentStatus/StdOut/succeeded'
+              message = (
+                'ssh-ed25519 ' +
+                'AAAAC3NzaC1lZDI1NTE5AAAAIK4Gak3xSoCDBBTD/UDsPazk1sN3TfGiZttuZXbTgQda'
+              )
+            }
+          )
+        }
+      }
+    }
+
+    It 'Should retry before making the first SSH connection' {
+      $result = Wait-AzureDevSsh `
+        -Context $script:context `
+        -HostName '203.0.113.10' `
+        -TimeoutSeconds 30
+
+      $result | Should-BeTrue
+      $script:context.SshHostTrustEstablished | Should-BeTrue
+      Should-Invoke `
+        -CommandName Invoke-AzureDevHostKeyRunCommand `
+        -Exactly `
+        -Times 2 `
+        -Scope It
+      Should-Invoke -CommandName Start-Sleep -Exactly -Times 1 -Scope It
+      Should-Invoke `
+        -CommandName Invoke-AzureDevNativeCommand `
+        -ParameterFilter { $FilePath -eq 'ssh' } `
+        -Exactly `
+        -Times 1 `
         -Scope It
     }
   }
@@ -282,7 +331,7 @@ Describe 'Wait-AzureDevSsh' -Tag 'Unit' {
       Mock -CommandName Invoke-AzureDevHostKeyRunCommand -MockWith {
         return [System.Management.Automation.PSObject]@{
           value = @(
-            [System.Management.Automation.PSObject]@{
+            New-Object -TypeName System.Management.Automation.PSObject -Property @{
               code = 'ComponentStatus/StdOut/succeeded'
               message = 'ssh-ed25519 QQ=='
             }
@@ -296,7 +345,7 @@ Describe 'Wait-AzureDevSsh' -Tag 'Unit' {
         Wait-AzureDevSsh `
           -Context $script:context `
           -HostName '203.0.113.10' `
-          -TimeoutSeconds 1
+          -TimeoutSeconds 0
       } | Should-Throw -ExceptionMessage (
         '*control-plane SSH host-key evidence was malformed*'
       )
@@ -305,6 +354,27 @@ Describe 'Wait-AzureDevSsh' -Tag 'Unit' {
         -CommandName Invoke-AzureDevNativeCommand `
         -ParameterFilter { $FilePath -eq 'ssh' } `
         -Scope It
+      $script:context.SshHostTrustEstablished | Should-BeFalse
+    }
+  }
+
+  Context 'When the resolved host name is empty' {
+    It 'Should fail before retrieving evidence or opening SSH' {
+      {
+        Wait-AzureDevSsh `
+          -Context $script:context `
+          -HostName '  ' `
+          -TimeoutSeconds 0
+      } | Should-Throw -ExceptionMessage '*resolved VM host is required*'
+
+      Should-NotInvoke `
+        -CommandName Invoke-AzureDevHostKeyRunCommand `
+        -Scope It
+      Should-NotInvoke `
+        -CommandName Invoke-AzureDevNativeCommand `
+        -ParameterFilter { $FilePath -eq 'ssh' } `
+        -Scope It
+      $script:context.SshHostTrustEstablished | Should-BeFalse
     }
   }
 

--- a/tests/unit/dev-env-contract.test.ts
+++ b/tests/unit/dev-env-contract.test.ts
@@ -156,7 +156,6 @@ describe('development environment contract', () => {
     const azureModule = readWorkspaceFile(
       'scripts/azure-dev/AzureDev.Azure.psm1',
     )
-
     expect(entryScript).toContain(
       '$image = Get-AzureDevDeploymentImage -Config $Context.Config',
     )
@@ -339,6 +338,9 @@ describe('development environment contract', () => {
     const azureModule = readWorkspaceFile(
       'scripts/azure-dev/AzureDev.Azure.psm1',
     )
+    const configModule = readWorkspaceFile(
+      'scripts/azure-dev/AzureDev.Config.psm1',
+    )
     const bicepTemplate = readWorkspaceFile(
       'scripts/azure-dev/templates/main.bicep',
     )
@@ -425,7 +427,12 @@ describe('development environment contract', () => {
     expect(entryScript).not.toContain(
       'function Test-AzureDevTrustedLaunchGuestReadiness',
     )
-    expect(readinessFunction).toContain('StrictHostKeyChecking=accept-new')
+    expect(readinessFunction).toContain('$Context.Config.SshHostKeyArguments')
+    expect(configModule).toContain('StrictHostKeyChecking=yes')
+    expect(configModule).toContain('UserKnownHostsFile=')
+    expect(configModule).toContain('GlobalKnownHostsFile=none')
+    expect(configModule).toContain('KnownHostsCommand=none')
+    expect(configModule).toContain('VerifyHostKeyDNS=no')
     expect(readinessFunction).toContain('$Context.Config.SshHostAlias')
     expect(readinessFunction).toContain(
       'DKMS kernel modules require manual Secure Boot validation',

--- a/tests/unit/dev-env-contract.test.ts
+++ b/tests/unit/dev-env-contract.test.ts
@@ -344,6 +344,20 @@ describe('development environment contract', () => {
     const bicepTemplate = readWorkspaceFile(
       'scripts/azure-dev/templates/main.bicep',
     )
+    const sshHostKeyArgumentsStart = configModule.indexOf(
+      '  $sshKnownHostsPath =',
+    )
+    const sshHostKeyArgumentsEnd = configModule.indexOf(
+      '\n  $workstationApproverPublicKeyPath =',
+      sshHostKeyArgumentsStart,
+    )
+    const sshHostKeyArgumentsBlock = configModule.slice(
+      sshHostKeyArgumentsStart,
+      sshHostKeyArgumentsEnd,
+    )
+    const sshHostKeyArgumentValues = [
+      ...sshHostKeyArgumentsBlock.matchAll(/^\s*(['"])(.*?)\1,?\s*$/gmu),
+    ].flatMap(match => (match[2] ? [match[2]] : []))
     const readinessStart = entryScript.indexOf(
       'function Wait-AzureDevTrustedLaunchGuestReadiness',
     )
@@ -424,15 +438,29 @@ describe('development environment contract', () => {
 
     expect(readinessStart).toBeGreaterThanOrEqual(0)
     expect(readinessEnd).toBeGreaterThan(readinessStart)
+    expect(sshHostKeyArgumentsStart).toBeGreaterThanOrEqual(0)
+    expect(sshHostKeyArgumentsEnd).toBeGreaterThan(sshHostKeyArgumentsStart)
     expect(entryScript).not.toContain(
       'function Test-AzureDevTrustedLaunchGuestReadiness',
     )
     expect(readinessFunction).toContain('$Context.Config.SshHostKeyArguments')
-    expect(configModule).toContain('StrictHostKeyChecking=yes')
-    expect(configModule).toContain('UserKnownHostsFile=')
-    expect(configModule).toContain('GlobalKnownHostsFile=none')
-    expect(configModule).toContain('KnownHostsCommand=none')
-    expect(configModule).toContain('VerifyHostKeyDNS=no')
+    expect(sshHostKeyArgumentsBlock).toContain(
+      "$sshKnownHostsPath = Join-Path (Join-Path $HOME '.ssh') 'known_hosts'",
+    )
+    expect(sshHostKeyArgumentValues).toContain('StrictHostKeyChecking=yes')
+    expect(sshHostKeyArgumentValues).toContain(
+      'UserKnownHostsFile=$sshKnownHostsPath',
+    )
+    expect(sshHostKeyArgumentValues).toContain('GlobalKnownHostsFile=none')
+    expect(sshHostKeyArgumentValues).toContain('KnownHostsCommand=none')
+    expect(sshHostKeyArgumentValues).toContain('VerifyHostKeyDNS=no')
+    expect(sshHostKeyArgumentValues).toContain('UpdateHostKeys=no')
+    const userKnownHostsFile = sshHostKeyArgumentValues.find(value =>
+      value.startsWith('UserKnownHostsFile='),
+    )
+    expect(userKnownHostsFile).toBeTruthy()
+    expect(userKnownHostsFile).not.toBe('UserKnownHostsFile=')
+    expect(userKnownHostsFile).not.toBe('UserKnownHostsFile=none')
     expect(readinessFunction).toContain('$Context.Config.SshHostAlias')
     expect(readinessFunction).toContain(
       'DKMS kernel modules require manual Secure Boot validation',


### PR DESCRIPTION
## Description

Authenticate Azure development VM SSH host keys through Azure Run Command before the first network SSH connection. Pin setup, bootstrap, validation, start, and maintenance SSH/SCP operations to that evidence, and fail closed when evidence is missing, malformed, unavailable, or does not match the network endpoint.

Managed trust updates replace only the environment alias and resolved host entries while preserving unrelated and hashed `known_hosts` entries. The developer documentation now describes first connection, legitimate VM replacement, and recovery behavior.

## Related Issues

Fixes #845

## Reviewer Notes

- `npm run check`
- `npm run test:powershell:integration` — 66 passed, 1 Windows-only test skipped
- Standards and issue-spec reviews completed with no remaining findings

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
No operator notes needed for Operator Upgrade Impact.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1071)
<!-- Reviewable:end -->
