### PR TITLE
docs: persist operator upgrade notes from #1072

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -308,6 +308,13 @@ Before rollout, confirm that users who manage RFI questions have the required re
 Before upgrade, review generated-output limits and temporary-storage capacity. JSON person data exports now use the existing CSV item, file-size, timeout, and shared per-node concurrency limits. PDF person data exports use the PDF item, file-size, timeout, per-node concurrency, and worker-memory limits.
 Exports that exceed these limits are rejected without a partial file. Validate the limits against retained subject histories and monitor privacy export capacity events after rollout.
 <!-- operator-upgrade:source pr-1068 end -->
+
+<!-- operator-upgrade:source pr-1072 start -->
+Before upgrade, inform MCP integration owners that numeric requirement catalog
+filters accept at most 200 unique positive IDs per filter. Update clients to
+remove duplicate IDs and split larger filter collections into separate calls.
+Calls that do not meet this contract are rejected before database work.
+<!-- operator-upgrade:source pr-1072 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #1072
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/32164480945

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1073)
<!-- Reviewable:end -->
