### PR TITLE
docs: persist operator upgrade notes from #1089

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -323,6 +323,10 @@ Before upgrade, tell MCP integration owners that requirement create and edit req
 <!-- operator-upgrade:source pr-1077 start -->
 After upgrade, only users with the Admin role can inspect which specification items are linked to a usage status through the direct API. Verify that affected integrations use an Admin identity. Non-Admin users now receive a 403 response.
 <!-- operator-upgrade:source pr-1077 end -->
+
+<!-- operator-upgrade:source pr-1089 start -->
+Before upgrade, verify that MCP clients remove no more than 200 unique requirements in one request. Requests with duplicate requirement IDs or more than 200 IDs now fail validation. Split larger removals into batches of 200 or fewer.
+<!-- operator-upgrade:source pr-1089 end -->
 ## v0.4.0 - 2026-08-02
 
 ### Invalid priority colors are reset during upgrade


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #1089
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/32238012590

Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1091)
<!-- Reviewable:end -->
