### PR TITLE
fix: keep operator note headings inert

### DIFF
--- a/.github/workflows/operator-upgrade-notes.yml
+++ b/.github/workflows/operator-upgrade-notes.yml
@@ -119,24 +119,27 @@ jobs:
           fi
 
           title="docs: persist operator upgrade notes from #${PR_NUMBER}"
-          body_file="$(mktemp)"
-          {
-            echo "This automated PR persists merged Operator Upgrade Impact notes under \`## Unreleased\`."
-            echo
-            echo "- Latest source PR: #${PR_NUMBER}"
-            echo "- Workflow run: ${RUN_URL}"
-            echo
-            echo "A human reviewer must approve the generated notes before merge."
-            echo "Merge after the required checks pass."
-            echo
-            echo "## Operator Upgrade Impact"
-            echo
-            echo "- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->"
-            echo
-            echo "## SSDLC (Secure Software Development Life Cycle) Gate"
-            echo
-            echo "- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->"
-          } > "${body_file}"
+          render_pr_body() {
+            sed \
+              -e "s|__PR_NUMBER__|${PR_NUMBER}|g" \
+              -e "s|__RUN_URL__|${RUN_URL}|g" <<'PR_BODY'
+          This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.
+
+          - Latest source PR: #__PR_NUMBER__
+          - Workflow run: __RUN_URL__
+
+          A human reviewer must approve the generated notes before merge.
+          Merge after the required checks pass.
+
+          ## Operator Upgrade Impact
+
+          - [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->
+
+          ## SSDLC (Secure Software Development Life Cycle) Gate
+
+          - [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->
+          PR_BODY
+          }
 
           pr_number="$(
             gh pr list --repo "${GITHUB_REPOSITORY}" \
@@ -147,11 +150,12 @@ jobs:
               --jq '.[0].number // empty'
           )"
           if [ -z "${pr_number}" ]; then
-            gh pr create --repo "${GITHUB_REPOSITORY}" \
-              --base main \
-              --head "${GITHUB_REPOSITORY%%/*}:${NOTES_BRANCH}" \
-              --title "${title}" \
-              --body-file "${body_file}"
+            render_pr_body | \
+              gh pr create --repo "${GITHUB_REPOSITORY}" \
+                --base main \
+                --head "${GITHUB_REPOSITORY%%/*}:${NOTES_BRANCH}" \
+                --title "${title}" \
+                --body-file -
             pr_number="$(
               gh pr list --repo "${GITHUB_REPOSITORY}" \
                 --base main \
@@ -161,11 +165,27 @@ jobs:
                 --jq '.[0].number // empty'
             )"
           else
-            gh pr edit "${pr_number}" --title "${title}" --body-file "${body_file}"
+            render_pr_body | \
+              gh pr edit "${pr_number}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --title "${title}" \
+                --body-file -
           fi
 
           if [ -z "${pr_number}" ]; then
             echo "::error::Unable to find or create the operator upgrade notes pull request."
+            exit 1
+          fi
+
+          expected_body="$(render_pr_body)"
+          stored_body="$(
+            gh pr view "${pr_number}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --json body \
+              --jq '.body'
+          )"
+          if [ "${stored_body}" != "${expected_body}" ]; then
+            echo "::error::Operator upgrade notes PR body verification failed."
             exit 1
           fi
 

--- a/.github/workflows/operator-upgrade-notes.yml
+++ b/.github/workflows/operator-upgrade-notes.yml
@@ -126,6 +126,7 @@ jobs:
             echo "- Latest source PR: #${PR_NUMBER}"
             echo "- Workflow run: ${RUN_URL}"
             echo
+            echo "A human reviewer must approve the generated notes before merge."
             echo "Merge after the required checks pass."
             echo
             echo "## Operator Upgrade Impact"
@@ -168,8 +169,4 @@ jobs:
             exit 1
           fi
 
-          if gh pr merge "${pr_number}" --squash --auto --delete-branch; then
-            echo "Enabled auto-merge for operator upgrade notes PR #${pr_number}."
-          else
-            echo "::warning::Opened operator upgrade notes PR #${pr_number}, but auto-merge could not be enabled. Merge it after required checks pass."
-          fi
+          echo "Operator upgrade notes PR #${pr_number} requires human review and merge."

--- a/docs/development/trusted-container-publishing.md
+++ b/docs/development/trusted-container-publishing.md
@@ -248,15 +248,17 @@ Operator upgrade notes are maintained in
 `docs/operations/operator-upgrade-notes.md`. A separate merged-pull-request
 workflow reads completed Operator Upgrade Impact evidence from the trusted pull
 request body and appends it under `## Unreleased` with hidden source markers.
+Level-two headings in the contributed notes are escaped before persistence so
+they remain visible text instead of becoming release-section boundaries.
 The Operator Upgrade gate and merged-pull-request workflow both skip pull
 requests authored by `dependabot[bot]` whose title starts with `build(deps):`;
 dependency-only updates therefore do not require or persist operator notes.
 Instead of pushing directly to protected `main`, the workflow opens or updates
-the `automation/operator-upgrade-notes` PR and enables auto-merge when GitHub
-allows it. Configure an `OPERATOR_UPGRADE_NOTES_TOKEN` secret from a
-fine-scoped PAT or GitHub App token for the `Viscalyxbot` machine user that can
-push branches and create pull requests so the normal PR checks run for that
-automation PR. The workflow commits those documentation changes as
+the `automation/operator-upgrade-notes` PR. A human reviewer must approve the
+generated notes before merge. Configure an `OPERATOR_UPGRADE_NOTES_TOKEN`
+secret from a fine-scoped PAT or GitHub App token for the `Viscalyxbot` machine
+user that can push branches and create pull requests so the normal PR checks
+run for that automation PR. The workflow commits those documentation changes as
 `Viscalyxbot <viscalyxbot@viscalyx.se>` before opening or updating the PR, and
 the PR title includes the latest source PR number. When the remote automation
 branch has no open pull request, the workflow treats it as stale and recreates
@@ -294,7 +296,7 @@ sequenceDiagram
     par Persist notes through PR
         Notes->>Notes: Append PR notes under Unreleased
         Notes->>AutomationPR: Open or update automation PR
-        AutomationPR->>AutomationPR: Merge after required checks
+        AutomationPR->>AutomationPR: Human review and merge after required checks
         AutomationPR-->>Main: Persist Unreleased notes
     and Prepare release
         Release->>Release: Compute release plan

--- a/scripts/release/__tests__/operator-upgrade-notes.test.mjs
+++ b/scripts/release/__tests__/operator-upgrade-notes.test.mjs
@@ -63,6 +63,7 @@ describe('operator upgrade notes lifecycle', () => {
   })
 
   it('keeps contributor release headings inert inside operator notes', () => {
+    const escapedHeading = '\\## v9.9.9 - 2099-12-31'
     const releaseHeadingPrBody = operatorNotesPrBody.replace(
       '### Topology changes',
       '## v9.9.9 - 2099-12-31',
@@ -78,13 +79,40 @@ describe('operator upgrade notes lifecycle', () => {
       filePath: operatorNotesPath,
       version: 'v1.0.0',
     })
+    const archivedSourceBlock = [
+      operatorUpgradeSourceStartMarker('pr-854'),
+      escapedHeading,
+      'Keep production HSA lookup pointed at the approved facade.',
+      operatorUpgradeSourceEndMarker('pr-854'),
+    ].join('\n')
 
-    expect(synced.content).toContain('\\## v9.9.9 - 2099-12-31')
+    expect(synced.content).not.toMatch(/^## v9\.9\.9 - 2099-12-31$/mu)
+    expect(synced.content).toContain(escapedHeading)
     expect(archived.content).toContain(
       `## v1.0.0 - 2026-08-19\n\n${operatorUpgradeSourceStartMarker('pr-854')}`,
     )
-    expect(archived.content).toContain('\\## v9.9.9 - 2099-12-31')
-    expect(archived.content).toContain(operatorUpgradeSourceEndMarker('pr-854'))
+    expect(archived.content).not.toMatch(/^## v9\.9\.9 - 2099-12-31$/mu)
+    expect(archived.content).toContain(escapedHeading)
+    expect(archived.content).toContain(archivedSourceBlock)
+  })
+
+  it.each([
+    ['bare', '##'],
+    ['space-only', '##   '],
+    ['tab-only', '##\t'],
+  ])('keeps %s level-two headings inert', (_label, heading) => {
+    const headingPrBody = operatorNotesPrBody.replace(
+      '### Topology changes',
+      heading,
+    )
+
+    const synced = addPullRequestNotesToContent(baseNotes, {
+      filePath: operatorNotesPath,
+      prBody: headingPrBody,
+      prNumber: '855',
+    })
+
+    expect(synced.content.split('\n')).toContain('\\##')
   })
 
   it('does nothing when the PR explicitly needs no operator notes', () => {

--- a/scripts/release/__tests__/operator-upgrade-notes.test.mjs
+++ b/scripts/release/__tests__/operator-upgrade-notes.test.mjs
@@ -62,6 +62,31 @@ describe('operator upgrade notes lifecycle', () => {
     expect(result.content).toContain(operatorUpgradeSourceEndMarker('pr-318'))
   })
 
+  it('keeps contributor release headings inert inside operator notes', () => {
+    const releaseHeadingPrBody = operatorNotesPrBody.replace(
+      '### Topology changes',
+      '## v9.9.9 - 2099-12-31',
+    )
+
+    const synced = addPullRequestNotesToContent(baseNotes, {
+      filePath: operatorNotesPath,
+      prBody: releaseHeadingPrBody,
+      prNumber: '854',
+    })
+    const archived = archiveStableOperatorUpgradeNotesContent(synced.content, {
+      date: '2026-08-19',
+      filePath: operatorNotesPath,
+      version: 'v1.0.0',
+    })
+
+    expect(synced.content).toContain('\\## v9.9.9 - 2099-12-31')
+    expect(archived.content).toContain(
+      `## v1.0.0 - 2026-08-19\n\n${operatorUpgradeSourceStartMarker('pr-854')}`,
+    )
+    expect(archived.content).toContain('\\## v9.9.9 - 2099-12-31')
+    expect(archived.content).toContain(operatorUpgradeSourceEndMarker('pr-854'))
+  })
+
   it('does nothing when the PR explicitly needs no operator notes', () => {
     const result = addPullRequestNotesToContent(baseNotes, {
       filePath: operatorNotesPath,

--- a/scripts/release/operator-upgrade-gate.mjs
+++ b/scripts/release/operator-upgrade-gate.mjs
@@ -59,7 +59,7 @@ function hasMeaningfulNoteText(line) {
 }
 
 function escapeLevelTwoHeadings(notes) {
-  return notes.replace(/^##(?=[ \t]+\S)/gmu, '\\##')
+  return notes.replace(/^##(?=[ \t]|$)/gmu, '\\##')
 }
 
 function operatorUpgradeNotesBlock(prBody) {

--- a/scripts/release/operator-upgrade-gate.mjs
+++ b/scripts/release/operator-upgrade-gate.mjs
@@ -58,6 +58,10 @@ function hasMeaningfulNoteText(line) {
   return /[^\s!-]/u.test(line)
 }
 
+function escapeLevelTwoHeadings(notes) {
+  return notes.replace(/^##(?=[ \t]+\S)/gmu, '\\##')
+}
+
 function operatorUpgradeNotesBlock(prBody) {
   const body = String(prBody ?? '')
   const startMarkerMatch = body.match(
@@ -78,11 +82,13 @@ function operatorUpgradeNotesBlock(prBody) {
   }
 
   const notesSection = afterStartMarker.slice(0, endMarkerMatch.index)
-  const notes = stripHtmlCommentMarkup(notesSection)
-    .split(/\r?\n/u)
-    .map(line => line.trim())
-    .filter(hasMeaningfulNoteText)
-    .join('\n')
+  const notes = escapeLevelTwoHeadings(
+    stripHtmlCommentMarkup(notesSection)
+      .split(/\r?\n/u)
+      .map(line => line.trim())
+      .filter(hasMeaningfulNoteText)
+      .join('\n'),
+  )
 
   return { notes, status: 'found' }
 }


### PR DESCRIPTION
## Description

- Escape contributor-supplied level-two headings while parsing Operator Upgrade Impact notes so they remain inert inside `## Unreleased`.
- Preserve the full note through stable-release archival and cover the security boundary with regression tests, including bare and whitespace-only headings.
- Require human review of generated operator-note persistence pull requests instead of enabling auto-merge.
- Stream generated PR bodies from a quoted heredoc and verify the body stored by GitHub.
- Document the constrained Markdown and review workflow.

## Related Issues

Fixes #854

## Reviewer Notes

- TDD seam: `addPullRequestNotesToContent()` through stable archival.
- Final code review: Standards 0 findings; Spec 0 findings.
- Validation: `npm run check` (7,323 Vitest tests passed, 86 skipped; HSA support tests passed).
- No visible application UI or manual Playwright workflow changed.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1090)
<!-- Reviewable:end -->
