### PR TITLE
Fix Docker Hub dependency drift pagination

### DIFF
--- a/.github/workflows/dependency-drift.mjs
+++ b/.github/workflows/dependency-drift.mjs
@@ -79,7 +79,7 @@ export const IMAGE_CONFIGS = {
   },
   nginx: {
     image: 'docker.io/library/nginx',
-    listTags: () => fetchDockerHubTags('library', 'nginx'),
+    listTags: () => fetchRegistryTags('registry-1.docker.io', 'library/nginx'),
     lockPath: 'containers/nginx/image.lock.json',
     name: 'nginx',
     parseTag: parseNginxTag,
@@ -114,7 +114,8 @@ export const IMAGE_CONFIGS = {
   },
   kong: {
     image: 'docker.io/kong/kong-gateway',
-    listTags: () => fetchDockerHubTags('kong', 'kong-gateway'),
+    listTags: () =>
+      fetchRegistryTags('registry-1.docker.io', 'kong/kong-gateway'),
     lockPath: 'containers/kong/image.lock.json',
     name: 'kong',
     parseTag: parseKongTag,
@@ -330,30 +331,6 @@ async function fetchLatestLycheeRelease(repository) {
     `https://api.github.com/repos/${repository}/releases/latest`,
     { headers },
   )
-}
-
-function dockerHubHeaders() {
-  const token =
-    readNonEmpty(process.env.DOCKERHUB_TOKEN) ??
-    readNonEmpty(process.env.DOCKER_HUB_TOKEN)
-  return token
-    ? { Accept: 'application/json', Authorization: `Bearer ${token}` }
-    : { Accept: 'application/json' }
-}
-
-async function fetchDockerHubTags(namespace, repository) {
-  const tags = []
-  let url =
-    `https://hub.docker.com/v2/repositories/${namespace}/${repository}` +
-    '/tags?page_size=100'
-  while (url) {
-    const payload = await fetchJson(url, { headers: dockerHubHeaders() })
-    for (const item of payload.results ?? []) {
-      if (typeof item.name === 'string') tags.push(item.name)
-    }
-    url = readNonEmpty(payload.next)
-  }
-  return tags
 }
 
 function nextLink(header, host) {

--- a/scripts/__tests__/dependency-drift.test.mjs
+++ b/scripts/__tests__/dependency-drift.test.mjs
@@ -191,6 +191,66 @@ describe('dependency drift selection', () => {
       ).tag,
     ).toBe('1.29.4-alpine')
   })
+
+  it('lists Docker Hub tags through registry cursor pagination', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(null, {
+          headers: {
+            'www-authenticate':
+              'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/nginx:pull"',
+          },
+          status: 401,
+        }),
+      )
+      .mockResolvedValueOnce(Response.json({ token: 'registry-token' }))
+      .mockResolvedValueOnce(
+        Response.json(
+          { name: 'library/nginx', tags: ['1.29.4-alpine'] },
+          {
+            headers: {
+              link: '</v2/library/nginx/tags/list?last=1.29.4-alpine&n=1000>; rel="next"',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(null, {
+          headers: {
+            'www-authenticate':
+              'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/nginx:pull"',
+          },
+          status: 401,
+        }),
+      )
+      .mockResolvedValueOnce(Response.json({ token: 'registry-token' }))
+      .mockResolvedValueOnce(
+        Response.json({
+          name: 'library/nginx',
+          tags: ['1.30.0-alpine'],
+        }),
+      )
+
+    await expect(IMAGE_CONFIGS.nginx.listTags()).resolves.toEqual([
+      '1.29.4-alpine',
+      '1.30.0-alpine',
+    ])
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      'https://registry-1.docker.io/v2/library/nginx/tags/list?n=1000',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer registry-token',
+        }),
+      }),
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      'https://registry-1.docker.io/v2/library/nginx/tags/list?last=1.29.4-alpine&n=1000',
+      expect.any(Object),
+    )
+  })
 })
 
 describe('drift detection', () => {


### PR DESCRIPTION
## Description

Replace Docker Hub API tag enumeration for nginx and Kong with Docker Registry
v2 cursor pagination. This avoids the anonymous pagination limit that caused
the dependency-drift workflow to fail after 1,000 nginx tags.

Add regression coverage for the registry authentication challenge and
multi-page cursor flow.

## Related Issues

Failed workflow run:
https://github.com/viscalyx/Kravhantering/actions/runs/32998380287/job/98273464584

## Reviewer Notes

- Verified live registry enumeration for 1,297 nginx tags and 2,897 Kong tags.
- `npm run test`: 8,179 passed, 86 skipped.
- Formatting, linting, spelling, link checks, and HSA support tests passed.

## Operator Upgrade Impact

Complete this section for every PR. Check the box when no operator notes are
needed; otherwise write the notes below.

- [x] No operator notes needed. <!-- DO NOT REMOVE: operator-upgrade:no-notes -->

<!-- DO NOT REMOVE: operator-upgrade:notes start -->
<!-- DO NOT REMOVE: operator-upgrade:notes end -->

## SSDLC (Secure Software Development Life Cycle) Gate

Complete this section for every PR. You are responsible for ensuring that
the change meets SSDLC requirements. If you are not confident you can
check this box, request a security review.

- [x] I have reviewed SSDLC requirements for this change and addressed any security, data protection, threat-model, and security-testing impacts. <!-- DO NOT REMOVE: ssdlc:requirements -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Kravhantering/1197)
<!-- Reviewable:end -->
