### PR TITLE
fix: bound MCP catalog filter IDs

### DIFF
--- a/docs/integrations/mcp-server-contributor-guide.md
+++ b/docs/integrations/mcp-server-contributor-guide.md
@@ -101,6 +101,11 @@ filters, norm-reference filters, and requirement-package filters. Lookup
 catalogs ignore requirement-only filters except `typeId`, which filters the
 `quality_characteristics` catalog.
 
+Each numeric requirement filter array accepts at most 200 unique positive
+integer IDs. The MCP schema rejects duplicate or oversized collections, and
+the shared requirement-list boundary independently rejects oversized arrays,
+before the requirements service can expand the filters into SQL parameters.
+
 Requirement version status, usage status, and priority-level catalog rows expose
 nullable `iconName` fields. Requirement list/detail version output also carries
 status icon data and priority-level icon data as additive fields so older

--- a/docs/integrations/mcp-server-user-guide.md
+++ b/docs/integrations/mcp-server-user-guide.md
@@ -27,7 +27,9 @@ agents can use it reliably.
   types, quality characteristics, priority levels, statuses, usage statuses,
   requirement packages, and transitions. Pass both `catalog` and `operation`
   (`"list"` or `"search"`). Rows are always returned in
-  `structuredContent.result`; search rows include `match` metadata.
+  `structuredContent.result`; search rows include `match` metadata. Numeric
+  requirement filter arrays accept at most 200 unique positive integer IDs
+  each.
 - `requirements_get_import_schema`
   Retrieve the canonical JSON Schema for a `Kravimportfil`. Use this as the
   mandatory file-format contract for generated import JSON. The schema tool is
@@ -750,6 +752,9 @@ For requirement lists and searches, it supports:
 - `verifiable`
 - `sortBy`
 - `sortDirection`
+
+Each numeric ID filter array accepts at most 200 unique positive integer IDs.
+Split a larger filter into separate paginated calls; duplicate IDs are invalid.
 
 For `quality_characteristics`, `typeId` filters rows to one requirement type.
 

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -87,6 +87,16 @@ const QueryCatalogKindSchema = z.enum([
   'transitions',
 ])
 
+function createRequirementCatalogFilterIdsSchema(
+  description: string,
+): z.ZodOptional<ReturnType<typeof uniquePositiveIntegerArraySchema>> {
+  return uniquePositiveIntegerArraySchema()
+    .optional()
+    .describe(
+      `${description} Accepts up to ${ARRAY_INPUT_MAX_ITEMS} unique IDs.`,
+    )
+}
+
 const ResponseFormatSchema = z
   .enum(['json', 'markdown'])
   .default('markdown')
@@ -847,21 +857,15 @@ function renderRequirementHtml(
 function createQueryCatalogSchema() {
   return z
     .object({
-      areaIds: z
-        .array(z.number().int().positive())
-        .optional()
-        .describe(
-          'Requirement area IDs. Applies only to catalog "requirements".',
-        ),
+      areaIds: createRequirementCatalogFilterIdsSchema(
+        'Requirement area IDs. Applies only to catalog "requirements".',
+      ),
       catalog: QueryCatalogKindSchema.describe(
         'Catalog to list or search. Use "requirements" for requirement rows or a lookup catalog for reference rows.',
       ),
-      categoryIds: z
-        .array(z.number().int().positive())
-        .optional()
-        .describe(
-          'Requirement category IDs. Applies only to catalog "requirements".',
-        ),
+      categoryIds: createRequirementCatalogFilterIdsSchema(
+        'Requirement category IDs. Applies only to catalog "requirements".',
+      ),
       cursor: z
         .string()
         .min(1)
@@ -886,35 +890,26 @@ function createQueryCatalogSchema() {
         .describe(
           'Bounded page size for catalog "requirements"; defaults to 50 and accepts 1 through 100.',
         ),
-      normReferenceIds: z
-        .array(z.number().int().positive())
-        .optional()
-        .describe(
-          'Norm reference IDs. Applies only to catalog "requirements".',
-        ),
+      normReferenceIds: createRequirementCatalogFilterIdsSchema(
+        'Norm reference IDs. Applies only to catalog "requirements".',
+      ),
       operation: z
         .enum(['list', 'search'])
         .describe(
           '"list" returns all matching rows in structuredContent.result. "search" returns matching rows with top-level match metadata.',
         ),
-      qualityCharacteristicIds: z
-        .array(z.number().int().positive())
-        .optional()
-        .describe(
-          'Quality characteristic IDs. Applies only to catalog "requirements".',
-        ),
+      qualityCharacteristicIds: createRequirementCatalogFilterIdsSchema(
+        'Quality characteristic IDs. Applies only to catalog "requirements".',
+      ),
       verifiable: z
         .array(z.boolean())
         .optional()
         .describe(
           'Filter by verifiability. Applies only to catalog "requirements".',
         ),
-      priorityLevelIds: z
-        .array(z.number().int().positive())
-        .optional()
-        .describe(
-          'Priority level IDs. Applies only to catalog "requirements".',
-        ),
+      priorityLevelIds: createRequirementCatalogFilterIdsSchema(
+        'Priority level IDs. Applies only to catalog "requirements".',
+      ),
       sortBy: z
         .enum([
           'uniqueId',
@@ -946,12 +941,9 @@ function createQueryCatalogSchema() {
         .describe(
           'Search text for operation "search". Requirement search matches id, uniqueId, version.description, and version.acceptanceCriteria; lookup search matches stable lookup fields.',
         ),
-      statuses: z
-        .array(z.number().int().positive())
-        .optional()
-        .describe(
-          'Requirement version status IDs. Applies only to catalog "requirements".',
-        ),
+      statuses: createRequirementCatalogFilterIdsSchema(
+        'Requirement version status IDs. Applies only to catalog "requirements".',
+      ),
       typeId: z
         .number()
         .int()
@@ -960,18 +952,12 @@ function createQueryCatalogSchema() {
         .describe(
           'Requirement type ID used only to filter catalog "quality_characteristics".',
         ),
-      typeIds: z
-        .array(z.number().int().positive())
-        .optional()
-        .describe(
-          'Requirement type IDs. Applies only to catalog "requirements".',
-        ),
-      requirementPackageIds: z
-        .array(z.number().int().positive())
-        .optional()
-        .describe(
-          'Requirements package IDs. Applies only to catalog "requirements".',
-        ),
+      typeIds: createRequirementCatalogFilterIdsSchema(
+        'Requirement type IDs. Applies only to catalog "requirements".',
+      ),
+      requirementPackageIds: createRequirementCatalogFilterIdsSchema(
+        'Requirements package IDs. Applies only to catalog "requirements".',
+      ),
     })
     .strict()
     .superRefine((val, ctx) => {
@@ -1861,8 +1847,7 @@ export function createKravhanteringMcpServer(
         openWorldHint: false,
         readOnlyHint: true,
       },
-      description:
-        'List or search the requirements library and lookup catalogs: requirements, areas, categories, types, quality_characteristics, priority_levels, specification_item_statuses, statuses, requirement_packages, and transitions. Catalog "requirements" uses bounded forward pages in result plus pagination, defaults to 50 rows, and returns no exact total; continue with pagination.nextCursor. Requirement search is SQL Server-authoritative and returns match.matchedFields without match.quality. On invalid_cursor, restart without cursor while retaining normalized filters, locale, and sort. Other catalogs keep the non-paginated { result: [...] } contract; typeId filters quality_characteristics.',
+      description: `List or search the requirements library and lookup catalogs: requirements, areas, categories, types, quality_characteristics, priority_levels, specification_item_statuses, statuses, requirement_packages, and transitions. Catalog "requirements" uses bounded forward pages in result plus pagination, defaults to 50 rows, and returns no exact total; continue with pagination.nextCursor. Its numeric filter arrays accept up to ${ARRAY_INPUT_MAX_ITEMS} unique IDs each. Requirement search is SQL Server-authoritative and returns match.matchedFields without match.quality. On invalid_cursor, restart without cursor while retaining normalized filters, locale, and sort. Other catalogs keep the non-paginated { result: [...] } contract; typeId filters quality_characteristics.`,
       inputSchema: createQueryCatalogSchema(),
       outputSchema: QueryCatalogOutputSchema,
       title: 'Query Requirements Library',

--- a/lib/requirements/list-query.ts
+++ b/lib/requirements/list-query.ts
@@ -4,6 +4,7 @@ import {
 } from '@/lib/dal/requirements'
 import type { SqlServerDatabase } from '@/lib/db'
 import { throwIfGenerationAborted } from '@/lib/generated-output/operation'
+import { ARRAY_INPUT_MAX_ITEMS } from '@/lib/http/validation-constants'
 import { recordCapacityEvent } from '@/lib/observability/capacity'
 import type {
   AuthorizationService,
@@ -13,6 +14,7 @@ import {
   internalError,
   isRequirementsServiceError,
   unauthorizedError,
+  validationError,
 } from '@/lib/requirements/errors'
 import {
   assertRequirementListCursorMatches,
@@ -39,6 +41,17 @@ export const DEFAULT_REQUIREMENT_LIST_PAGE_LIMIT = 200
 export const MAX_REQUIREMENT_LIST_PAGE_LIMIT = 200
 export const REQUIREMENT_COMPLETE_RESULT_PAGE_SIZE = 200
 export const MAX_COMPLETE_REQUIREMENT_LIST_PAGES = 10_000
+
+const REQUIREMENT_LIST_FILTER_ID_FIELDS = [
+  'areaIds',
+  'categoryIds',
+  'normReferenceIds',
+  'priorityLevelIds',
+  'qualityCharacteristicIds',
+  'requirementPackageIds',
+  'statuses',
+  'typeIds',
+] as const satisfies ReadonlyArray<keyof FilterValues>
 
 export interface RequirementListPagination {
   count: number
@@ -97,6 +110,19 @@ function normalizeLimit(limit: number | undefined): number {
     Math.max(Math.trunc(limit ?? DEFAULT_REQUIREMENT_LIST_PAGE_LIMIT), 1),
     MAX_REQUIREMENT_LIST_PAGE_LIMIT,
   )
+}
+
+function assertBoundedRequirementListFilterIds(
+  filters: FilterValues | undefined,
+): void {
+  for (const field of REQUIREMENT_LIST_FILTER_ID_FIELDS) {
+    if ((filters?.[field]?.length ?? 0) > ARRAY_INPUT_MAX_ITEMS) {
+      throw validationError(
+        `Requirement list filter ${field} accepts at most ${ARRAY_INPUT_MAX_ITEMS} IDs`,
+        { field, maxItems: ARRAY_INPUT_MAX_ITEMS },
+      )
+    }
+  }
 }
 
 function normalizeIds(values: number[] | undefined): number[] | undefined {
@@ -210,6 +236,7 @@ export async function queryRequirementList(
 
   try {
     await authorizeRequirementListQuery(authorizationOptions)
+    assertBoundedRequirementListFilterIds(input.filters)
 
     const filters = normalizeRequirementListFilters(input.filters)
     const limit = normalizeLimit(input.limit)

--- a/tests/unit/mcp-http.test.ts
+++ b/tests/unit/mcp-http.test.ts
@@ -417,11 +417,22 @@ describe('handleRequirementsMcpRequest', () => {
       expect(queryTool).toBeDefined()
       expect(queryTool?.description).toContain('priority_levels')
       expect(queryTool?.description).toContain('quality_characteristics')
+      expect(queryTool?.description).toContain(
+        `up to ${ARRAY_INPUT_MAX_ITEMS} unique IDs`,
+      )
       const queryInputSchemaText = JSON.stringify(queryTool?.inputSchema)
       const queryInputSchema = JSON.parse(queryInputSchemaText) as {
         properties: {
+          areaIds: { maxItems: number }
+          categoryIds: { maxItems: number }
           cursor: { maxLength: number }
           limit: { maximum: number }
+          normReferenceIds: { maxItems: number }
+          priorityLevelIds: { maxItems: number }
+          qualityCharacteristicIds: { maxItems: number }
+          requirementPackageIds: { maxItems: number }
+          statuses: { maxItems: number }
+          typeIds: { maxItems: number }
         }
       }
       expect(queryInputSchemaText).toContain('priority_levels')
@@ -432,6 +443,20 @@ describe('handleRequirementsMcpRequest', () => {
       expect(queryInputSchemaText).toContain('sortBy')
       expect(queryInputSchema.properties.cursor.maxLength).toBe(512)
       expect(queryInputSchema.properties.limit.maximum).toBe(100)
+      for (const filter of [
+        'areaIds',
+        'categoryIds',
+        'normReferenceIds',
+        'priorityLevelIds',
+        'qualityCharacteristicIds',
+        'requirementPackageIds',
+        'statuses',
+        'typeIds',
+      ] as const) {
+        expect(queryInputSchema.properties[filter].maxItems).toBe(
+          ARRAY_INPUT_MAX_ITEMS,
+        )
+      }
       expect(JSON.stringify(queryTool?.outputSchema)).toContain('result')
       expect(JSON.stringify(queryTool?.outputSchema)).toContain('pagination')
       expect(queryTool?.description).toContain('without match.quality')
@@ -914,6 +939,59 @@ describe('handleRequirementsMcpRequest', () => {
         sortDirection: 'desc',
         requirementPackageIds: [3],
       }),
+    )
+
+    await client.close()
+    await transport.close()
+  })
+
+  it('bounds requirements catalog filter IDs before query delegation', async () => {
+    const { client, transport } = await createClient()
+    const fakeService = serviceState.getService.mock.results[0]?.value
+    const maximumFilterIds = Array.from(
+      { length: ARRAY_INPUT_MAX_ITEMS },
+      (_, index) => index + 1,
+    )
+
+    const maximumResult = await client.callTool({
+      arguments: {
+        areaIds: maximumFilterIds,
+        catalog: 'requirements',
+        categoryIds: maximumFilterIds,
+        normReferenceIds: maximumFilterIds,
+        operation: 'list',
+        priorityLevelIds: maximumFilterIds,
+        qualityCharacteristicIds: maximumFilterIds,
+        requirementPackageIds: maximumFilterIds,
+        statuses: maximumFilterIds,
+        typeIds: maximumFilterIds,
+      },
+      name: 'requirements_query_catalog',
+    })
+    const overMaximumResult = await client.callTool({
+      arguments: {
+        areaIds: [...maximumFilterIds, ARRAY_INPUT_MAX_ITEMS + 1],
+        catalog: 'requirements',
+        operation: 'list',
+      },
+      name: 'requirements_query_catalog',
+    })
+    const duplicateResult = await client.callTool({
+      arguments: {
+        catalog: 'requirements',
+        operation: 'list',
+        statuses: [1, 1],
+      },
+      name: 'requirements_query_catalog',
+    })
+
+    expect(maximumResult.isError).not.toBe(true)
+    expect(overMaximumResult.isError).toBe(true)
+    expect(duplicateResult.isError).toBe(true)
+    expect(fakeService.queryCatalog).toHaveBeenCalledTimes(1)
+    expect(fakeService.queryCatalog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ areaIds: maximumFilterIds }),
     )
 
     await client.close()

--- a/tests/unit/requirements-list-query.test.ts
+++ b/tests/unit/requirements-list-query.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ARRAY_INPUT_MAX_ITEMS } from '@/lib/http/validation-constants'
 import type { RequestContext } from '@/lib/requirements/auth'
 import {
   normalizeRequirementListFilters,
@@ -106,6 +107,38 @@ describe('queryRequirementList', () => {
       }),
     )
   })
+
+  it.each([
+    'areaIds',
+    'categoryIds',
+    'normReferenceIds',
+    'priorityLevelIds',
+    'qualityCharacteristicIds',
+    'requirementPackageIds',
+    'statuses',
+    'typeIds',
+  ] as const)(
+    'rejects an oversized %s filter before database work',
+    async field => {
+      await expect(
+        queryRequirementList(
+          {} as never,
+          {
+            filters: {
+              [field]: Array.from(
+                { length: ARRAY_INPUT_MAX_ITEMS + 1 },
+                (_, index) => index + 1,
+              ),
+            },
+          },
+          { allowUnauthenticated: true },
+        ),
+      ).rejects.toMatchObject({ code: 'validation' })
+
+      expect(mocks.listRequirements).not.toHaveBeenCalled()
+      expect(mocks.resolveRequirementListVisibility).not.toHaveBeenCalled()
+    },
+  )
 
   it('fails closed when authorization options are missing', async () => {
     await expect(queryRequirementList({} as never, {})).rejects.toMatchObject({

--- a/tests/unit/requirements-list-sql.test.ts
+++ b/tests/unit/requirements-list-sql.test.ts
@@ -3,6 +3,7 @@ import {
   buildRequirementListSql,
   escapeLike,
 } from '@/lib/dal/requirements-list-sql.mjs'
+import { ARRAY_INPUT_MAX_ITEMS } from '@/lib/http/validation-constants'
 import { STATUS_PUBLISHED } from '@/lib/requirements/status-constants.mjs'
 
 describe('requirement list SQL builders', () => {
@@ -89,6 +90,30 @@ describe('requirement list SQL builders', () => {
     )
     expect(query.sqlText).toContain('priority_level.code AS priorityLevelCode')
     expect(query.sqlText).toContain('ORDER BY CASE WHEN requirement_status')
+  })
+
+  it('keeps maximum MCP filter combinations below the SQL Server parameter ceiling', () => {
+    const maximumFilterIds = Array.from(
+      { length: ARRAY_INPUT_MAX_ITEMS },
+      (_, index) => index + 1,
+    )
+    const query = buildRequirementListSql({
+      after: { nullRank: 0, requirementId: 1, sortValue: 'REQ-1' },
+      areaIds: maximumFilterIds,
+      categoryIds: maximumFilterIds,
+      limit: 100,
+      normReferenceIds: maximumFilterIds,
+      priorityLevelIds: maximumFilterIds,
+      qualityCharacteristicIds: maximumFilterIds,
+      requirementPackageIds: maximumFilterIds,
+      search: 'security',
+      statuses: maximumFilterIds,
+      typeIds: maximumFilterIds,
+      verifiable: [true, false],
+    })
+
+    expect(query.parameters).toHaveLength(1_607)
+    expect(query.parameters.length).toBeLessThan(2_100)
   })
 
   it('omits the active-only filter when archived rows are explicitly included', () => {


### PR DESCRIPTION
## Description

Bounds numeric requirement filter arrays for `requirements_query_catalog` to
200 unique positive IDs at both the MCP schema and the shared requirement-list
boundary. This prevents authenticated clients from expanding unbounded filter
collections into SQL parameters and documents the updated contract.

## Related Issues

Fixes #846

## Reviewer Notes

- `npm run check`
- Maximum-size contract coverage verifies all eight affected filters.
- The maximum combined MCP query uses 1,607 SQL parameters, below SQL Server's
  2,100-parameter ceiling.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
Before upgrade, inform MCP integration owners that numeric requirement catalog
filters accept at most 200 unique positive IDs per filter. Update clients to
remove duplicate IDs and split larger filter collections into separate calls.
Calls that do not meet this contract are rejected before database work.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1072)
<!-- Reviewable:end -->
