### PR TITLE
docs: persist operator upgrade notes from #1074

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -315,6 +315,10 @@ filters accept at most 200 unique positive IDs per filter. Update clients to
 remove duplicate IDs and split larger filter collections into separate calls.
 Calls that do not meet this contract are rejected before database work.
 <!-- operator-upgrade:source pr-1072 end -->
+
+<!-- operator-upgrade:source pr-1074 start -->
+Before upgrade, tell MCP integration owners that requirement create and edit requests accept at most 200 unique norm reference IDs and 200 unique requirement package IDs. Requests that exceed a limit or contain duplicate IDs are rejected. Update affected clients to deduplicate these collections and keep them within the limits before rollout.
+<!-- operator-upgrade:source pr-1074 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #1074
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/32169612796

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1075)
<!-- Reviewable:end -->
