### PR TITLE
fix: scope RFI suggestion reads

### DIFF
--- a/app/[locale]/requirements/stewardship/rfi-questions-client.tsx
+++ b/app/[locale]/requirements/stewardship/rfi-questions-client.tsx
@@ -27,6 +27,7 @@ import {
   readRfiQuestionSuggestionMutationError,
   shouldReloadRfiQuestionSuggestions,
 } from '@/lib/requirements/rfi-question-suggestion-conflicts'
+import { fetchRfiQuestionSuggestionPages } from '@/lib/requirements/rfi-question-suggestion-pages'
 
 interface RequirementArea {
   id: number
@@ -310,11 +311,14 @@ export default function RfiQuestionsClient() {
     setLoading(true)
     setError(null)
     try {
-      const [areasResponse, questionsResponse, suggestionsResponse] =
+      const [areasResponse, questionsResponse, loadedSuggestions] =
         await Promise.all([
           apiFetch('/api/requirement-areas'),
           apiFetch('/api/rfi-questions?includeArchived=true'),
-          apiFetch('/api/rfi-question-suggestions'),
+          fetchRfiQuestionSuggestionPages<RfiSuggestion>(
+            '/api/rfi-question-suggestions',
+            { errorMessage: copy.loadError },
+          ).catch(() => []),
         ])
 
       if (!areasResponse.ok) {
@@ -337,14 +341,7 @@ export default function RfiQuestionsClient() {
       setAreas(areaData.areas ?? [])
       setQuestions(questionData.questions ?? [])
 
-      if (suggestionsResponse.ok) {
-        const suggestionData = (await suggestionsResponse.json()) as {
-          suggestions?: RfiSuggestion[]
-        }
-        setSuggestions(suggestionData.suggestions ?? [])
-      } else {
-        setSuggestions([])
-      }
+      setSuggestions(loadedSuggestions)
     } catch (loadError) {
       setError(loadError instanceof Error ? loadError.message : copy.loadError)
       setQuestions([])

--- a/app/[locale]/specifications/[specificationId]/specification-rfi-list-panel.tsx
+++ b/app/[locale]/specifications/[specificationId]/specification-rfi-list-panel.tsx
@@ -28,6 +28,7 @@ import {
   readRfiQuestionSuggestionMutationError,
   shouldReloadRfiQuestionSuggestions,
 } from '@/lib/requirements/rfi-question-suggestion-conflicts'
+import { fetchRfiQuestionSuggestionPages } from '@/lib/requirements/rfi-question-suggestion-pages'
 
 type RfiRelevance = 'not_relevant' | 'relevant'
 
@@ -173,29 +174,15 @@ export default function SpecificationRfiListPanel({
         setSuggestions([])
         return
       }
-      const areaIds = Array.from(new Set(items.map(item => item.areaId)))
-      if (areaIds.length === 0) {
+      if (items.length === 0) {
         setSuggestions([])
         return
       }
-      const loaded = await Promise.all(
-        areaIds.map(async areaId => {
-          const response = await apiFetch(
-            `/api/rfi-question-suggestions?areaId=${areaId}&specificationId=${specificationId}`,
-          )
-          if (!response.ok) {
-            throw new Error(
-              (await readResponseMessage(response)) ??
-                t('loadSuggestionsError'),
-            )
-          }
-          const data = (await response.json()) as {
-            suggestions?: RfiSuggestion[]
-          }
-          return data.suggestions ?? []
-        }),
+      const loaded = await fetchRfiQuestionSuggestionPages<RfiSuggestion>(
+        `/api/rfi-question-suggestions?specificationId=${specificationId}`,
+        { errorMessage: t('loadSuggestionsError') },
       )
-      setSuggestions(loaded.flat())
+      setSuggestions(loaded)
     },
     [canEdit, specificationId, t],
   )

--- a/app/api/rfi-question-suggestions/route.ts
+++ b/app/api/rfi-question-suggestions/route.ts
@@ -4,7 +4,6 @@ import {
   rfiQuestionSuggestionCreateSchema,
   rfiQuestionSuggestionQuerySchema,
 } from '@/app/api/rfi-questions/_schemas'
-import { listRfiQuestionSuggestions } from '@/lib/dal/rfi-questions'
 import { getRequestSqlServerDataSource } from '@/lib/db'
 import { withRestResponsePolicy } from '@/lib/http/response-policy'
 import {
@@ -14,11 +13,9 @@ import {
 import { parseSearchParams } from '@/lib/http/validation'
 import { applyResponseCorrelationHeaders } from '@/lib/observability/request-ids'
 import { requireHumanActorSnapshot } from '@/lib/requirements/auth'
-import { unauthorizedError } from '@/lib/requirements/errors'
 import { toHttpErrorPayload } from '@/lib/requirements/http-errors'
 import { createRfiQuestionSuggestionWithAudit } from '@/lib/requirements/rfi-question-suggestion-mutations'
 import { createRequirementsRestRuntime } from '@/lib/requirements/server'
-import { authorize } from '@/lib/requirements/service-shared'
 
 type RfiQuestionSuggestionCreateBody = z.infer<
   typeof rfiQuestionSuggestionCreateSchema
@@ -40,18 +37,12 @@ async function getHandler(request: NextRequest) {
 
   const runtime = await createRequirementsRestRuntime(request)
   try {
-    const suggestions =
-      parsedQuery.data.areaId == null
-        ? await listAuthorizedSuggestions(
-            runtime,
-            parsedQuery.data.specificationId,
-          )
-        : await listSuggestionsForArea(runtime, {
-            areaId: parsedQuery.data.areaId,
-            specificationId: parsedQuery.data.specificationId,
-          })
+    const page = await runtime.service.listRfiQuestionSuggestions(
+      runtime.context,
+      parsedQuery.data,
+    )
     return applyResponseCorrelationHeaders(
-      NextResponse.json({ suggestions }),
+      NextResponse.json(page),
       runtime.context,
     )
   } catch (error) {
@@ -63,64 +54,6 @@ async function getHandler(request: NextRequest) {
 }
 
 export const GET = withRestResponsePolicy(getHandler)
-
-async function listSuggestionsForArea(
-  runtime: Awaited<ReturnType<typeof createRequirementsRestRuntime>>,
-  options: { areaId: number; specificationId?: number },
-) {
-  await authorize(
-    runtime.authorization,
-    {
-      areaId: options.areaId,
-      kind: 'manage_rfi_question_suggestion',
-      operation: 'list',
-    },
-    runtime.context,
-  )
-  return listRfiQuestionSuggestions(runtime.db, options)
-}
-
-async function listAuthorizedSuggestions(
-  runtime: Awaited<ReturnType<typeof createRequirementsRestRuntime>>,
-  specificationId?: number,
-) {
-  if (!runtime.context.actor.isAuthenticated) {
-    throw unauthorizedError()
-  }
-
-  const suggestions = await listRfiQuestionSuggestions(runtime.db, {
-    specificationId,
-  })
-  if (runtime.context.actor.roles.includes('Admin')) return suggestions
-
-  const authorizedAreaIds = new Set<number>()
-  const deniedAreaIds = new Set<number>()
-  for (const suggestion of suggestions) {
-    if (authorizedAreaIds.has(suggestion.areaId)) continue
-    if (deniedAreaIds.has(suggestion.areaId)) continue
-
-    try {
-      await authorize(
-        runtime.authorization,
-        {
-          areaId: suggestion.areaId,
-          kind: 'manage_rfi_question_suggestion',
-          operation: 'list',
-        },
-        runtime.context,
-      )
-      authorizedAreaIds.add(suggestion.areaId)
-    } catch (error) {
-      const { status } = toHttpErrorPayload(error)
-      if (status !== 403) throw error
-      deniedAreaIds.add(suggestion.areaId)
-    }
-  }
-
-  return suggestions.filter(suggestion =>
-    authorizedAreaIds.has(suggestion.areaId),
-  )
-}
 
 const createPolicy = {
   action: ({ body }) => ({

--- a/app/api/rfi-questions/_schemas.ts
+++ b/app/api/rfi-questions/_schemas.ts
@@ -9,6 +9,10 @@ import {
   positiveIntegerStringSchema,
   queryBooleanSchema,
 } from '@/lib/http/validation'
+import {
+  MAX_RFI_QUESTION_SUGGESTION_PAGE_LIMIT,
+  RFI_QUESTION_SUGGESTION_CURSOR_MAX_LENGTH,
+} from '@/lib/requirements/rfi-question-suggestion-cursor'
 
 const idArraySchema = z.array(positiveIntegerSchema).max(200).optional()
 
@@ -98,6 +102,16 @@ export const rfiQuestionSuggestionCreateSchema = z
 export const rfiQuestionSuggestionQuerySchema = z
   .object({
     areaId: positiveIntegerStringSchema.optional(),
+    cursor: z
+      .string()
+      .min(1)
+      .max(RFI_QUESTION_SUGGESTION_CURSOR_MAX_LENGTH)
+      .optional(),
+    limit: positiveIntegerStringSchema
+      .refine(value => value <= MAX_RFI_QUESTION_SUGGESTION_PAGE_LIMIT, {
+        message: `Expected limit to be at most ${MAX_RFI_QUESTION_SUGGESTION_PAGE_LIMIT}`,
+      })
+      .optional(),
     specificationId: positiveIntegerStringSchema.optional(),
   })
   .strict()

--- a/docs/reference/database-schema.md
+++ b/docs/reference/database-schema.md
@@ -1395,6 +1395,10 @@ insert, update, and delete rules. It permits creation only as draft, the
 forward-only lifecycle, actor anonymization, and specification cleanup while
 rejecting evidence changes and non-draft deletion.
 
+**Page indexes:** `idx_rfi_question_suggestions_created_at_id` supports the
+stable collection order. The area and specification variants prefix that order
+with `area_id` or `specification_id` for filtered pages.
+
 ---
 
 ### `norm_references`
@@ -2764,6 +2768,9 @@ its purpose and the table/column(s) it covers.
 | `idx_improvement_suggestions_requirement_version_id` | `improvement_suggestions` | `requirement_version_id` | Speed up lookups of suggestions by requirement version |
 | `idx_improvement_suggestions_created_by_hsa_id` | `improvement_suggestions` | `created_by_hsa_id` | Speed up privacy erasure of suggestion creators |
 | `idx_improvement_suggestions_resolved_by_hsa_id` | `improvement_suggestions` | `resolved_by_hsa_id` | Speed up privacy erasure of suggestion resolvers |
+| `idx_rfi_question_suggestions_created_at_id` | `rfi_question_suggestions` | `created_at, id` | Support stable bounded suggestion pages |
+| `idx_rfi_question_suggestions_area_id_created_at_id` | `rfi_question_suggestions` | `area_id, created_at, id` | Support stable bounded suggestion pages filtered by requirement area |
+| `idx_rfi_question_suggestions_specification_id_created_at_id` | `rfi_question_suggestions` | `specification_id, created_at, id` | Support stable bounded suggestion pages filtered by specification |
 | `idx_access_review_runs_status` | `access_review_runs` | `status` | Speed up filtering review runs by lifecycle status |
 | `idx_access_review_runs_due_at` | `access_review_runs` | `due_at` | Speed up overdue and next-due review queries |
 | `idx_access_review_runs_reviewer_hsa_id` | `access_review_runs` | `reviewer_hsa_id` | Speed up assigned-reviewer access checks and privacy lookups |
@@ -2918,6 +2925,7 @@ graph LR
         R[requirements]
         RV[requirement_versions]
         IS[improvement_suggestions]
+        RFIS[rfi_question_suggestions]
     end
 
     subgraph Transient MCP State
@@ -3011,6 +3019,10 @@ graph LR
     IS -- "idx_..._requirement_version_id\n(requirement_version_id)" --> RV
     IS -- "idx_..._created_by_hsa_id\n(created_by_hsa_id)" --> IS
     IS -- "idx_..._resolved_by_hsa_id\n(resolved_by_hsa_id)" --> IS
+
+    RFIS -- "idx_..._created_at_id\n(created_at, id)" --> RFIS
+    RFIS -- "idx_..._area_id_created_at_id\n(area_id, created_at, id)" --> RFIS
+    RFIS -- "idx_..._specification_id_created_at_id\n(specification_id, created_at, id)" --> RFIS
 
     RAC -- "FK area_id" --> RA
     RAC -- "FK hsa_id" --> RRP

--- a/lib/__tests__/rfi-question-suggestion-pages.test.ts
+++ b/lib/__tests__/rfi-question-suggestion-pages.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fetchRfiQuestionSuggestionPages } from '@/lib/requirements/rfi-question-suggestion-pages'
+
+describe('fetchRfiQuestionSuggestionPages', () => {
+  it('follows bounded cursors and deduplicates repeated suggestion rows', async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({
+          pagination: { hasMore: true, nextCursor: 'cursor-2' },
+          suggestions: [{ id: 2 }, { id: 1 }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          pagination: { hasMore: false, nextCursor: null },
+          suggestions: [{ id: 1 }, { id: 0 }],
+        }),
+      )
+
+    await expect(
+      fetchRfiQuestionSuggestionPages<{ id: number }>(
+        '/api/rfi-question-suggestions?areaId=7',
+        { errorMessage: 'Failed', fetchPage },
+      ),
+    ).resolves.toEqual([{ id: 2 }, { id: 1 }, { id: 0 }])
+    expect(fetchPage).toHaveBeenNthCalledWith(
+      1,
+      '/api/rfi-question-suggestions?areaId=7',
+    )
+    expect(fetchPage).toHaveBeenNthCalledWith(
+      2,
+      '/api/rfi-question-suggestions?areaId=7&cursor=cursor-2',
+    )
+  })
+
+  it('rejects a repeated cursor before another request can amplify work', async () => {
+    const fetchPage = vi.fn(async () =>
+      Response.json({
+        pagination: { hasMore: true, nextCursor: 'same-cursor' },
+        suggestions: [{ id: 1 }],
+      }),
+    )
+
+    await expect(
+      fetchRfiQuestionSuggestionPages<{ id: number }>(
+        '/api/rfi-question-suggestions',
+        { errorMessage: 'Failed', fetchPage },
+      ),
+    ).rejects.toThrow('Failed')
+    expect(fetchPage).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects aggregate response bytes before retaining another page', async () => {
+    let page = 0
+    const fetchPage = vi.fn(async () => {
+      page += 1
+      return Response.json({
+        pagination: { hasMore: true, nextCursor: `cursor-${page}` },
+        suggestions: [{ content: 'x'.repeat(1_048_000), id: page }],
+      })
+    })
+
+    await expect(
+      fetchRfiQuestionSuggestionPages<{ content: string; id: number }>(
+        '/api/rfi-question-suggestions',
+        { errorMessage: 'Failed', fetchPage },
+      ),
+    ).rejects.toThrow('Failed')
+    expect(fetchPage).toHaveBeenCalledTimes(9)
+  })
+})

--- a/lib/__tests__/rfi-question-suggestion-pages.test.ts
+++ b/lib/__tests__/rfi-question-suggestion-pages.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { fetchRfiQuestionSuggestionPages } from '@/lib/requirements/rfi-question-suggestion-pages'
 
 describe('fetchRfiQuestionSuggestionPages', () => {
+  afterEach(() => vi.useRealTimers())
+
   it('follows bounded cursors and deduplicates repeated suggestion rows', async () => {
+    vi.useFakeTimers()
     const fetchPage = vi
       .fn()
       .mockResolvedValueOnce(
@@ -27,11 +30,15 @@ describe('fetchRfiQuestionSuggestionPages', () => {
     expect(fetchPage).toHaveBeenNthCalledWith(
       1,
       '/api/rfi-question-suggestions?areaId=7',
+      expect.any(AbortSignal),
     )
     expect(fetchPage).toHaveBeenNthCalledWith(
       2,
       '/api/rfi-question-suggestions?areaId=7&cursor=cursor-2',
+      expect.any(AbortSignal),
     )
+    expect(fetchPage.mock.calls[0]?.[1]).toBe(fetchPage.mock.calls[1]?.[1])
+    expect(vi.getTimerCount()).toBe(0)
   })
 
   it('rejects a repeated cursor before another request can amplify work', async () => {
@@ -68,5 +75,28 @@ describe('fetchRfiQuestionSuggestionPages', () => {
       ),
     ).rejects.toThrow('Failed')
     expect(fetchPage).toHaveBeenCalledTimes(9)
+  })
+
+  it('aborts a stalled traversal when its shared deadline expires', async () => {
+    vi.useFakeTimers()
+    const fetchPage = vi.fn(
+      (_url: string, signal: AbortSignal) =>
+        new Promise<Response>((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), {
+            once: true,
+          })
+        }),
+    )
+
+    const traversal = fetchRfiQuestionSuggestionPages<{ id: number }>(
+      '/api/rfi-question-suggestions',
+      { errorMessage: 'Failed', fetchPage },
+    )
+    const rejection = expect(traversal).rejects.toThrow()
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    await rejection
+    expect(fetchPage.mock.calls[0]?.[1].aborted).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/lib/dal/rfi-questions.ts
+++ b/lib/dal/rfi-questions.ts
@@ -11,6 +11,8 @@ export type RfiRelevance = 'not_relevant' | 'relevant'
 
 export const RFI_SUGGESTION_RESOLVED = 1
 export const RFI_SUGGESTION_DISMISSED = 2
+export const MAX_RFI_QUESTION_SUGGESTION_QUERY_ROWS = 201
+export const MAX_RFI_QUESTION_SUGGESTION_TEXT_CHARACTERS = 10_000
 
 export interface SqlExecutor {
   query<T = unknown[]>(sql: string, parameters?: unknown[]): Promise<T>
@@ -38,6 +40,20 @@ export interface RfiQuestionSuggestionMutationTarget {
   id: number
   rfiQuestionId: number | null
   specificationId: number | null
+}
+
+export interface RfiQuestionSuggestionPageBoundary {
+  createdAt: string
+  id: number
+}
+
+export interface RfiQuestionSuggestionListOptions {
+  actorHsaId?: string
+  after?: RfiQuestionSuggestionPageBoundary
+  areaId?: number
+  limit?: number
+  specificationId?: number
+  suggestionId?: number
 }
 
 export interface RfiQuestionVersionLinks {
@@ -1472,14 +1488,19 @@ export async function getRfiQuestionSuggestion(
 
 export async function listRfiQuestionSuggestions(
   db: SqlExecutor,
-  options: {
-    areaId?: number
-    specificationId?: number
-    suggestionId?: number
-  } = {},
+  options: RfiQuestionSuggestionListOptions = {},
 ): Promise<RfiQuestionSuggestionRow[]> {
   const params: unknown[] = []
   const conditions: string[] = []
+  const limit = options.limit ?? MAX_RFI_QUESTION_SUGGESTION_QUERY_ROWS
+  if (
+    !Number.isInteger(limit) ||
+    limit < 1 ||
+    limit > MAX_RFI_QUESTION_SUGGESTION_QUERY_ROWS
+  ) {
+    throw validationError('Invalid RFI question suggestion query row limit')
+  }
+  params.push(limit)
   if (options.suggestionId != null) {
     params.push(options.suggestionId)
     conditions.push(`suggestion.id = @${params.length - 1}`)
@@ -1488,6 +1509,27 @@ export async function listRfiQuestionSuggestions(
     params.push(options.areaId)
     conditions.push(`suggestion.area_id = @${params.length - 1}`)
   }
+  if (options.actorHsaId != null) {
+    params.push(options.actorHsaId)
+    const actorParameter = `@${params.length - 1}`
+    conditions.push(
+      `(area.owner_hsa_id = ${actorParameter} OR EXISTS (
+        SELECT 1
+        FROM requirement_area_co_authors co_author
+        WHERE co_author.area_id = area.id
+          AND co_author.hsa_id = ${actorParameter}
+      ))`,
+    )
+  }
+  if (options.after != null) {
+    params.push(options.after.createdAt)
+    const createdAtParameter = `@${params.length - 1}`
+    params.push(options.after.id)
+    const idParameter = `@${params.length - 1}`
+    conditions.push(
+      `(suggestion.created_at < ${createdAtParameter} OR (suggestion.created_at = ${createdAtParameter} AND suggestion.id < ${idParameter}))`,
+    )
+  }
   if (options.specificationId != null) {
     params.push(options.specificationId)
     conditions.push(`suggestion.specification_id = @${params.length - 1}`)
@@ -1495,26 +1537,26 @@ export async function listRfiQuestionSuggestions(
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
   const rows = (await db.query(
     `
-      SELECT
+      SELECT TOP (@0)
         suggestion.id AS id,
         suggestion.area_id AS areaId,
-        area.name AS areaName,
+        LEFT(area.name, ${MAX_RFI_QUESTION_SUGGESTION_TEXT_CHARACTERS}) AS areaName,
         suggestion.rfi_question_id AS rfiQuestionId,
         question.question_code AS questionCode,
         suggestion.specification_id AS specificationId,
         suggestion.source_specification_code AS sourceSpecificationCode,
-        suggestion.source_specification_name AS sourceSpecificationName,
-        suggestion.content AS content,
+        LEFT(suggestion.source_specification_name, ${MAX_RFI_QUESTION_SUGGESTION_TEXT_CHARACTERS}) AS sourceSpecificationName,
+        LEFT(suggestion.content, ${MAX_RFI_QUESTION_SUGGESTION_TEXT_CHARACTERS}) AS content,
         suggestion.is_review_requested AS isReviewRequested,
         suggestion.review_requested_at AS reviewRequestedAt,
         suggestion.resolution AS resolution,
-        suggestion.resolution_motivation AS resolutionMotivation,
+        LEFT(suggestion.resolution_motivation, ${MAX_RFI_QUESTION_SUGGESTION_TEXT_CHARACTERS}) AS resolutionMotivation,
         suggestion.created_by_hsa_id AS createdByHsaId,
-        suggestion.created_by_display_name AS createdByDisplayName,
+        LEFT(suggestion.created_by_display_name, ${MAX_RFI_QUESTION_SUGGESTION_TEXT_CHARACTERS}) AS createdByDisplayName,
         suggestion.created_at AS createdAt,
         suggestion.updated_at AS updatedAt,
         suggestion.resolved_by_hsa_id AS resolvedByHsaId,
-        suggestion.resolved_by_display_name AS resolvedByDisplayName,
+        LEFT(suggestion.resolved_by_display_name, ${MAX_RFI_QUESTION_SUGGESTION_TEXT_CHARACTERS}) AS resolvedByDisplayName,
         suggestion.resolved_at AS resolvedAt
       FROM rfi_question_suggestions suggestion
       INNER JOIN requirement_areas area

--- a/lib/requirements/rfi-question-suggestion-cursor.ts
+++ b/lib/requirements/rfi-question-suggestion-cursor.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod'
+import type { RfiQuestionSuggestionPageBoundary } from '@/lib/dal/rfi-questions'
+import {
+  createVersionedCursorCodec,
+  fingerprintCursorQuery,
+  type VersionedCursorPayload,
+} from '@/lib/requirements/cursor-codec'
+
+const CURSOR_VERSION = 1
+export const MAX_RFI_QUESTION_SUGGESTION_PAGE_LIMIT = 200
+export const RFI_QUESTION_SUGGESTION_CURSOR_MAX_LENGTH = 1024
+
+const boundarySchema = z
+  .object({
+    createdAt: z.string().datetime(),
+    id: z.number().int().positive(),
+  })
+  .strict()
+
+export type RfiQuestionSuggestionCursorPayload = VersionedCursorPayload<
+  RfiQuestionSuggestionPageBoundary,
+  typeof CURSOR_VERSION
+>
+
+const cursorCodec = createVersionedCursorCodec({
+  boundarySchema,
+  maxLength: RFI_QUESTION_SUGGESTION_CURSOR_MAX_LENGTH,
+  version: CURSOR_VERSION,
+})
+
+export function fingerprintRfiQuestionSuggestionQuery(value: unknown): string {
+  return fingerprintCursorQuery(value)
+}
+
+export function encodeRfiQuestionSuggestionCursor(
+  boundary: RfiQuestionSuggestionPageBoundary,
+  queryFingerprint: string,
+): string {
+  return cursorCodec.encode(boundary, queryFingerprint)
+}
+
+export function decodeRfiQuestionSuggestionCursor(
+  cursor: string,
+): RfiQuestionSuggestionCursorPayload {
+  return cursorCodec.decode(cursor)
+}
+
+export function assertRfiQuestionSuggestionCursorMatches(
+  payload: RfiQuestionSuggestionCursorPayload,
+  queryFingerprint: string,
+): void {
+  cursorCodec.assertMatches(payload, queryFingerprint)
+}

--- a/lib/requirements/rfi-question-suggestion-pages.ts
+++ b/lib/requirements/rfi-question-suggestion-pages.ts
@@ -4,6 +4,7 @@ import { readResponseMessage } from '@/lib/http/response-message'
 const MAX_COMPLETE_RFI_QUESTION_SUGGESTION_ITEMS = 2_000
 const MAX_COMPLETE_RFI_QUESTION_SUGGESTION_PAGES = 20
 const MAX_COMPLETE_RFI_QUESTION_SUGGESTION_BYTES = 8 * 1_048_576
+const COMPLETE_RFI_QUESTION_SUGGESTION_DEADLINE_MS = 30_000
 
 interface SuggestionIdentity {
   id: number
@@ -19,7 +20,7 @@ interface SuggestionPage<T extends SuggestionIdentity> {
 
 export interface FetchRfiQuestionSuggestionPagesOptions {
   errorMessage: string
-  fetchPage?: (url: string) => Promise<Response>
+  fetchPage?: (url: string, signal: AbortSignal) => Promise<Response>
 }
 
 function withCursor(url: string, cursor: string): string {
@@ -34,7 +35,14 @@ export async function fetchRfiQuestionSuggestionPages<
   initialUrl: string,
   options: FetchRfiQuestionSuggestionPagesOptions,
 ): Promise<T[]> {
-  const fetchPage = options.fetchPage ?? apiFetch
+  const fetchPage =
+    options.fetchPage ??
+    ((url: string, signal: AbortSignal) => apiFetch(url, { signal }))
+  const deadline = new AbortController()
+  const deadlineTimeout = setTimeout(
+    () => deadline.abort(),
+    COMPLETE_RFI_QUESTION_SUGGESTION_DEADLINE_MS,
+  )
   const seenCursors = new Set<string>()
   const seenSuggestionIds = new Set<number>()
   const suggestions: T[] = []
@@ -42,39 +50,43 @@ export async function fetchRfiQuestionSuggestionPages<
   let encodedBytes = 0
   let url = initialUrl
 
-  for (
-    let pageNumber = 1;
-    pageNumber <= MAX_COMPLETE_RFI_QUESTION_SUGGESTION_PAGES;
-    pageNumber += 1
-  ) {
-    const response = await fetchPage(url)
-    if (!response.ok) {
-      throw new Error(
-        (await readResponseMessage(response)) ?? options.errorMessage,
-      )
-    }
-    const page = (await response.json()) as SuggestionPage<T>
-    for (const suggestion of page.suggestions ?? []) {
-      if (seenSuggestionIds.has(suggestion.id)) continue
-      encodedBytes += encoder.encode(JSON.stringify(suggestion)).byteLength
-      if (encodedBytes > MAX_COMPLETE_RFI_QUESTION_SUGGESTION_BYTES) {
+  try {
+    for (
+      let pageNumber = 1;
+      pageNumber <= MAX_COMPLETE_RFI_QUESTION_SUGGESTION_PAGES;
+      pageNumber += 1
+    ) {
+      const response = await fetchPage(url, deadline.signal)
+      if (!response.ok) {
+        throw new Error(
+          (await readResponseMessage(response)) ?? options.errorMessage,
+        )
+      }
+      const page = (await response.json()) as SuggestionPage<T>
+      for (const suggestion of page.suggestions ?? []) {
+        if (seenSuggestionIds.has(suggestion.id)) continue
+        encodedBytes += encoder.encode(JSON.stringify(suggestion)).byteLength
+        if (encodedBytes > MAX_COMPLETE_RFI_QUESTION_SUGGESTION_BYTES) {
+          throw new Error(options.errorMessage)
+        }
+        seenSuggestionIds.add(suggestion.id)
+        suggestions.push(suggestion)
+        if (suggestions.length > MAX_COMPLETE_RFI_QUESTION_SUGGESTION_ITEMS) {
+          throw new Error(options.errorMessage)
+        }
+      }
+
+      if (!page.pagination?.hasMore) return suggestions
+      const nextCursor = page.pagination.nextCursor
+      if (!nextCursor || seenCursors.has(nextCursor)) {
         throw new Error(options.errorMessage)
       }
-      seenSuggestionIds.add(suggestion.id)
-      suggestions.push(suggestion)
-      if (suggestions.length > MAX_COMPLETE_RFI_QUESTION_SUGGESTION_ITEMS) {
-        throw new Error(options.errorMessage)
-      }
+      seenCursors.add(nextCursor)
+      url = withCursor(initialUrl, nextCursor)
     }
 
-    if (!page.pagination?.hasMore) return suggestions
-    const nextCursor = page.pagination.nextCursor
-    if (!nextCursor || seenCursors.has(nextCursor)) {
-      throw new Error(options.errorMessage)
-    }
-    seenCursors.add(nextCursor)
-    url = withCursor(initialUrl, nextCursor)
+    throw new Error(options.errorMessage)
+  } finally {
+    clearTimeout(deadlineTimeout)
   }
-
-  throw new Error(options.errorMessage)
 }

--- a/lib/requirements/rfi-question-suggestion-pages.ts
+++ b/lib/requirements/rfi-question-suggestion-pages.ts
@@ -1,0 +1,80 @@
+import { apiFetch } from '@/lib/http/api-fetch'
+import { readResponseMessage } from '@/lib/http/response-message'
+
+const MAX_COMPLETE_RFI_QUESTION_SUGGESTION_ITEMS = 2_000
+const MAX_COMPLETE_RFI_QUESTION_SUGGESTION_PAGES = 20
+const MAX_COMPLETE_RFI_QUESTION_SUGGESTION_BYTES = 8 * 1_048_576
+
+interface SuggestionIdentity {
+  id: number
+}
+
+interface SuggestionPage<T extends SuggestionIdentity> {
+  pagination?: {
+    hasMore?: boolean
+    nextCursor?: string | null
+  }
+  suggestions?: T[]
+}
+
+export interface FetchRfiQuestionSuggestionPagesOptions {
+  errorMessage: string
+  fetchPage?: (url: string) => Promise<Response>
+}
+
+function withCursor(url: string, cursor: string): string {
+  const parsed = new URL(url, 'http://localhost')
+  parsed.searchParams.set('cursor', cursor)
+  return `${parsed.pathname}${parsed.search}`
+}
+
+export async function fetchRfiQuestionSuggestionPages<
+  T extends SuggestionIdentity,
+>(
+  initialUrl: string,
+  options: FetchRfiQuestionSuggestionPagesOptions,
+): Promise<T[]> {
+  const fetchPage = options.fetchPage ?? apiFetch
+  const seenCursors = new Set<string>()
+  const seenSuggestionIds = new Set<number>()
+  const suggestions: T[] = []
+  const encoder = new TextEncoder()
+  let encodedBytes = 0
+  let url = initialUrl
+
+  for (
+    let pageNumber = 1;
+    pageNumber <= MAX_COMPLETE_RFI_QUESTION_SUGGESTION_PAGES;
+    pageNumber += 1
+  ) {
+    const response = await fetchPage(url)
+    if (!response.ok) {
+      throw new Error(
+        (await readResponseMessage(response)) ?? options.errorMessage,
+      )
+    }
+    const page = (await response.json()) as SuggestionPage<T>
+    for (const suggestion of page.suggestions ?? []) {
+      if (seenSuggestionIds.has(suggestion.id)) continue
+      encodedBytes += encoder.encode(JSON.stringify(suggestion)).byteLength
+      if (encodedBytes > MAX_COMPLETE_RFI_QUESTION_SUGGESTION_BYTES) {
+        throw new Error(options.errorMessage)
+      }
+      seenSuggestionIds.add(suggestion.id)
+      suggestions.push(suggestion)
+      if (suggestions.length > MAX_COMPLETE_RFI_QUESTION_SUGGESTION_ITEMS) {
+        throw new Error(options.errorMessage)
+      }
+    }
+
+    if (!page.pagination?.hasMore) return suggestions
+    const nextCursor = page.pagination.nextCursor
+    if (!nextCursor || seenCursors.has(nextCursor)) {
+      throw new Error(options.errorMessage)
+    }
+    seenCursors.add(nextCursor)
+    url = withCursor(initialUrl, nextCursor)
+  }
+
+  throw new Error(options.errorMessage)
+}

--- a/lib/requirements/service-rfi-questions.ts
+++ b/lib/requirements/service-rfi-questions.ts
@@ -1,21 +1,94 @@
 import { listAreaIdsActorCanAuthor } from '@/lib/dal/requirement-areas'
 import {
+  listRfiQuestionSuggestions as listRfiQuestionSuggestionRows,
   listRfiQuestions,
   type RfiQuestionListOptions,
   type RfiQuestionRow,
+  type RfiQuestionSuggestionRow,
 } from '@/lib/dal/rfi-questions'
 import type { SqlServerDatabase } from '@/lib/db'
 import type {
   AuthorizationService,
   RequestContext,
 } from '@/lib/requirements/auth'
+import { unauthorizedError, validationError } from '@/lib/requirements/errors'
+import {
+  assertRfiQuestionSuggestionCursorMatches,
+  decodeRfiQuestionSuggestionCursor,
+  encodeRfiQuestionSuggestionCursor,
+  fingerprintRfiQuestionSuggestionQuery,
+  MAX_RFI_QUESTION_SUGGESTION_PAGE_LIMIT,
+} from '@/lib/requirements/rfi-question-suggestion-cursor'
 import { authorize } from '@/lib/requirements/service-shared'
 
+export const DEFAULT_RFI_QUESTION_SUGGESTION_PAGE_LIMIT = 100
+export const MAX_RFI_QUESTION_SUGGESTION_PAGE_BYTES = 1_048_576
+
+const RFI_QUESTION_SUGGESTION_PAGE_ENVELOPE_BYTES = 4_096
+
+export interface RfiQuestionSuggestionPageInput {
+  areaId?: number
+  cursor?: string
+  limit?: number
+  specificationId?: number
+}
+
+export interface RfiQuestionSuggestionPageResult {
+  pagination: {
+    count: number
+    hasMore: boolean
+    limit: number
+    nextCursor: string | null
+  }
+  suggestions: RfiQuestionSuggestionRow[]
+}
+
 export interface RfiQuestionQueryService {
+  listRfiQuestionSuggestions(
+    context: RequestContext,
+    input: RfiQuestionSuggestionPageInput,
+  ): Promise<RfiQuestionSuggestionPageResult>
   listRfiQuestions(
     context: RequestContext,
     input: Omit<RfiQuestionListOptions, 'areaIds'>,
   ): Promise<RfiQuestionRow[]>
+}
+
+function normalizeSuggestionPageLimit(limit: number | undefined): number {
+  if (limit == null) return DEFAULT_RFI_QUESTION_SUGGESTION_PAGE_LIMIT
+  if (
+    !Number.isInteger(limit) ||
+    limit < 1 ||
+    limit > MAX_RFI_QUESTION_SUGGESTION_PAGE_LIMIT
+  ) {
+    throw validationError('Expected limit to be an integer from 1 to 200')
+  }
+  return limit
+}
+
+function suggestionsWithinByteBudget(
+  rows: RfiQuestionSuggestionRow[],
+  limit: number,
+): RfiQuestionSuggestionRow[] {
+  const encoder = new TextEncoder()
+  const itemBudget =
+    MAX_RFI_QUESTION_SUGGESTION_PAGE_BYTES -
+    RFI_QUESTION_SUGGESTION_PAGE_ENVELOPE_BYTES
+  const suggestions: RfiQuestionSuggestionRow[] = []
+  let encodedBytes = 0
+
+  for (const row of rows.slice(0, limit)) {
+    const rowBytes = encoder.encode(JSON.stringify(row)).byteLength
+    const separatorBytes = suggestions.length === 0 ? 0 : 1
+    if (encodedBytes + separatorBytes + rowBytes > itemBudget) break
+    suggestions.push(row)
+    encodedBytes += separatorBytes + rowBytes
+  }
+
+  if (rows.length > 0 && suggestions.length === 0) {
+    throw validationError('Stored RFI question suggestion exceeds page budget')
+  }
+  return suggestions
 }
 
 export function createRfiQuestionQueryService({
@@ -51,6 +124,71 @@ export function createRfiQuestionQueryService({
         areaIds,
         includeArchived: input.includeArchived,
       })
+    },
+
+    async listRfiQuestionSuggestions(context, input) {
+      if (!context.actor.isAuthenticated) throw unauthorizedError()
+
+      const limit = normalizeSuggestionPageLimit(input.limit)
+      let actorHsaId: string | undefined
+      if (input.areaId != null) {
+        await authorize(
+          authorization,
+          {
+            areaId: input.areaId,
+            kind: 'manage_rfi_question_suggestion',
+            operation: 'list',
+          },
+          context,
+        )
+      } else if (!context.actor.roles.includes('Admin')) {
+        actorHsaId = context.actor.hsaId ?? undefined
+        if (!actorHsaId) {
+          return {
+            pagination: { count: 0, hasMore: false, limit, nextCursor: null },
+            suggestions: [],
+          }
+        }
+      }
+
+      const queryFingerprint = fingerprintRfiQuestionSuggestionQuery({
+        actorHsaId,
+        areaId: input.areaId,
+        specificationId: input.specificationId,
+      })
+      const cursor = input.cursor
+        ? decodeRfiQuestionSuggestionCursor(input.cursor)
+        : undefined
+      if (cursor) {
+        assertRfiQuestionSuggestionCursorMatches(cursor, queryFingerprint)
+      }
+
+      const rows = await listRfiQuestionSuggestionRows(db, {
+        actorHsaId,
+        after: cursor?.boundary,
+        areaId: input.areaId,
+        limit: limit + 1,
+        specificationId: input.specificationId,
+      })
+      const suggestions = suggestionsWithinByteBudget(rows, limit)
+      const hasMore = rows.length > suggestions.length
+      const boundary = suggestions.at(-1)
+
+      return {
+        pagination: {
+          count: suggestions.length,
+          hasMore,
+          limit,
+          nextCursor:
+            hasMore && boundary
+              ? encodeRfiQuestionSuggestionCursor(
+                  { createdAt: boundary.createdAt, id: boundary.id },
+                  queryFingerprint,
+                )
+              : null,
+        },
+        suggestions,
+      }
     },
   }
 }

--- a/lib/typeorm/entities/rfi-question-suggestion.ts
+++ b/lib/typeorm/entities/rfi-question-suggestion.ts
@@ -143,14 +143,21 @@ export const rfiQuestionSuggestionEntity =
       },
     ],
     indices: [
-      { columns: ['areaId'], name: 'idx_rfi_question_suggestions_area_id' },
+      {
+        columns: ['areaId', 'createdAt', 'id'],
+        name: 'idx_rfi_question_suggestions_area_id_created_at_id',
+      },
       {
         columns: ['rfiQuestionId'],
         name: 'idx_rfi_question_suggestions_rfi_question_id',
       },
       {
-        columns: ['specificationId'],
-        name: 'idx_rfi_question_suggestions_specification_id',
+        columns: ['specificationId', 'createdAt', 'id'],
+        name: 'idx_rfi_question_suggestions_specification_id_created_at_id',
+      },
+      {
+        columns: ['createdAt', 'id'],
+        name: 'idx_rfi_question_suggestions_created_at_id',
       },
       {
         columns: ['createdByHsaId'],

--- a/scripts/check-stewardship-bundle.mjs
+++ b/scripts/check-stewardship-bundle.mjs
@@ -47,8 +47,8 @@ export const STEWARDSHIP_WORKSPACE_GZIP_MAX_BYTES = {
   packages: 256_666,
   // 2026-07-20 isolated-route baseline: 268,160 gzip bytes plus 5% headroom.
   questions: 281_568,
-  // 2026-07-20 isolated-route baseline: 11,780 gzip bytes plus 5% headroom.
-  rfi: 12_369,
+  // 2026-08-18 isolated-route baseline: 12,571 gzip bytes plus 5% headroom.
+  rfi: 13_200,
   // 2026-07-20 isolated-route baseline: 237,747 gzip bytes plus 5% headroom.
   norms: 249_635,
 }

--- a/tests/unit/mcp-authz.test.ts
+++ b/tests/unit/mcp-authz.test.ts
@@ -179,6 +179,7 @@ function createService() {
     listDeviations: vi.fn(),
     listGraduationTargetAreas,
     listRfiQuestions: vi.fn(async () => []),
+    listRfiQuestionSuggestions: vi.fn(),
     listSpecifications,
     listSuggestions,
     manageDeviation: vi.fn(),

--- a/tests/unit/mcp-property.test.ts
+++ b/tests/unit/mcp-property.test.ts
@@ -275,6 +275,7 @@ function createService() {
     queryCatalog: vi.fn(async () => ({
       result: [],
     })),
+    listRfiQuestionSuggestions: vi.fn(),
     mutateRequirementApplications: vi.fn(async () => ({
       operation: 'update' as const,
       updatedCount: 0,

--- a/tests/unit/mcp-security.test.ts
+++ b/tests/unit/mcp-security.test.ts
@@ -189,6 +189,7 @@ function createService() {
     queryCatalog: vi.fn(async () => ({
       result: [],
     })),
+    listRfiQuestionSuggestions: vi.fn(),
     mutateRequirementApplications: vi.fn(async () => ({
       operation: 'update' as const,
       updatedCount: 0,

--- a/tests/unit/rfi-question-suggestion-page-indexes-migration.test.ts
+++ b/tests/unit/rfi-question-suggestion-page-indexes-migration.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+import RfiQuestionSuggestionPageIndexes from '@/typeorm/migrations/0059_rfi_question_suggestion_page_indexes.mjs'
+
+describe('RFI question suggestion page indexes migration', () => {
+  it('indexes the stable page order and its common filters', async () => {
+    const query = vi.fn(async (_sql: string) => undefined)
+
+    await new RfiQuestionSuggestionPageIndexes().up({ query })
+
+    const sql = query.mock.calls.map(([statement]) => statement).join('\n')
+    expect(sql).toContain('[idx_rfi_question_suggestions_created_at_id]')
+    expect(sql).toContain('([created_at], [id])')
+    expect(sql).toContain(
+      '[idx_rfi_question_suggestions_area_id_created_at_id]',
+    )
+    expect(sql).toContain('([area_id], [created_at], [id])')
+    expect(sql).toContain(
+      '[idx_rfi_question_suggestions_specification_id_created_at_id]',
+    )
+    expect(sql).toContain('([specification_id], [created_at], [id])')
+  })
+
+  it('restores the former area and specification indexes on rollback', async () => {
+    const query = vi.fn(async (_sql: string) => undefined)
+
+    await new RfiQuestionSuggestionPageIndexes().down({ query })
+
+    const sql = query.mock.calls.map(([statement]) => statement).join('\n')
+    expect(sql).toContain('[idx_rfi_question_suggestions_area_id]')
+    expect(sql).toContain('[idx_rfi_question_suggestions_specification_id]')
+  })
+})

--- a/tests/unit/rfi-question-suggestion-routes.test.ts
+++ b/tests/unit/rfi-question-suggestion-routes.test.ts
@@ -21,13 +21,12 @@ const mocks = vi.hoisted(() => {
 
   return {
     assertAuthorized,
-    authorize: vi.fn(),
     context,
     createRfiQuestionSuggestionWithAudit: vi.fn(),
     db,
     deleteRfiQuestionSuggestionWithAudit: vi.fn(),
     getRequestSqlServerDataSource: vi.fn(async () => db),
-    listRfiQuestionSuggestions: vi.fn(),
+    listRfiQuestionSuggestionsPage: vi.fn(),
     requestRfiQuestionSuggestionReviewWithAudit: vi.fn(),
     resolveRfiQuestionSuggestionWithAudit: vi.fn(),
   }
@@ -50,7 +49,6 @@ vi.mock('@/lib/requirements/auth', async importOriginal => {
 })
 
 vi.mock('@/lib/dal/rfi-questions', () => ({
-  listRfiQuestionSuggestions: mocks.listRfiQuestionSuggestions,
   RFI_SUGGESTION_DISMISSED: 2,
   RFI_SUGGESTION_RESOLVED: 1,
 }))
@@ -71,11 +69,10 @@ vi.mock('@/lib/requirements/server', () => ({
     authorization: {},
     context: mocks.context,
     db: mocks.db,
+    service: {
+      listRfiQuestionSuggestions: mocks.listRfiQuestionSuggestionsPage,
+    },
   })),
-}))
-
-vi.mock('@/lib/requirements/service-shared', () => ({
-  authorize: mocks.authorize,
 }))
 
 import { POST as requestRfiQuestionSuggestionReviewRoute } from '@/app/api/rfi-question-suggestions/[id]/request-review/route'
@@ -103,12 +100,19 @@ describe('RFI question suggestion routes', () => {
     vi.clearAllMocks()
     mocks.createRfiQuestionSuggestionWithAudit.mockResolvedValue(suggestion)
     mocks.deleteRfiQuestionSuggestionWithAudit.mockResolvedValue(undefined)
-    mocks.listRfiQuestionSuggestions.mockResolvedValue([])
+    mocks.listRfiQuestionSuggestionsPage.mockResolvedValue({
+      pagination: {
+        count: 0,
+        hasMore: false,
+        limit: 100,
+        nextCursor: null,
+      },
+      suggestions: [],
+    })
     mocks.requestRfiQuestionSuggestionReviewWithAudit.mockResolvedValue(
       suggestion,
     )
     mocks.resolveRfiQuestionSuggestionWithAudit.mockResolvedValue(suggestion)
-    mocks.authorize.mockResolvedValue(undefined)
     mocks.context.actor.isAuthenticated = true
     mocks.context.actor.roles = ['RequirementsEditor']
   })
@@ -269,7 +273,15 @@ describe('RFI question suggestion routes', () => {
 
   it('lists RFI question suggestions for one requirement area', async () => {
     const suggestions = [{ areaId: 5, content: 'Clarify retention.', id: 1 }]
-    mocks.listRfiQuestionSuggestions.mockResolvedValue(suggestions)
+    mocks.listRfiQuestionSuggestionsPage.mockResolvedValue({
+      pagination: {
+        count: 1,
+        hasMore: false,
+        limit: 100,
+        nextCursor: null,
+      },
+      suggestions,
+    })
 
     const response = await listRfiQuestionSuggestionsRoute(
       new NextRequest(
@@ -278,46 +290,65 @@ describe('RFI question suggestion routes', () => {
     )
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({ suggestions })
-    expect(mocks.authorize).toHaveBeenCalledWith(
-      {},
-      {
-        areaId: 5,
-        kind: 'manage_rfi_question_suggestion',
-        operation: 'list',
+    await expect(response.json()).resolves.toEqual({
+      pagination: {
+        count: 1,
+        hasMore: false,
+        limit: 100,
+        nextCursor: null,
       },
-      mocks.context,
-    )
-    expect(mocks.listRfiQuestionSuggestions).toHaveBeenCalledWith(mocks.db, {
-      areaId: 5,
-      specificationId: 9,
+      suggestions,
     })
+    expect(mocks.listRfiQuestionSuggestionsPage).toHaveBeenCalledWith(
+      mocks.context,
+      { areaId: 5, specificationId: 9 },
+    )
+  })
+
+  it('accepts the maximum page size and rejects larger pages before service work', async () => {
+    const maximumResponse = await listRfiQuestionSuggestionsRoute(
+      new NextRequest(
+        'http://localhost/api/rfi-question-suggestions?limit=200',
+      ),
+    )
+    const overMaximumResponse = await listRfiQuestionSuggestionsRoute(
+      new NextRequest(
+        'http://localhost/api/rfi-question-suggestions?limit=201',
+      ),
+    )
+
+    expect(maximumResponse.status).toBe(200)
+    expect(overMaximumResponse.status).toBe(400)
+    expect(mocks.listRfiQuestionSuggestionsPage).toHaveBeenCalledTimes(1)
+    expect(mocks.listRfiQuestionSuggestionsPage).toHaveBeenCalledWith(
+      mocks.context,
+      { limit: 200 },
+    )
   })
 
   it('lists all authorized RFI question suggestions when no area is provided', async () => {
-    const suggestions = [
-      { areaId: 1, content: 'Allowed suggestion.', id: 1 },
-      { areaId: 2, content: 'Hidden suggestion.', id: 2 },
-    ]
-    mocks.listRfiQuestionSuggestions.mockResolvedValue(suggestions)
-    mocks.authorize.mockImplementation(async (_authorization, action) => {
-      if ((action as { areaId?: number }).areaId !== 2) return
-      const error = Object.assign(new Error('Forbidden'), { status: 403 })
-      throw error
-    })
+    const suggestions = [{ areaId: 1, content: 'Allowed suggestion.', id: 1 }]
+    const page = {
+      pagination: {
+        count: 1,
+        hasMore: false,
+        limit: 100,
+        nextCursor: null,
+      },
+      suggestions,
+    }
+    mocks.listRfiQuestionSuggestionsPage.mockResolvedValue(page)
 
     const response = await listRfiQuestionSuggestionsRoute(
       new NextRequest('http://localhost/api/rfi-question-suggestions'),
     )
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({
-      suggestions: [{ areaId: 1, content: 'Allowed suggestion.', id: 1 }],
-    })
-    expect(mocks.listRfiQuestionSuggestions).toHaveBeenCalledWith(mocks.db, {
-      specificationId: undefined,
-    })
-    expect(mocks.authorize).toHaveBeenCalledTimes(2)
+    await expect(response.json()).resolves.toEqual(page)
+    expect(mocks.listRfiQuestionSuggestionsPage).toHaveBeenCalledWith(
+      mocks.context,
+      {},
+    )
   })
 
   it('lets admins list all RFI question suggestions without per-area checks', async () => {
@@ -326,15 +357,27 @@ describe('RFI question suggestion routes', () => {
       { areaId: 1, content: 'Allowed suggestion.', id: 1 },
       { areaId: 2, content: 'Admin suggestion.', id: 2 },
     ]
-    mocks.listRfiQuestionSuggestions.mockResolvedValue(suggestions)
+    const page = {
+      pagination: {
+        count: 2,
+        hasMore: false,
+        limit: 100,
+        nextCursor: null,
+      },
+      suggestions,
+    }
+    mocks.listRfiQuestionSuggestionsPage.mockResolvedValue(page)
 
     const response = await listRfiQuestionSuggestionsRoute(
       new NextRequest('http://localhost/api/rfi-question-suggestions'),
     )
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({ suggestions })
-    expect(mocks.authorize).not.toHaveBeenCalled()
+    await expect(response.json()).resolves.toEqual(page)
+    expect(mocks.listRfiQuestionSuggestionsPage).toHaveBeenCalledWith(
+      mocks.context,
+      {},
+    )
   })
 
   it('rejects invalid suggestion filters before reading persistence', async () => {
@@ -343,37 +386,37 @@ describe('RFI question suggestion routes', () => {
     )
 
     expect(response.status).toBe(400)
-    expect(mocks.listRfiQuestionSuggestions).not.toHaveBeenCalled()
+    expect(mocks.listRfiQuestionSuggestionsPage).not.toHaveBeenCalled()
   })
 
   it('requires authentication before listing suggestions across areas', async () => {
     mocks.context.actor.isAuthenticated = false
+    mocks.listRfiQuestionSuggestionsPage.mockRejectedValueOnce(
+      Object.assign(new Error('Authentication required'), { status: 401 }),
+    )
 
     const response = await listRfiQuestionSuggestionsRoute(
       new NextRequest('http://localhost/api/rfi-question-suggestions'),
     )
 
     expect(response.status).toBe(401)
-    expect(mocks.listRfiQuestionSuggestions).not.toHaveBeenCalled()
   })
 
   it('returns an area authorization rejection without listing suggestions', async () => {
-    mocks.authorize.mockRejectedValueOnce(forbiddenError('No area access'))
+    mocks.listRfiQuestionSuggestionsPage.mockRejectedValueOnce(
+      forbiddenError('No area access'),
+    )
 
     const response = await listRfiQuestionSuggestionsRoute(
       new NextRequest('http://localhost/api/rfi-question-suggestions?areaId=5'),
     )
 
     expect(response.status).toBe(403)
-    expect(mocks.listRfiQuestionSuggestions).not.toHaveBeenCalled()
   })
 
-  it('does not suppress non-authorization failures while filtering areas', async () => {
-    mocks.listRfiQuestionSuggestions.mockResolvedValueOnce([
-      { areaId: 5, content: 'Clarify retention.', id: 1 },
-    ])
-    mocks.authorize.mockRejectedValueOnce(
-      new Error('authorization unavailable'),
+  it('does not suppress failures while resolving authorized areas', async () => {
+    mocks.listRfiQuestionSuggestionsPage.mockRejectedValueOnce(
+      new Error('area lookup unavailable'),
     )
 
     const response = await listRfiQuestionSuggestionsRoute(
@@ -381,32 +424,6 @@ describe('RFI question suggestion routes', () => {
     )
 
     expect(response.status).toBe(500)
-  })
-
-  it('checks each allowed or denied area only once while filtering suggestions', async () => {
-    mocks.listRfiQuestionSuggestions.mockResolvedValueOnce([
-      { areaId: 5, content: 'Allowed one.', id: 1 },
-      { areaId: 5, content: 'Allowed two.', id: 2 },
-      { areaId: 6, content: 'Denied one.', id: 3 },
-      { areaId: 6, content: 'Denied two.', id: 4 },
-    ])
-    mocks.authorize.mockImplementation(async (_authorization, action) => {
-      if ((action as { areaId?: number }).areaId === 5) return
-      throw forbiddenError('Forbidden')
-    })
-
-    const response = await listRfiQuestionSuggestionsRoute(
-      new NextRequest('http://localhost/api/rfi-question-suggestions'),
-    )
-
-    expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({
-      suggestions: [
-        { areaId: 5, content: 'Allowed one.', id: 1 },
-        { areaId: 5, content: 'Allowed two.', id: 2 },
-      ],
-    })
-    expect(mocks.authorize).toHaveBeenCalledTimes(2)
   })
 
   it('normalizes omitted suggestion associations to null', async () => {

--- a/tests/unit/rfi-questions-dal.test.ts
+++ b/tests/unit/rfi-questions-dal.test.ts
@@ -783,15 +783,59 @@ describe('RFI questions DAL', () => {
 
     expect(query).toHaveBeenCalledWith(
       expect.stringContaining(
-        'WHERE suggestion.area_id = @0 AND suggestion.specification_id = @1',
+        'WHERE suggestion.area_id = @1 AND suggestion.specification_id = @2',
       ),
-      [2, 4],
+      [201, 2, 4],
     )
     expect(result).toHaveLength(1)
     expect(result[0]).toMatchObject({
       content: 'Ny fråga om loggning',
       specificationId: 4,
     })
+  })
+
+  it('bounds suggestion rows and scopes them to the actor in SQL', async () => {
+    const query = createQuery([[]])
+
+    await listRfiQuestionSuggestions(
+      { query } as unknown as Parameters<typeof listRfiQuestionSuggestions>[0],
+      {
+        actorHsaId: 'SE5560000001-author',
+        after: { createdAt: '2026-08-18T10:00:00.000Z', id: 77 },
+        limit: 101,
+        specificationId: 9,
+      },
+    )
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT TOP (@0)'),
+      [101, 'SE5560000001-author', '2026-08-18T10:00:00.000Z', 77, 9],
+    )
+    const sql = String(query.mock.calls[0]?.[0])
+    expect(sql).toContain('area.owner_hsa_id = @1')
+    expect(sql).toContain('co_author.hsa_id = @1')
+    expect(sql).toContain('suggestion.created_at < @2')
+    expect(sql).toContain('suggestion.id < @3')
+    expect(sql).toContain('suggestion.specification_id = @4')
+    expect(sql).toContain('LEFT(area.name, 10000)')
+    expect(sql).toContain('LEFT(suggestion.content, 10000)')
+    expect(sql).toContain(
+      'ORDER BY suggestion.created_at DESC, suggestion.id DESC',
+    )
+  })
+
+  it('rejects oversized suggestion reads before querying', async () => {
+    const query = createQuery([[]])
+
+    await expect(
+      listRfiQuestionSuggestions(
+        { query } as unknown as Parameters<
+          typeof listRfiQuestionSuggestions
+        >[0],
+        { limit: 202 },
+      ),
+    ).rejects.toMatchObject({ code: 'validation', status: 400 })
+    expect(query).not.toHaveBeenCalled()
   })
 
   it('deletes only RFI question suggestions that have not entered review or resolution', async () => {
@@ -1519,7 +1563,7 @@ describe('RFI questions DAL', () => {
 
     const result = await listRfiQuestionSuggestions({ query })
 
-    expect(query.mock.calls[0]?.[1]).toEqual([])
+    expect(query.mock.calls[0]?.[1]).toEqual([201])
     expect(result[0]).toMatchObject({
       resolvedAt: '2026-06-21T09:00:00.000Z',
       reviewRequestedAt: '2026-06-20T10:00:00.000Z',

--- a/tests/unit/rfi-ui-client.test.tsx
+++ b/tests/unit/rfi-ui-client.test.tsx
@@ -763,9 +763,7 @@ describe('RFI client UI states', () => {
         if (href === '/api/requirements-specifications/1/rfi-list') {
           return Promise.resolve(okJson({ list: rfiList }))
         }
-        if (
-          href === '/api/rfi-question-suggestions?areaId=1&specificationId=1'
-        ) {
+        if (href === '/api/rfi-question-suggestions?specificationId=1') {
           return Promise.resolve(okJson({ suggestions: initialSuggestions }))
         }
         if (
@@ -919,9 +917,7 @@ describe('RFI client UI states', () => {
         if (href === '/api/requirements-specifications/1/rfi-list') {
           return Promise.resolve(okJson({ list: rfiList }))
         }
-        if (
-          href === '/api/rfi-question-suggestions?areaId=1&specificationId=1'
-        ) {
+        if (href === '/api/rfi-question-suggestions?specificationId=1') {
           suggestionLoads += 1
           return Promise.resolve(
             okJson({
@@ -1050,10 +1046,7 @@ describe('RFI client UI states', () => {
         if (href === '/api/requirements-specifications/1/rfi-list') {
           return Promise.resolve(okJson({ list: initialList }))
         }
-        if (
-          href === '/api/rfi-question-suggestions?areaId=1&specificationId=1' ||
-          href === '/api/rfi-question-suggestions?areaId=2&specificationId=1'
-        ) {
+        if (href === '/api/rfi-question-suggestions?specificationId=1') {
           return Promise.resolve(okJson({ suggestions: [] }))
         }
         if (
@@ -1078,6 +1071,12 @@ describe('RFI client UI states', () => {
     const securitySection = await screen.findByRole('region', {
       name: 'Security',
     })
+    expect(
+      fetchMock.mock.calls.filter(
+        ([url]) =>
+          String(url) === '/api/rfi-question-suggestions?specificationId=1',
+      ),
+    ).toHaveLength(1)
     expect(
       within(securitySection).getByText('specificationRfiList.partial'),
     ).toBeInTheDocument()
@@ -1221,9 +1220,7 @@ describe('RFI client UI states', () => {
         if (href === '/api/requirements-specifications/1/rfi-list') {
           return Promise.resolve(okJson({ list: lockedList }))
         }
-        if (
-          href === '/api/rfi-question-suggestions?areaId=1&specificationId=1'
-        ) {
+        if (href === '/api/rfi-question-suggestions?specificationId=1') {
           return Promise.resolve(okJson({ suggestions: [] }))
         }
         if (
@@ -1315,9 +1312,7 @@ describe('RFI client UI states', () => {
         if (href === '/api/requirements-specifications/1/rfi-list') {
           return Promise.resolve(okJson({ list: unlockedList }))
         }
-        if (
-          href === '/api/rfi-question-suggestions?areaId=1&specificationId=1'
-        ) {
+        if (href === '/api/rfi-question-suggestions?specificationId=1') {
           return Promise.resolve(okJson({ suggestions: [] }))
         }
         if (
@@ -1874,9 +1869,7 @@ describe('RFI client UI states', () => {
         if (href === '/api/requirements-specifications/1/rfi-list') {
           return Promise.resolve(okJson({ list }))
         }
-        if (
-          href === '/api/rfi-question-suggestions?areaId=1&specificationId=1'
-        ) {
+        if (href === '/api/rfi-question-suggestions?specificationId=1') {
           return Promise.resolve(okJson({}))
         }
         if (init?.method === 'POST' || init?.method === 'PATCH') {

--- a/tests/unit/service-rfi-questions.test.ts
+++ b/tests/unit/service-rfi-questions.test.ts
@@ -5,6 +5,7 @@ import { forbiddenError } from '@/lib/requirements/errors'
 const mocks = vi.hoisted(() => ({
   listAreaIdsActorCanAuthor: vi.fn(),
   listRfiQuestions: vi.fn(),
+  listRfiQuestionSuggestions: vi.fn(),
   recordAuthorizationDenied: vi.fn(),
 }))
 
@@ -14,6 +15,7 @@ vi.mock('@/lib/dal/requirement-areas', () => ({
 
 vi.mock('@/lib/dal/rfi-questions', () => ({
   listRfiQuestions: mocks.listRfiQuestions,
+  listRfiQuestionSuggestions: mocks.listRfiQuestionSuggestions,
 }))
 
 vi.mock('@/lib/requirements/security-audit', async importOriginal => {
@@ -25,10 +27,18 @@ vi.mock('@/lib/requirements/security-audit', async importOriginal => {
   }
 })
 
-import { createRfiQuestionQueryService } from '@/lib/requirements/service-rfi-questions'
+import {
+  createRfiQuestionQueryService,
+  MAX_RFI_QUESTION_SUGGESTION_PAGE_BYTES,
+} from '@/lib/requirements/service-rfi-questions'
 
 const db = { query: vi.fn() }
 const question = { areaId: 7, id: 12, questionCode: 'INF-RFI001' }
+const suggestion = {
+  areaId: 7,
+  createdAt: '2026-08-18T10:00:00.000Z',
+  id: 12,
+}
 const context: RequestContext = {
   actor: {
     displayName: 'RFI Author',
@@ -52,10 +62,13 @@ describe('RFI question query service', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    context.actor.hsaId = 'SE5560000001-rfi-author'
+    context.actor.isAuthenticated = true
     context.actor.roles = ['RequirementsEditor']
     assertAuthorized.mockResolvedValue(undefined)
     mocks.listAreaIdsActorCanAuthor.mockResolvedValue([7])
     mocks.listRfiQuestions.mockResolvedValue([question])
+    mocks.listRfiQuestionSuggestions.mockResolvedValue([suggestion])
     mocks.recordAuthorizationDenied.mockResolvedValue(undefined)
   })
 
@@ -126,6 +139,177 @@ describe('RFI question query service', () => {
     expect(mocks.listAreaIdsActorCanAuthor).not.toHaveBeenCalled()
     expect(mocks.listRfiQuestions).toHaveBeenCalledWith(db, {
       includeArchived: true,
+    })
+  })
+
+  it('bounds and scopes suggestion pages before reading protected rows', async () => {
+    const suggestions = Array.from({ length: 201 }, (_, index) => ({
+      ...suggestion,
+      createdAt: new Date(Date.UTC(2026, 7, 18, 10, 0, -index)).toISOString(),
+      id: 300 - index,
+    }))
+    mocks.listRfiQuestionSuggestions.mockResolvedValueOnce(suggestions)
+
+    const result = await service.listRfiQuestionSuggestions(context, {
+      limit: 200,
+      specificationId: 9,
+    })
+
+    expect(result.suggestions).toHaveLength(200)
+    expect(result.pagination).toMatchObject({
+      count: 200,
+      hasMore: true,
+      limit: 200,
+    })
+    expect(result.pagination.nextCursor).toEqual(expect.any(String))
+    expect(mocks.listRfiQuestionSuggestions).toHaveBeenCalledWith(db, {
+      actorHsaId: context.actor.hsaId,
+      after: undefined,
+      limit: 201,
+      specificationId: 9,
+    })
+  })
+
+  it('authorizes an explicit suggestion area before the bounded query', async () => {
+    await service.listRfiQuestionSuggestions(context, {
+      areaId: 7,
+      limit: 20,
+    })
+
+    expect(assertAuthorized).toHaveBeenCalledWith(
+      {
+        areaId: 7,
+        kind: 'manage_rfi_question_suggestion',
+        operation: 'list',
+      },
+      context,
+    )
+    expect(mocks.listRfiQuestionSuggestions).toHaveBeenCalledWith(db, {
+      after: undefined,
+      areaId: 7,
+      limit: 21,
+      specificationId: undefined,
+    })
+  })
+
+  it('ends a page before its encoded output exceeds the byte budget', async () => {
+    const longText = 'å'.repeat(10_000)
+    const suggestions = Array.from({ length: 20 }, (_, index) => ({
+      ...suggestion,
+      areaName: longText,
+      content: longText,
+      createdAt: new Date(Date.UTC(2026, 7, 18, 10, 0, -index)).toISOString(),
+      createdByDisplayName: longText,
+      createdByHsaId: null,
+      id: 300 - index,
+      isReviewRequested: true,
+      questionCode: null,
+      resolution: 1,
+      resolutionMotivation: longText,
+      resolvedAt: null,
+      resolvedByDisplayName: longText,
+      resolvedByHsaId: null,
+      reviewRequestedAt: null,
+      rfiQuestionId: null,
+      sourceSpecificationCode: null,
+      sourceSpecificationName: longText,
+      specificationId: 9,
+      updatedAt: null,
+    }))
+    mocks.listRfiQuestionSuggestions.mockResolvedValueOnce(suggestions)
+
+    const result = await service.listRfiQuestionSuggestions(context, {
+      limit: 20,
+      specificationId: 9,
+    })
+
+    expect(result.suggestions.length).toBeGreaterThan(0)
+    expect(result.suggestions.length).toBeLessThan(20)
+    expect(result.pagination.hasMore).toBe(true)
+    expect(result.pagination.nextCursor).toEqual(expect.any(String))
+    expect(
+      new TextEncoder().encode(JSON.stringify(result)).byteLength,
+    ).toBeLessThan(MAX_RFI_QUESTION_SUGGESTION_PAGE_BYTES)
+  })
+
+  it('rejects unauthenticated suggestion pages before database work', async () => {
+    context.actor.isAuthenticated = false
+
+    await expect(
+      service.listRfiQuestionSuggestions(context, {}),
+    ).rejects.toMatchObject({ code: 'unauthorized', status: 401 })
+    expect(mocks.listRfiQuestionSuggestions).not.toHaveBeenCalled()
+    expect(assertAuthorized).not.toHaveBeenCalled()
+  })
+
+  it('rejects unauthorized explicit suggestion areas before database work', async () => {
+    assertAuthorized.mockRejectedValueOnce(forbiddenError('denied'))
+
+    await expect(
+      service.listRfiQuestionSuggestions(context, { areaId: 8 }),
+    ).rejects.toMatchObject({ code: 'forbidden', status: 403 })
+    expect(mocks.listRfiQuestionSuggestions).not.toHaveBeenCalled()
+  })
+
+  it('does not add an actor-area predicate for Admin suggestion pages', async () => {
+    context.actor.roles = ['Admin']
+
+    await service.listRfiQuestionSuggestions(context, {})
+
+    expect(mocks.listRfiQuestionSuggestions).toHaveBeenCalledWith(db, {
+      after: undefined,
+      limit: 101,
+      specificationId: undefined,
+    })
+  })
+
+  it('returns an empty bounded page when the actor has no HSA-id', async () => {
+    context.actor.hsaId = null
+
+    await expect(
+      service.listRfiQuestionSuggestions(context, {}),
+    ).resolves.toEqual({
+      pagination: {
+        count: 0,
+        hasMore: false,
+        limit: 100,
+        nextCursor: null,
+      },
+      suggestions: [],
+    })
+    expect(mocks.listRfiQuestionSuggestions).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed suggestion cursors before database work', async () => {
+    await expect(
+      service.listRfiQuestionSuggestions(context, { cursor: 'not-a-cursor' }),
+    ).rejects.toMatchObject({ code: 'invalid_cursor', status: 400 })
+
+    expect(mocks.listRfiQuestionSuggestions).not.toHaveBeenCalled()
+  })
+
+  it('continues suggestion pages from an opaque scoped cursor', async () => {
+    const firstRows = Array.from({ length: 101 }, (_, index) => ({
+      ...suggestion,
+      createdAt: new Date(Date.UTC(2026, 7, 18, 10, 0, -index)).toISOString(),
+      id: 300 - index,
+    }))
+    mocks.listRfiQuestionSuggestions.mockResolvedValueOnce(firstRows)
+    const firstPage = await service.listRfiQuestionSuggestions(context, {})
+
+    mocks.listRfiQuestionSuggestions.mockResolvedValueOnce([])
+    await service.listRfiQuestionSuggestions(context, {
+      cursor: firstPage.pagination.nextCursor ?? undefined,
+    })
+
+    expect(mocks.listRfiQuestionSuggestions).toHaveBeenLastCalledWith(db, {
+      actorHsaId: context.actor.hsaId,
+      after: {
+        createdAt: firstRows[99]?.createdAt,
+        id: firstRows[99]?.id,
+      },
+      limit: 101,
+      specificationId: undefined,
     })
   })
 })

--- a/typeorm/migrations/0059_rfi_question_suggestion_page_indexes.mjs
+++ b/typeorm/migrations/0059_rfi_question_suggestion_page_indexes.mjs
@@ -1,0 +1,39 @@
+const UP_STATEMENTS = [
+  `DROP INDEX [idx_rfi_question_suggestions_area_id]
+    ON [rfi_question_suggestions];`,
+  `DROP INDEX [idx_rfi_question_suggestions_specification_id]
+    ON [rfi_question_suggestions];`,
+  `CREATE INDEX [idx_rfi_question_suggestions_created_at_id]
+    ON [rfi_question_suggestions] ([created_at], [id]);`,
+  `CREATE INDEX [idx_rfi_question_suggestions_area_id_created_at_id]
+    ON [rfi_question_suggestions] ([area_id], [created_at], [id]);`,
+  `CREATE INDEX [idx_rfi_question_suggestions_specification_id_created_at_id]
+    ON [rfi_question_suggestions] ([specification_id], [created_at], [id]);`,
+]
+
+const DOWN_STATEMENTS = [
+  `DROP INDEX [idx_rfi_question_suggestions_specification_id_created_at_id]
+    ON [rfi_question_suggestions];`,
+  `DROP INDEX [idx_rfi_question_suggestions_area_id_created_at_id]
+    ON [rfi_question_suggestions];`,
+  `DROP INDEX [idx_rfi_question_suggestions_created_at_id]
+    ON [rfi_question_suggestions];`,
+  `CREATE INDEX [idx_rfi_question_suggestions_specification_id]
+    ON [rfi_question_suggestions] ([specification_id]);`,
+  `CREATE INDEX [idx_rfi_question_suggestions_area_id]
+    ON [rfi_question_suggestions] ([area_id]);`,
+]
+
+export class RfiQuestionSuggestionPageIndexes1720600000000 {
+  name = 'RfiQuestionSuggestionPageIndexes1720600000000'
+
+  async up(queryRunner) {
+    for (const statement of UP_STATEMENTS) await queryRunner.query(statement)
+  }
+
+  async down(queryRunner) {
+    for (const statement of DOWN_STATEMENTS) await queryRunner.query(statement)
+  }
+}
+
+export default RfiQuestionSuggestionPageIndexes1720600000000


### PR DESCRIPTION
## Description

Prevent unbounded RFI question suggestion reads by applying authorization in the requirements service before database work, using actor-scoped SQL, and returning bounded keyset-paginated pages. Responses are limited by row and byte budgets, clients follow opaque cursors with aggregate limits, and the specification view performs one scoped traversal instead of per-area fan-out.

Add supporting SQL Server indexes for the stable page order and common area and specification filters.

## Related Issues

Closes #849

## Reviewer Notes

- `npm run check`
- Final standards review: no actionable findings.
- Final issue-spec review: no actionable findings.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
<!-- No operator upgrade notes required. -->
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1076)
<!-- Reviewable:end -->
