### PR TITLE
fix: bound specification requirement removals

### DIFF
--- a/docs/integrations/mcp-server-contributor-guide.md
+++ b/docs/integrations/mcp-server-contributor-guide.md
@@ -386,9 +386,11 @@ specification authorship before calling the transactional DAL copy operation.
 
 ### `requirements_remove_from_specification`
 
-Unlinks requirements from a specification. Accepts numeric `specificationId`.
-The requirements themselves are not deleted. The operation is idempotent —
-removing an ID that is not in the specification produces no error. Use the
+Unlinks from 1 through 200 unique requirements from a specification. Accepts
+numeric `specificationId`. The MCP schema and shared service boundary reject
+empty, duplicate, and oversized `requirementIds` collections before mutation
+work. The requirements themselves are not deleted. The operation is idempotent
+— removing an ID that is not in the specification produces no error. Use the
 specification copy path above, and copy only library requirement IDs from:
 
 ```text

--- a/docs/integrations/mcp-server-user-guide.md
+++ b/docs/integrations/mcp-server-user-guide.md
@@ -129,8 +129,9 @@ agents can use it reliably.
   requirement remains unchanged in the specification, and deviations stay with
   that source row.
 - `requirements_remove_from_specification`
-  Unlink one or more requirements from a specification. The requirements themselves
-  are not deleted. Use `specificationId` to identify the specification.
+  Unlink from 1 through 200 unique requirements from a specification. The
+  requirements themselves are not deleted. Use `specificationId` to identify
+  the specification.
 
 #### Improvement Suggestions
 

--- a/lib/mcp/server.ts
+++ b/lib/mcp/server.ts
@@ -2683,7 +2683,7 @@ export function createKravhanteringMcpServer(
         openWorldHint: false,
         readOnlyHint: false,
       },
-      description: `Unlink one or more requirements from a requirements specification. The requirements themselves are not deleted. Identify the specification with specificationId. ${specificationIdCopyPath} ${removeRequirementIdsCopyPath}`,
+      description: `Unlink up to ${ARRAY_INPUT_MAX_ITEMS} unique requirements from a requirements specification. The requirements themselves are not deleted. Identify the specification with specificationId. ${specificationIdCopyPath} ${removeRequirementIdsCopyPath}`,
       inputSchema: z
         .object({
           locale: ResponseLocaleSchema,
@@ -2694,11 +2694,10 @@ export function createKravhanteringMcpServer(
             .describe(
               `Numeric ID of the requirements specification. ${specificationIdCopyPath}`,
             ),
-          requirementIds: z
-            .array(z.number().int().positive())
+          requirementIds: uniquePositiveIntegerArraySchema()
             .min(1)
             .describe(
-              `Numeric requirement IDs to remove from the specification. ${removeRequirementIdsCopyPath}`,
+              `One to ${ARRAY_INPUT_MAX_ITEMS} unique numeric requirement IDs to remove from the specification. ${removeRequirementIdsCopyPath}`,
             ),
           responseFormat: z.enum(['json', 'markdown']).default('markdown'),
         })

--- a/lib/requirements/service-specifications.ts
+++ b/lib/requirements/service-specifications.ts
@@ -78,16 +78,14 @@ interface RequirementPublishedVersionLookup {
   requirementId: number
 }
 
-const addToSpecificationRequirementIdsSchema =
+const specificationRequirementIdsSchema =
   uniquePositiveIntegerArraySchema().min(1)
 const PUBLISHED_VERSION_LOOKUP_CONCURRENCY = 8
 
-function assertValidAddToSpecificationRequirementIds(
+function assertValidSpecificationRequirementIds(
   requirementIds: number[],
 ): void {
-  if (
-    addToSpecificationRequirementIdsSchema.safeParse(requirementIds).success
-  ) {
+  if (specificationRequirementIdsSchema.safeParse(requirementIds).success) {
     return
   }
 
@@ -588,7 +586,7 @@ export function createSpecificationWorkflow({
     async addToSpecification(context, input: AddToSpecificationInput) {
       const responseFormat = input.responseFormat ?? 'markdown'
       const locale = input.locale ?? 'en'
-      assertValidAddToSpecificationRequirementIds(input.requirementIds)
+      assertValidSpecificationRequirementIds(input.requirementIds)
 
       await authorize(
         authorization,
@@ -696,6 +694,7 @@ export function createSpecificationWorkflow({
     ) {
       const responseFormat = input.responseFormat ?? 'markdown'
       const locale = input.locale ?? 'en'
+      assertValidSpecificationRequirementIds(input.requirementIds)
 
       const specificationId = await resolveSpecificationIdOrThrow(input)
       const outcome = await requirementApplicationMutations.mutate(context, {

--- a/tests/unit/mcp-http.test.ts
+++ b/tests/unit/mcp-http.test.ts
@@ -1425,48 +1425,60 @@ describe('handleRequirementsMcpRequest', () => {
     await transport.close()
   })
 
-  it('bounds unique add-to-specification requirement IDs before mutation delegation', async () => {
-    const { client, transport } = await createClient()
-    const fakeService = serviceState.getService.mock.results[0]?.value
-    const maximumRequirementIds = Array.from(
-      { length: ARRAY_INPUT_MAX_ITEMS },
-      (_, index) => index + 1,
-    )
+  it.each([
+    {
+      serviceMethod: 'addToSpecification',
+      toolName: 'requirements_add_to_specification',
+    },
+    {
+      serviceMethod: 'removeFromSpecification',
+      toolName: 'requirements_remove_from_specification',
+    },
+  ] as const)(
+    'bounds unique requirement IDs before $toolName mutation delegation',
+    async ({ serviceMethod, toolName }) => {
+      const { client, transport } = await createClient()
+      const fakeService = serviceState.getService.mock.results[0]?.value
+      const maximumRequirementIds = Array.from(
+        { length: ARRAY_INPUT_MAX_ITEMS },
+        (_, index) => index + 1,
+      )
 
-    const maximumResult = await client.callTool({
-      arguments: {
-        requirementIds: maximumRequirementIds,
-        specificationId: 7,
-      },
-      name: 'requirements_add_to_specification',
-    })
-    const overMaximumResult = await client.callTool({
-      arguments: {
-        requirementIds: [...maximumRequirementIds, ARRAY_INPUT_MAX_ITEMS + 1],
-        specificationId: 7,
-      },
-      name: 'requirements_add_to_specification',
-    })
-    const duplicateResult = await client.callTool({
-      arguments: {
-        requirementIds: [1, 1],
-        specificationId: 7,
-      },
-      name: 'requirements_add_to_specification',
-    })
+      const maximumResult = await client.callTool({
+        arguments: {
+          requirementIds: maximumRequirementIds,
+          specificationId: 7,
+        },
+        name: toolName,
+      })
+      const overMaximumResult = await client.callTool({
+        arguments: {
+          requirementIds: [...maximumRequirementIds, ARRAY_INPUT_MAX_ITEMS + 1],
+          specificationId: 7,
+        },
+        name: toolName,
+      })
+      const duplicateResult = await client.callTool({
+        arguments: {
+          requirementIds: [1, 1],
+          specificationId: 7,
+        },
+        name: toolName,
+      })
 
-    expect(maximumResult.isError).not.toBe(true)
-    expect(overMaximumResult.isError).toBe(true)
-    expect(duplicateResult.isError).toBe(true)
-    expect(fakeService.addToSpecification).toHaveBeenCalledTimes(1)
-    expect(fakeService.addToSpecification).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ requirementIds: maximumRequirementIds }),
-    )
+      expect(maximumResult.isError).not.toBe(true)
+      expect(overMaximumResult.isError).toBe(true)
+      expect(duplicateResult.isError).toBe(true)
+      expect(fakeService[serviceMethod]).toHaveBeenCalledTimes(1)
+      expect(fakeService[serviceMethod]).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ requirementIds: maximumRequirementIds }),
+      )
 
-    await client.close()
-    await transport.close()
-  })
+      await client.close()
+      await transport.close()
+    },
+  )
 
   it('returns skipped unpublished requirement IDs from add-to-specification', async () => {
     const { client, transport } = await createClient()

--- a/tests/unit/requirements-service.test.ts
+++ b/tests/unit/requirements-service.test.ts
@@ -284,6 +284,15 @@ function makeContext() {
   }
 }
 
+const invalidSpecificationRequirementIdCases: [string, number[]][] = [
+  ['an empty collection', []],
+  ['duplicate IDs', [10, 10]],
+  [
+    'more than the shared item limit',
+    Array.from({ length: ARRAY_INPUT_MAX_ITEMS + 1 }, (_, index) => index + 1),
+  ],
+]
+
 describe('createRequirementsService', () => {
   const logger = {
     error: vi.fn(),
@@ -1746,17 +1755,7 @@ describe('createRequirementsService', () => {
     })
   })
 
-  it.each([
-    ['an empty collection', []],
-    ['duplicate IDs', [10, 10]],
-    [
-      'more than the shared item limit',
-      Array.from(
-        { length: ARRAY_INPUT_MAX_ITEMS + 1 },
-        (_, index) => index + 1,
-      ),
-    ],
-  ])(
+  it.each(invalidSpecificationRequirementIdCases)(
     'rejects %s before add-to-specification database work',
     async (_case, requirementIds) => {
       const service = createTestRequirementsService()
@@ -1826,6 +1825,23 @@ describe('createRequirementsService', () => {
       title: 'Requirements Removed from Specification',
     })
   })
+
+  it.each(invalidSpecificationRequirementIdCases)(
+    'rejects %s before remove-from-specification database work',
+    async (_case, requirementIds) => {
+      const service = createTestRequirementsService()
+
+      await expect(
+        service.removeFromSpecification(makeContext(), {
+          requirementIds,
+          specificationId: 7,
+        }),
+      ).rejects.toMatchObject({ code: 'validation' })
+
+      expect(mocks.auditTransaction).not.toHaveBeenCalled()
+      expect(mocks.unlinkRequirementsFromSpecification).not.toHaveBeenCalled()
+    },
+  )
 
   it('lists graduation target requirement areas for actors who can author target requirement areas without source specification access', async () => {
     mocks.canAuthorSpecification.mockResolvedValueOnce(false)

--- a/tests/unit/requirements-specifications-dal.test.ts
+++ b/tests/unit/requirements-specifications-dal.test.ts
@@ -47,6 +47,7 @@ import {
   updateSpecificationResponsible,
   updateSpecificationWithExecutor,
 } from '@/lib/dal/requirements-specifications'
+import { ARRAY_INPUT_MAX_ITEMS } from '@/lib/http/validation'
 import { DEFAULT_SPECIFICATION_ITEM_STATUS_ID } from '@/lib/specification-item-status-constants'
 
 function createSqlServerDb() {
@@ -2280,20 +2281,27 @@ describe('requirements-specifications DAL (SQL Server path)', () => {
     expect(query).not.toHaveBeenCalled()
   })
 
-  it('unlinks requirements from a specification on SQL Server', async () => {
+  it('unlinks the maximum bounded requirement collection with one SQL Server query', async () => {
     const { db, query } = createSqlServerDb()
-    query.mockResolvedValueOnce([{ id: 31 }, { id: 32 }])
+    const requirementIds = Array.from(
+      { length: ARRAY_INPUT_MAX_ITEMS },
+      (_, index) => index + 1,
+    )
+    query.mockResolvedValueOnce(requirementIds.map(id => ({ id })))
 
     const removedCount = await unlinkRequirementsFromSpecification(
       db,
       5,
-      [7, 8],
+      requirementIds,
     )
 
-    expect(removedCount).toBe(2)
+    expect(removedCount).toBe(ARRAY_INPUT_MAX_ITEMS)
+    expect(query).toHaveBeenCalledTimes(1)
     expect(query).toHaveBeenCalledWith(
-      expect.stringContaining('DELETE FROM requirements_specification_items'),
-      [5, 7, 8],
+      expect.stringMatching(
+        /DELETE FROM requirements_specification_items[\s\S]*WHERE requirements_specification_id = @0 AND requirement_id IN \(@1,[\s\S]*@200\)/u,
+      ),
+      [5, ...requirementIds],
     )
   })
 


### PR DESCRIPTION
## Description

- Bound `requirements_remove_from_specification` to 1–200 unique positive requirement IDs.
- Reuse the shared specification membership validation before database work.
- Document the MCP contract and cover the MCP, service, and SQL boundaries.

## Related Issues

Fixes #852

## Reviewer Notes

- `npm run check` passes, including 7,322 unit tests and both HSA support suites.
- Two-axis code review completed with no remaining Standards or Spec findings.
- No UI or manual test cases changed; this is an MCP contract and service-boundary fix.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [ ] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
Before upgrade, verify that MCP clients remove no more than 200 unique requirements in one request. Requests with duplicate requirement IDs or more than 200 IDs now fail validation. Split larger removals into batches of 200 or fewer.
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1089)
<!-- Reviewable:end -->
