### PR TITLE
fix: bound MCP requirement taxonomy links

### DIFF
--- a/docs/integrations/mcp-server-contributor-guide.md
+++ b/docs/integrations/mcp-server-contributor-guide.md
@@ -297,6 +297,13 @@ Edit calls must first fetch the requirement with `view: "history"` and copy
 tokens to `409 Conflict` details with `reason: "stale_requirement_edit"` and
 the latest requirement snapshot.
 
+`requirement.normReferenceIds` and `requirement.requirementPackageIds` each
+accept at most 200 unique positive integer IDs. The MCP schema rejects
+duplicates and oversized collections before service delegation. The shared
+taxonomy-reference boundary independently caps direct callers, deduplicates
+accepted values before lookups, and persists each collection with one bounded
+multi-row insert.
+
 Delete-draft results use one canonical shape across REST and MCP:
 `result.deleted` is an ordered deletion ledger. It contains a
 `draftRequirementVersion` item with `requirementUniqueId` and `versionNumber`,

--- a/docs/integrations/mcp-server-user-guide.md
+++ b/docs/integrations/mcp-server-user-guide.md
@@ -67,7 +67,9 @@ agents can use it reliably.
   version. For `operation: "edit"`, first fetch the requirement with
   `view: "history"` and pass `requirement.versions[0].id` and
   `requirement.versions[0].revisionToken` back as
-  `requirement.baseVersionId` and `requirement.baseRevisionToken`. A
+  `requirement.baseVersionId` and `requirement.baseRevisionToken`.
+  `requirement.normReferenceIds` and `requirement.requirementPackageIds` each
+  accept at most 200 unique positive integer IDs. A
   successful `operation: "delete_draft"` returns `result.deleted` as an
   ordered deletion ledger. It contains a `draftRequirementVersion` item with
   `requirementUniqueId` and `versionNumber`, followed by a `requirement` item

--- a/lib/dal/requirement-reference-validation.ts
+++ b/lib/dal/requirement-reference-validation.ts
@@ -1,3 +1,4 @@
+import { ARRAY_INPUT_MAX_ITEMS } from '@/lib/http/validation-constants'
 import { validationError } from '@/lib/requirements/errors'
 
 export interface RequirementReferenceExecutor {
@@ -105,6 +106,12 @@ function normalizeIdArray(
 
   if (!Array.isArray(values)) {
     throw validationError(`${field} must contain positive integer IDs`)
+  }
+  if (values.length > ARRAY_INPUT_MAX_ITEMS) {
+    throw validationError(
+      `${field} accepts at most ${ARRAY_INPUT_MAX_ITEMS} IDs`,
+      { field, maxItems: ARRAY_INPUT_MAX_ITEMS },
+    )
   }
 
   const normalized: number[] = []

--- a/lib/dal/requirements.ts
+++ b/lib/dal/requirements.ts
@@ -331,16 +331,28 @@ async function insertVersionJoinsSqlServer(
   requirementPackageIds: number[],
   normRefIds: number[],
 ) {
-  for (const requirementPackageId of requirementPackageIds) {
+  const joins = [
+    {
+      foreignKey: 'requirement_package_id',
+      ids: requirementPackageIds,
+      table: 'requirement_version_requirement_packages',
+    },
+    {
+      foreignKey: 'norm_reference_id',
+      ids: normRefIds,
+      table: 'requirement_version_norm_references',
+    },
+  ] as const
+
+  for (const join of joins) {
+    if (join.ids.length === 0) continue
+
+    const valuesSql = join.ids
+      .map((_, index) => `(@0, @${index + 1})`)
+      .join(', ')
     await tx.query(
-      `INSERT INTO requirement_version_requirement_packages (requirement_version_id, requirement_package_id) VALUES (@0, @1)`,
-      [versionId, requirementPackageId],
-    )
-  }
-  for (const normReferenceId of normRefIds) {
-    await tx.query(
-      `INSERT INTO requirement_version_norm_references (requirement_version_id, norm_reference_id) VALUES (@0, @1)`,
-      [versionId, normReferenceId],
+      `INSERT INTO ${join.table} (requirement_version_id, ${join.foreignKey}) VALUES ${valuesSql}`,
+      [versionId, ...join.ids],
     )
   }
 }

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -87,7 +87,7 @@ const QueryCatalogKindSchema = z.enum([
   'transitions',
 ])
 
-function createRequirementCatalogFilterIdsSchema(
+function createUniquePositiveIntegerIdsSchema(
   description: string,
 ): z.ZodOptional<ReturnType<typeof uniquePositiveIntegerArraySchema>> {
   return uniquePositiveIntegerArraySchema()
@@ -857,13 +857,13 @@ function renderRequirementHtml(
 function createQueryCatalogSchema() {
   return z
     .object({
-      areaIds: createRequirementCatalogFilterIdsSchema(
+      areaIds: createUniquePositiveIntegerIdsSchema(
         'Requirement area IDs. Applies only to catalog "requirements".',
       ),
       catalog: QueryCatalogKindSchema.describe(
         'Catalog to list or search. Use "requirements" for requirement rows or a lookup catalog for reference rows.',
       ),
-      categoryIds: createRequirementCatalogFilterIdsSchema(
+      categoryIds: createUniquePositiveIntegerIdsSchema(
         'Requirement category IDs. Applies only to catalog "requirements".',
       ),
       cursor: z
@@ -890,7 +890,7 @@ function createQueryCatalogSchema() {
         .describe(
           'Bounded page size for catalog "requirements"; defaults to 50 and accepts 1 through 100.',
         ),
-      normReferenceIds: createRequirementCatalogFilterIdsSchema(
+      normReferenceIds: createUniquePositiveIntegerIdsSchema(
         'Norm reference IDs. Applies only to catalog "requirements".',
       ),
       operation: z
@@ -898,7 +898,7 @@ function createQueryCatalogSchema() {
         .describe(
           '"list" returns all matching rows in structuredContent.result. "search" returns matching rows with top-level match metadata.',
         ),
-      qualityCharacteristicIds: createRequirementCatalogFilterIdsSchema(
+      qualityCharacteristicIds: createUniquePositiveIntegerIdsSchema(
         'Quality characteristic IDs. Applies only to catalog "requirements".',
       ),
       verifiable: z
@@ -907,7 +907,7 @@ function createQueryCatalogSchema() {
         .describe(
           'Filter by verifiability. Applies only to catalog "requirements".',
         ),
-      priorityLevelIds: createRequirementCatalogFilterIdsSchema(
+      priorityLevelIds: createUniquePositiveIntegerIdsSchema(
         'Priority level IDs. Applies only to catalog "requirements".',
       ),
       sortBy: z
@@ -941,7 +941,7 @@ function createQueryCatalogSchema() {
         .describe(
           'Search text for operation "search". Requirement search matches id, uniqueId, version.description, and version.acceptanceCriteria; lookup search matches stable lookup fields.',
         ),
-      statuses: createRequirementCatalogFilterIdsSchema(
+      statuses: createUniquePositiveIntegerIdsSchema(
         'Requirement version status IDs. Applies only to catalog "requirements".',
       ),
       typeId: z
@@ -952,10 +952,10 @@ function createQueryCatalogSchema() {
         .describe(
           'Requirement type ID used only to filter catalog "quality_characteristics".',
         ),
-      typeIds: createRequirementCatalogFilterIdsSchema(
+      typeIds: createUniquePositiveIntegerIdsSchema(
         'Requirement type IDs. Applies only to catalog "requirements".',
       ),
-      requirementPackageIds: createRequirementCatalogFilterIdsSchema(
+      requirementPackageIds: createUniquePositiveIntegerIdsSchema(
         'Requirements package IDs. Applies only to catalog "requirements".',
       ),
     })
@@ -1386,14 +1386,12 @@ const RequirementMutationSchema = z
       .describe(
         'How the requirement should be verified when verifiable is true.',
       ),
-    requirementPackageIds: z
-      .array(z.number().int().positive())
-      .optional()
-      .describe('Requirements package IDs linked to the version.'),
-    normReferenceIds: z
-      .array(z.number().int().positive())
-      .optional()
-      .describe('Norm reference IDs linked to the version.'),
+    requirementPackageIds: createUniquePositiveIntegerIdsSchema(
+      'Requirements package IDs linked to the version.',
+    ),
+    normReferenceIds: createUniquePositiveIntegerIdsSchema(
+      'Norm reference IDs linked to the version.',
+    ),
     qualityCharacteristicId: z
       .number()
       .int()
@@ -2127,8 +2125,7 @@ export function createKravhanteringMcpServer(
         openWorldHint: false,
         readOnlyHint: false,
       },
-      description:
-        'Create, edit, archive, delete a latest draft, or restore a historical requirement version. For operation "create", pass requirement.areaId and requirement.description, plus optional classification/verification fields. For operation "edit", first call requirements_get_requirement with view: "history", then pass requirement.versions[0].id as requirement.baseVersionId and requirement.versions[0].revisionToken as requirement.baseRevisionToken.',
+      description: `Create, edit, archive, delete a latest draft, or restore a historical requirement version. For operation "create", pass requirement.areaId and requirement.description, plus optional classification/verification fields. For operation "edit", first call requirements_get_requirement with view: "history", then pass requirement.versions[0].id as requirement.baseVersionId and requirement.versions[0].revisionToken as requirement.baseRevisionToken. requirement.normReferenceIds and requirement.requirementPackageIds each accept up to ${ARRAY_INPUT_MAX_ITEMS} unique IDs.`,
       inputSchema: createManageRequirementSchema(),
       outputSchema: ManageRequirementOutputSchema,
       title: 'Manage Requirement',

--- a/tests/unit/mcp-http.test.ts
+++ b/tests/unit/mcp-http.test.ts
@@ -705,6 +705,9 @@ describe('handleRequirementsMcpRequest', () => {
       expect(manageTool?.description).toContain('requirement.areaId')
       expect(manageTool?.description).toContain('requirement.description')
       expect(manageTool?.description).toContain('view: "history"')
+      expect(manageTool?.description).toContain(
+        `up to ${ARRAY_INPUT_MAX_ITEMS} unique IDs`,
+      )
       const manageInputSchemaText = JSON.stringify(manageTool?.inputSchema)
       expect(manageInputSchemaText).toContain('For create')
       expect(manageInputSchemaText).toContain('acceptanceCriteria')
@@ -712,6 +715,24 @@ describe('handleRequirementsMcpRequest', () => {
       expect(manageInputSchemaText).toContain(
         'requirement.versions[0].revisionToken',
       )
+      const manageInputSchema = JSON.parse(manageInputSchemaText) as {
+        properties: {
+          requirement: {
+            properties: {
+              normReferenceIds: { maxItems: number }
+              requirementPackageIds: { maxItems: number }
+            }
+          }
+        }
+      }
+      expect(
+        manageInputSchema.properties.requirement.properties.normReferenceIds
+          .maxItems,
+      ).toBe(ARRAY_INPUT_MAX_ITEMS)
+      expect(
+        manageInputSchema.properties.requirement.properties
+          .requirementPackageIds.maxItems,
+      ).toBe(ARRAY_INPUT_MAX_ITEMS)
       const manageOutputSchemaText = JSON.stringify(manageTool?.outputSchema)
       expect(manageOutputSchemaText).toContain('draftRequirementVersion')
       expect(manageOutputSchemaText).toContain('requirement')
@@ -2390,6 +2411,73 @@ describe('handleRequirementsMcpRequest', () => {
           baseRevisionToken: '11111111-1111-4111-8111-111111111111',
           baseVersionId: 10,
           normReferenceIds: [1, 2],
+        }),
+      }),
+    )
+
+    await client.close()
+    await transport.close()
+  })
+
+  it('bounds manage_requirement taxonomy IDs before service delegation', async () => {
+    const { client, transport } = await createClient()
+    const fakeService = serviceState.getService.mock.results[0]?.value
+    const maximumIds = Array.from(
+      { length: ARRAY_INPUT_MAX_ITEMS },
+      (_, index) => index + 1,
+    )
+
+    const maximumResult = await client.callTool({
+      arguments: {
+        operation: 'edit',
+        requirement: {
+          baseRevisionToken: '11111111-1111-4111-8111-111111111111',
+          baseVersionId: 10,
+          description: 'Updated description',
+          normReferenceIds: maximumIds,
+          requirementPackageIds: maximumIds,
+        },
+        uniqueId: 'INT0001',
+      },
+      name: 'requirements_manage_requirement',
+    })
+    const overMaximumResult = await client.callTool({
+      arguments: {
+        operation: 'edit',
+        requirement: {
+          baseRevisionToken: '11111111-1111-4111-8111-111111111111',
+          baseVersionId: 10,
+          description: 'Updated description',
+          normReferenceIds: [...maximumIds, ARRAY_INPUT_MAX_ITEMS + 1],
+        },
+        uniqueId: 'INT0001',
+      },
+      name: 'requirements_manage_requirement',
+    })
+    const duplicateResult = await client.callTool({
+      arguments: {
+        operation: 'edit',
+        requirement: {
+          baseRevisionToken: '11111111-1111-4111-8111-111111111111',
+          baseVersionId: 10,
+          description: 'Updated description',
+          requirementPackageIds: [1, 1],
+        },
+        uniqueId: 'INT0001',
+      },
+      name: 'requirements_manage_requirement',
+    })
+
+    expect(maximumResult.isError).not.toBe(true)
+    expect(overMaximumResult.isError).toBe(true)
+    expect(duplicateResult.isError).toBe(true)
+    expect(fakeService.manageRequirement).toHaveBeenCalledTimes(1)
+    expect(fakeService.manageRequirement).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        requirement: expect.objectContaining({
+          normReferenceIds: maximumIds,
+          requirementPackageIds: maximumIds,
         }),
       }),
     )

--- a/tests/unit/requirement-reference-validation.test.ts
+++ b/tests/unit/requirement-reference-validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { validateRequirementTaxonomyReferences } from '@/lib/dal/requirement-reference-validation'
+import { ARRAY_INPUT_MAX_ITEMS } from '@/lib/http/validation'
 
 function createExecutor(missing: string[] = []) {
   const missingKeys = new Set(missing)
@@ -71,6 +72,39 @@ describe('validateRequirementTaxonomyReferences', () => {
       requirementPackageIds: [],
       requirementTypeId: null,
       priorityLevelId: null,
+    })
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('bounds taxonomy ID arrays before database lookups', async () => {
+    const { executor, query } = createExecutor()
+    const maximumIds = Array.from(
+      { length: ARRAY_INPUT_MAX_ITEMS },
+      (_, index) => index + 1,
+    )
+
+    await expect(
+      validateRequirementTaxonomyReferences(executor, {
+        normReferenceIds: maximumIds,
+        requirementPackageIds: maximumIds,
+      }),
+    ).resolves.toMatchObject({
+      normReferenceIds: maximumIds,
+      requirementPackageIds: maximumIds,
+    })
+
+    query.mockClear()
+    await expect(
+      validateRequirementTaxonomyReferences(executor, {
+        normReferenceIds: [...maximumIds, ARRAY_INPUT_MAX_ITEMS + 1],
+      }),
+    ).rejects.toMatchObject({
+      code: 'validation',
+      details: {
+        field: 'normReferenceIds',
+        maxItems: ARRAY_INPUT_MAX_ITEMS,
+      },
+      status: 400,
     })
     expect(query).not.toHaveBeenCalled()
   })

--- a/tests/unit/requirements-dal.test.ts
+++ b/tests/unit/requirements-dal.test.ts
@@ -423,9 +423,9 @@ describe('requirements DAL (SQL Server path)', () => {
         [
           {
             description: 'Batch one',
-            normReferenceIds: [10],
+            normReferenceIds: [10, 11, 10],
             requirementAreaId: 1,
-            requirementPackageIds: [20],
+            requirementPackageIds: [20, 21, 20],
             verifiable: true,
             verificationMethod: 'inspection',
           },
@@ -444,6 +444,20 @@ describe('requirements DAL (SQL Server path)', () => {
         sql.includes('requirement_version_requirement_packages'),
       ),
     ).toBe(true)
+    const packageInsertCalls = query.mock.calls.filter(([sql]) =>
+      sql.includes('INSERT INTO requirement_version_requirement_packages'),
+    )
+    const normReferenceInsertCalls = query.mock.calls.filter(([sql]) =>
+      sql.includes('INSERT INTO requirement_version_norm_references'),
+    )
+    expect(packageInsertCalls).toHaveLength(1)
+    expect(packageInsertCalls[0]?.[0]).toContain('VALUES (@0, @1), (@0, @2)')
+    expect(packageInsertCalls[0]?.[1]).toEqual([101, 20, 21])
+    expect(normReferenceInsertCalls).toHaveLength(1)
+    expect(normReferenceInsertCalls[0]?.[0]).toContain(
+      'VALUES (@0, @1), (@0, @2)',
+    )
+    expect(normReferenceInsertCalls[0]?.[1]).toEqual([101, 10, 11])
     await expect(
       createRequirementsBatchWithExecutor(executor, []),
     ).resolves.toEqual([])


### PR DESCRIPTION
## Description

Bound MCP requirement create and edit taxonomy-link collections to 200 unique positive IDs each. Apply the same bound at the shared taxonomy validation boundary, deduplicate accepted direct inputs, and persist each link collection with one bounded multi-row insert instead of per-item writes.

Update the MCP contract documentation and add focused tests for maximum, oversized, duplicate, pre-database rejection, and batched persistence behavior.

## Related Issues

Fixes #848

## Reviewer Notes

- `npm run check`
- 7,300 Vitest tests passed; 86 environment-gated tests skipped.
- 35 HSA support tests passed.
- No visible UI or manual Playwright scenario changed.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
Before upgrade, tell MCP integration owners that requirement create and edit requests accept at most 200 unique norm reference IDs and 200 unique requirement package IDs. Requests that exceed a limit or contain duplicate IDs are rejected. Update affected clients to deduplicate these collections and keep them within the limits before rollout.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1074)
<!-- Reviewable:end -->
