### PR TITLE
fix: restrict usage-status linked specification details

### DIFF
--- a/app/api/catalog/specification-item-statuses/[id]/route.ts
+++ b/app/api/catalog/specification-item-statuses/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   updateSpecificationItemStatus,
 } from '@/lib/dal/specification-item-statuses'
 import { getRequestSqlServerDataSource } from '@/lib/db'
+import { withRestResponsePolicy } from '@/lib/http/response-policy'
 import {
   adminMutationPolicy,
   secureMutationRoute,
@@ -20,6 +21,9 @@ import {
   strictHexColorSchema,
 } from '@/lib/http/validation'
 import { nullableOptionalStatusIconNameSchema } from '@/lib/icons/status-icon-schema'
+import { createRequestContext } from '@/lib/requirements/auth'
+import { forbiddenError } from '@/lib/requirements/errors'
+import { toHttpErrorPayload } from '@/lib/requirements/http-errors'
 
 export const dynamic = 'force-dynamic'
 
@@ -37,21 +41,40 @@ const specificationItemStatusUpdateSchema = z
   })
   .strict()
 
-export async function GET(
-  _request: NextRequest,
+async function getHandler(
+  request: NextRequest,
   { params }: { params: Params },
 ) {
   const parsedParams = await parseRouteParams(params, idParamSchema)
   if (!parsedParams.ok) return parsedParams.response
-  const { id } = parsedParams.data
-  const db = await getRequestSqlServerDataSource()
-  const status = await getSpecificationItemStatusById(db, id)
-  if (!status) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  try {
+    const context = await createRequestContext(request, 'rest')
+    if (!context.actor.roles.includes('Admin')) {
+      throw forbiddenError(
+        'Admin role is required to inspect linked specification items',
+        {
+          actorRoles: context.actor.roles,
+          reason: 'required_role_missing',
+          requiredRoles: ['Admin'],
+        },
+      )
+    }
+
+    const { id } = parsedParams.data
+    const db = await getRequestSqlServerDataSource()
+    const status = await getSpecificationItemStatusById(db, id)
+    if (!status) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+    const linkedItems = await getLinkedSpecificationItems(db, id)
+    return NextResponse.json({ status, linkedItems })
+  } catch (error) {
+    const { body, status } = toHttpErrorPayload(error)
+    return NextResponse.json(body, { status })
   }
-  const linkedItems = await getLinkedSpecificationItems(db, id)
-  return NextResponse.json({ status, linkedItems })
 }
+
+export const GET = withRestResponsePolicy(getHandler)
 
 export const PUT = secureMutationRoute({
   bodySchema: specificationItemStatusUpdateSchema,

--- a/cspell.jsonc
+++ b/cspell.jsonc
@@ -63,6 +63,7 @@
     "kravtextens",
     "kravunderlagssidan",
     "kravunderlagsavsteg",
+    "kravunderlagsdetaljer",
     "sessionsskapanden",
     "mellanlagringsfil",
     "MesloLGS",

--- a/docs/governance/manuella-testfall.md
+++ b/docs/governance/manuella-testfall.md
@@ -379,6 +379,8 @@ arbete.
 1. Kontrollera att sidan inte visar redigerings- eller AI-kontroller.
 1. Försök öppna `/sv/admin`.
 1. Kör API-kontroll för att uppdatera `AUTHZ-SPEC-2026`.
+1. Anropa via direkt API de kravunderlagsdetaljer som är länkade till en
+   användningsstatus.
 1. Anropa kravunderlagets kravunderlagslokala krav, avstegslista och ett
    enskilt avsteg direkt med deras identifierare. Anropa även ett saknat
    avsteg och kombinera ett befintligt lokalt krav med ett annat befintligt
@@ -389,7 +391,8 @@ arbete.
 
 **Förväntat resultat:** Läsning är bara tillåten där produkten medger det.
 Privilegierade UI-kontroller saknas. Befintliga otillåtna underresurser och
-fel föräldrakombination ger 403, medan den saknade underresursen ger 404.
+användningsstatusens länkade kravunderlagsdetaljer ger 403 och `no-store`.
+Fel föräldrakombination ger 403, medan den saknade underresursen ger 404.
 Förslaget för det publicerade kravet och dess lista kan läsas, förslaget för
 det opublicerade kravet ger 403 och samtliga förslagssvar har `no-store`.
 

--- a/lib/http/route-security-policy.ts
+++ b/lib/http/route-security-policy.ts
@@ -412,8 +412,8 @@ export const REST_OPERATION_DECLARATIONS = [
     '/api/catalog/specification-item-statuses/[id]',
     'session',
     'none',
-    'authenticated',
-    'framework-default',
+    'sensitive',
+    'no-store',
     'focused',
   ],
   [

--- a/tests/integration/authorization/01-no-global-roles-no-assignments.spec.ts
+++ b/tests/integration/authorization/01-no-global-roles-no-assignments.spec.ts
@@ -345,6 +345,17 @@ test('AUTHZ-01/AUTH-08/AUTH-10/AUTH-11: authenticated users without roles or ass
       403,
       'no-role action log read',
     )
+    const usageStatusDetailResponse = await noRoles.get(
+      '/api/catalog/specification-item-statuses/1',
+    )
+    await expectStatus(
+      usageStatusDetailResponse,
+      403,
+      'no-role usage-status linked specification detail read',
+    )
+    expect(usageStatusDetailResponse.headers()['cache-control']).toBe(
+      'no-store',
+    )
     await expectStatus(
       await noRoles.post('/api/ai/generate-requirement-import', {
         data: aiGenerationBody({

--- a/tests/unit/taxonomy-routes.test.ts
+++ b/tests/unit/taxonomy-routes.test.ts
@@ -1463,6 +1463,7 @@ describe('specification-governance-object-types routes', () => {
 describe('specification-item-statuses catalog routes', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    authState.context.actor.roles = ['Admin']
   })
 
   it('GET returns catalog statuses with linked item counts', async () => {
@@ -1513,6 +1514,27 @@ describe('specification-item-statuses catalog routes', () => {
       linkedItems: [],
       status: { id: 5 },
     })
+  })
+
+  it('GET by id rejects non-Admins before reading protected specification metadata', async () => {
+    authState.context.actor.roles = []
+
+    const response = await getSpecItemStatus(
+      new NextRequest('http://l/api/catalog/specification-item-statuses/5', {
+        method: 'GET',
+      }),
+      makeParams('5'),
+    )
+
+    expect(response.status).toBe(403)
+    expect(response.headers.get('Cache-Control')).toBe('no-store')
+    await expect(response.json()).resolves.toMatchObject({
+      code: 'forbidden',
+      error: 'Forbidden',
+    })
+    expect(routeState.getRequestSqlServerDataSource).not.toHaveBeenCalled()
+    expect(mockGetSpecItemStatus).not.toHaveBeenCalled()
+    expect(mockGetLinkedSpecificationItems).not.toHaveBeenCalled()
   })
 
   it('GET by id rejects invalid identifiers before opening the database', async () => {


### PR DESCRIPTION
## Description

Restrict linked specification-item details for a usage status to Admin users before database access. Mark the response as sensitive and non-cacheable, and add unit, integration, and manual authorization coverage.

## Related Issues

Fixes #850

## Reviewer Notes

The authorization scope follows the domain model for usage-status administration. Verification completed with `npm run check` and the focused AUTHZ-01 Playwright scenario.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
After upgrade, only users with the Admin role can inspect which specification items are linked to a usage status through the direct API. Verify that affected integrations use an Admin identity. Non-Admin users now receive a 403 response.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1077)
<!-- Reviewable:end -->
