### PR TITLE
docs: persist operator upgrade notes from #1094

### DIFF
--- a/docs/operations/operator-upgrade-notes.md
+++ b/docs/operations/operator-upgrade-notes.md
@@ -7,6 +7,11 @@ target version.
 
 ## Unreleased
 
+<!-- operator-upgrade:source pr-1094 start -->
+- Before upgrade, keep AI-assisted authoring blocked and verify that every application host uses the required container runtime. Provision the versioned provider-secret root keyring on every application node. Configure approved egress, TLS, and data policies. The previous direct OpenRouter configuration does not migrate.
+- Apply the database migration and required seed. An Administrator must then register AI connections, enter provider secrets, record attestations, verify models, and configure each intended run profile. Configure the new AI alerts and complete the AI deployment evidence gate before you enable AI-assisted authoring. Update clients and support procedures because users no longer select models, and the model-catalog and credit endpoints are removed.
+- Treat each database backup and its required root-key versions as one recovery set. Test their combined restore and retain old root-key versions while any database row or retained backup needs them. During rollback or restore, block AI-assisted authoring, restore the matching keyring, run transient-state cleanup, and repeat the deployment evidence gate. There is no legacy OpenRouter fallback.
+<!-- operator-upgrade:source pr-1094 end -->
 ## v0.5.0 - 2026-08-23
 
 <!-- operator-upgrade:source issue-477 start -->


### PR DESCRIPTION
This automated PR persists merged Operator Upgrade Impact notes under `## Unreleased`.

- Latest source PR: #1094
- Workflow run: https://github.com/viscalyx/Kravhantering/actions/runs/32639891725

A human reviewer must approve the generated notes before merge.
Merge after the required checks pass.

## Operator Upgrade Impact

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

## SSDLC (Secure Software Development Life Cycle) Gate

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1103)
<!-- Reviewable:end -->
